### PR TITLE
Add category property to packagedProductTag definition.

### DIFF
--- a/public.json
+++ b/public.json
@@ -3478,6 +3478,15 @@
         "name": {
           "description": "human-readable tag name",
           "type": "string"
+        },
+        "category": {
+          "description": "category code describing the type of tag",
+          "type": "string",
+          "enum": [
+            "status",
+            "price-level",
+            "characteristic"
+          ]
         }
       }
     },


### PR DESCRIPTION
This will be used by the frontend to filter unwanted tags from being
displayed.   This way product status tags, e.g., can be distinguished
from other tag types.