### PR TITLE
public.json: Add a trailing paren to price.discount.description

### DIFF
--- a/public.json
+++ b/public.json
@@ -3137,7 +3137,7 @@
           "type": "boolean"
         },
         "discount": {
-          "description": "text for the discount (e.g. \"12%\", or \"$3.50\"",
+          "description": "text for the discount (e.g. \"12%\", or \"$3.50\")",
           "type": "string"
         }
       },


### PR DESCRIPTION
This snuck in with 6a2d0e629 (public.json: Add /products and
/product/{code}, 2014-11-26).