### PR TITLE
public.json: Add public=? boolean to /packaged-product-tags

### DIFF
--- a/public.json
+++ b/public.json
@@ -1217,6 +1217,13 @@
         ],
         "parameters": [
           {
+            "name": "internal",
+            "in": "query",
+            "description": "if true, only return internal tags (that the user has access to).  If false, only return public tags (regardless of the user's access to internal tags).  If unset, don't filter based on the tag visibility",
+            "required": false,
+            "type": "boolean"
+          },
+          {
             "name": "limit",
             "in": "query",
             "description": "maximum number of results to return",


### PR DESCRIPTION
A user who is authorized to view all tags may not want to view
internal tags (e.g. they're hitting this endpoint while shopping for
themselves).  This option allows UI code to explicitly set
`?public=true` when they don't intend to access those internal tags.
I expect most UIs will be setting `?public=true`, but defaulting to
limited results (and requiring folks to specify `?all=true` or some
such) would break our usual pattern of “show everything and filter
with query parameters”.