### PR TITLE
public.json: Add 'GET /registration/confirm?token=...'

### DIFF
--- a/public.json
+++ b/public.json
@@ -2460,6 +2460,36 @@
       }
     },
     "/registration/confirm": {
+      "get": {
+        "summary": "Complete an in-progress registration",
+        "operationId": "confirmRegistrationGet",
+        "tags": [
+          "registration"
+        ],
+        "parameters": [
+          {
+            "name": "token",
+            "in": "query",
+            "description": "The registrant's confirmation token",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "person response",
+            "schema": {
+              "$ref": "#/definitions/person"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      },
       "post": {
         "summary": "Complete an in-progress registration",
         "operationId": "confirmRegistration",


### PR DESCRIPTION
This allows us to support the registrant copy/pasting confirmation
URLs into their browser (it's harder to get your browser to POST
without an HTML form or such).