### PR TITLE
public.json: Require name and email for registrants

### DIFF
--- a/public.json
+++ b/public.json
@@ -3363,7 +3363,7 @@
           "format": "url"
         },
         "person": {
-          "description": "The registrant's personal information.",
+          "description": "The registrant's personal information.  Name, email, and password are required.",
           "type": "object",
           "schema": {
             "$ref": "#/definitions/updatePerson"


### PR DESCRIPTION
Folks using updatePerson in other contexts are free to only set the
fields they intend to update, but for creating new people we need an
email address (to send the confirmation email) and might as well have
a name ;).