### PR TITLE
public.json: Add person.price-level and a multi-level price object

### DIFF
--- a/public.json
+++ b/public.json
@@ -3123,8 +3123,8 @@
         "name"
       ]
     },
-    "price": {
-      "description": "product price information",
+    "_price": {
+      "description": "a helper object for 'price'",
       "type": "object",
       "properties": {
         "dollars": {
@@ -3144,6 +3144,32 @@
       "required": [
         "dollars"
       ]
+    },
+    "priceLevel": {
+      "description": "a customer property to pick the right price from 'price'",
+      "type": "string",
+      "enum": [
+        "retail",
+        "wholesale"
+      ]
+    },
+    "price": {
+      "description": "product price information",
+      "type": "object",
+      "properties": {
+        "retail": {
+          "description": "pricing for retail customers",
+          "schema": {
+            "$ref": "#/definitions/_price"
+          }
+        },
+        "wholesale": {
+          "description": "pricing for retail customers",
+          "schema": {
+            "$ref": "#/definitions/_price"
+          }
+        }
+      }
     },
     "category": {
       "description": "a category available for sale",
@@ -3559,6 +3585,13 @@
         "allow-social-media": {
           "description": "Does this person want social media links to display",
           "type": "boolean"
+        },
+        "price-level": {
+          "description": "Which 'price' entry applies to this person",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/priceLevel"
+          }
         }
       },
       "required": [


### PR DESCRIPTION
This is a first step in our shift to more flexible pricing.  The
current API implementation checks the requester's price level and
returns the appropriate prices object (now _price, after this
commit). As we shift to Algolia for product searches, we'll need less
dynamic pricing information, because Algolia isn't going to
authenticate reqeusters for us.  This commit associates
requester-independent pricing information with the packaged-products,
and gives customers the information they need (via their /person or
/person/{id} result) to select the appropriate price from the satic
packaged-products information.

In the future, we will likely transition to a more
complicated/flexible pricing model, with base-price information on
packaged-products that's not price-level dependent (e.g. a base price
and scaling coefficient).  Then the per-person information will
include a formula for converting that person-independent information
into a price.  But this is too fuzzy to move toward at the moment, and
we need the person-independent information now ;).

This is part of my plan for allowing
azurestandard/azure-angular-providers@82a3977 to land independent of
the rest of azurestandard/azure-angular-providers#7, and for keeping
the API as consistent with the Algolia data as possible.