### PR TITLE
public.json: Add order.placed, .shipped, and .delivered times

### DIFF
--- a/public.json
+++ b/public.json
@@ -2905,6 +2905,21 @@
             "lost"
           ]
         },
+        "placed": {
+          "description": "when the order was placed",
+          "type": "string",
+          "format": "date-time"
+        },
+        "shipped": {
+          "description": "when the order was shipped",
+          "type": "string",
+          "format": "date-time"
+        },
+        "delivered": {
+          "description": "when the order was delivered",
+          "type": "string",
+          "format": "date-time"
+        },
         "drop": {
           "description": "drop the order is destined for (unset for UPS orders)",
           "type": "integer",


### PR DESCRIPTION
We want to display these times when showing user's the current status
of their order.  For orders we deliver to drops, we can find the
delivery time by looking at the stop.time for the associated stop.
But for orders delivered by UPS or another carrier, we'll want to
cache delivery times that we get from the carrier here.

The backend has implemented order.placed since
azurestandard/beehive@37489b5 (apps/api/views/order.py: Set
order.shipped to the shipping date, 2015-03-20).  We store the placed
time already (as Order.order_time, see
azurestandard/beehive@8ae576fcc5, apps/orders/models.py: Add help_text
to Order.order_date, 2015-08-05).  We don't store the delivery time
yet, but I think we should.