### PR TITLE
public.json: Add address.preference

### DIFF
--- a/public.json
+++ b/public.json
@@ -2038,7 +2038,7 @@
     "/addresses": {
       "get": {
         "summary": "Returns all addresses from the system that the user has access to",
-        "description": "Addresses associated with a person are ordered by decreasing preference.  The ordering between addresses associated with different people is undefined.",
+        "description": "Addresses associated with a person are ordered by decreasing preference.  The ordering between addresses associated with different people or (for the same person) with the same preference value is undefined.",
         "operationId": "findAddresses",
         "tags": [
           "address"
@@ -3577,6 +3577,11 @@
         },
         "country-name": {
           "type": "string"
+        },
+        "preference": {
+          "description": "ordering precedence for the findAddresses.  Defaults to zero.",
+          "type": "integer",
+          "format": "int32",
         }
       },
       "required": [


### PR DESCRIPTION
We need a consistent way to select a user's primary address, and the
cleanest API for that seems to be letting the user order all their
preferences.  Then setting a new primary address would look something
like (using [azure-angular-providers][1]):

    newPrimary.preference = 100;
    oldPrimary.preference = 0;
    newPrimary.$save().$promise.then(function () {
      oldPrimary.$save();
    });

There's a low probability that the `newPrimary.$save` goes through and
the `oldPrimary.$save` does not.  If the `oldPrimary.preference` was
originally 100, that means there is some time (while the
`oldPrimary.$save` is in flight, and possibly after if that call fails)
where both addresses will have the same preference on the server.  If
that's a concern, you could use something like:

    newPrimary.preference = oldPrimary.preference + 1;
    oldPrimary.preference = 0;
    newPrimary.$save().$promise.then(function () {
      oldPrimary.$save().$promise.then(function () {
        newPrimary.preference -= 1;
        newPrimary.$save();
      });
    });

If you weren't worried about rolling over the int32 (you're probably
safe ;), you could skip the decrement step.

[1]: https://github.com/azurestandard/azure-angular-providers