### PR TITLE
public.json: Move 'POST /account-entries' to 'POST /payments'

### DIFF
--- a/public.json
+++ b/public.json
@@ -1877,7 +1877,42 @@
             }
           }
         }
-      },
+      }
+    },
+    "/account-entry/{id}": {
+      "get": {
+        "summary": "Returns a credit or debit based on a single ID",
+        "operationId": "findAccountEntryById",
+        "tags": [
+          "account"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of account entry to fetch",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "account entry response",
+            "schema": {
+              "$ref": "#/definitions/accountEntry"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      }
+    },
+    "/payments": {
       "post": {
         "summary": "Create a new payment (settled immediately)",
         "operationId": "addPayment",
@@ -1900,39 +1935,6 @@
             "required": true,
             "type": "number",
             "format": "float"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "account entry response",
-            "schema": {
-              "$ref": "#/definitions/accountEntry"
-            }
-          },
-          "default": {
-            "description": "unexpected error",
-            "schema": {
-              "$ref": "#/definitions/errorModel"
-            }
-          }
-        }
-      }
-    },
-    "/account-entry/{id}": {
-      "get": {
-        "summary": "Returns a credit or debit based on a single ID",
-        "operationId": "findAccountEntryById",
-        "tags": [
-          "account"
-        ],
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "ID of account entry to fetch",
-            "required": true,
-            "type": "integer",
-            "format": "int64"
           }
         ],
         "responses": {


### PR DESCRIPTION
The existing Beehive API actually had a 'POST /account-entries'
implementation, but it was just for creating account entry instances,
and not for side effects like settling credit card charges.  We want
to keep those entry-creation instances so we can do things like credit
customers for damaged orders (there's no payment-method then), so
shift the new-payment endpoint from 2b8dbfe (public.json: Add POST
/account-entries, 2015-08-28, #16) over to 'POST /payments'.