### PR TITLE
public.json: List the default values for boolean person creation

### DIFF
--- a/public.json
+++ b/public.json
@@ -3576,11 +3576,11 @@
           "format": "email"
         },
         "can-email": {
-          "description": "Can Azure contact this person for reasons other than registration",
+          "description": "Can Azure contact this person for reasons other than registration?  Defaults to true when creating a person",
           "type": "boolean"
         },
         "catalog": {
-          "description": "Subscribed to receive the product catalog",
+          "description": "Subscribed to receive the product catalog?  Defaults to false when creating a person",
           "type": "boolean"
         },
         "company": {
@@ -3588,7 +3588,7 @@
           "type": "string"
         },
         "allow-social-media": {
-          "description": "Does this person want social media links to display",
+          "description": "Does this person want social media links to display?  Defaults to true when creating a person",
           "type": "boolean"
         }
       }


### PR DESCRIPTION
The `registerPerson` endpoint uses the `registration` model, which
includes the `updatePerson` model.  To avoid folks having to guess
what happens when they don't specify a boolean field, this commit
explicitly lists the default value for those fields.

If a field is not specified during an `updatePerson` call, we leave it
alone.