### PR TITLE
public.json: Restrict telephoneType to values we can use

### DIFF
--- a/public.json
+++ b/public.json
@@ -3444,14 +3444,7 @@
       "type": "string",
       "enum": [
         "text",
-        "voice",
-        "video",
-        "fax",
-        "pager",
-        "textphone",
-        "cell",
-        "home",
-        "work"
+        "voice"
       ]
     },
     "person": {


### PR DESCRIPTION
We're not currently video-calling people, faxing people,
distinguishing between their home and cell numbers, etc.