### PR TITLE
public.json: Remove a trialing comma from address.preference.format

### DIFF
--- a/public.json
+++ b/public.json
@@ -3643,7 +3643,7 @@
         "preference": {
           "description": "ordering precedence for the findAddresses.  Defaults to zero.",
           "type": "integer",
-          "format": "int32",
+          "format": "int32"
         }
       },
       "required": [


### PR DESCRIPTION
This slipped through with cf10fceb (public.json: Add
address.preference, 2015-08-31, #17).