### PR TITLE
public.json: Add drop.order-minimum

### DIFF
--- a/public.json
+++ b/public.json
@@ -2772,6 +2772,12 @@
         "fees": {
           "$fees": "#definitions/dropFees"
         },
+        "order-minimum": {
+          "description": "the minimum total order value (in dollars) required to ship a particular trip to this drop.  For example, if the minimum is $400 and there are three $100 orders placed for a stop, that stop will be under-minimum, and the orders will not be shipped.  If, on the other hand, there were four $100 orders placed for a stop, that stop would be (just) over-minimum, and the orders would be shipped.",
+          "type": "number",
+          "format": "float"
+          }
+        },
         "members": {
           "description": "number of customers on this drop",
           "type": "integer",


### PR DESCRIPTION
On Tue, Sep 15, 2015 at 12:19:21PM -0700, heuscher [wrote][1]:
> Reference Google spec document 8.7.1 Current Drop.
>
> Need to return the minimum, total order amount
> (`drop.minimum_order_amount`) required for a drop.

Part of azurestandard/beehive#1192.

[1]: https://github.com/azurestandard/beehive/issues/1192