### PR TITLE
public.json: Add orderLine.volume

### DIFF
--- a/public.json
+++ b/public.json
@@ -3295,6 +3295,11 @@
           "type": "integer",
           "format": "float"
         },
+        "volume": {
+          "description": "volume of the shipped products in cubic feet (estimated until picking time)",
+          "type": "integer",
+          "format": "float"
+        },
         "price": {
           "description": "per-product price (currently locked in when you place the order)",
           "$ref": "#/definitions/price"
@@ -3305,7 +3310,8 @@
         "order",
         "product",
         "quantity-ordered",
-        "weight"
+        "weight",
+        "volume"
       ]
     },
     "accountEntry": {


### PR DESCRIPTION
Customers expect access to this:

On Thu, Sep 17, 2015 at 02:59:57PM -0700, Jordan Schatz wrote [1]:
> > By "is currently displayed" do you mean old site, new site, or
> > both?
>
> Old site, invoices, emails, etc. The customers are accustomed to
> being able to see it.

This commit just copies our current handling of orderLine.weight.  The
cubic-foot measurement matches the existing internal calculations, and
the US still hasn't seen the metrification light ;).

See azurestandard/website#66 and azurestandard/beehive#1197.

[1]: https://github.com/azurestandard/website/issues/66#issuecomment-141243331