### PR TITLE
public.json: 'person' -> 'filter-person' for GET /packaged-product-tag-associations

### DIFF
--- a/public.json
+++ b/public.json
@@ -1276,9 +1276,9 @@
         ],
         "parameters": [
           {
-            "name": "person",
+            "name": "filter-person",
             "in": "query",
-            "description": "person to find saved filter preferences for",
+            "description": "person ID to filter by",
             "required": true,
             "type": "integer",
             "format": "int64"


### PR DESCRIPTION
The current 'person' landed in 272387d5 (Add methods to manage a
person's filter preferences, 2015-08-14, #13), after [I suggested it
during review][1]:

13:31 <+wking> cbessette: orders are like person-tags in their
  relationship with people.  Maybe just:
  /packaged-product-tag-associations, where we push/delete {'person':
  <id>, 'tag': <slug>} objects?  And then
  /packaged-product-tag-associations?person=<your-id> to get your
  personal tags?
13:31 <+cbessette> That sounds good to me, I'll update it.

However, I'd forgotten that 2ab80437 (public.json: Add
packagedProduct.favorite boolean and annotate-person parameter,
2015-06-08) had changed the 'person' query parameter to
'filter-person' (to avoid confusion with annotate-person).  This
commit adjusts the name to catch up, and copies the description from
/drop's filter-person parameter (adjusting from IDs to ID).

The packaged-product-tag-association usage is slightly different than
our other endpoints in that we [require person-filtering][2] and only
support a single person, but it makes sense to match the existing
pattern in case we want to extend our implementation to support
optional person-filtering or multiple people later.

[1]: https://azurestandard.slack.com/archives/general/p1439584103003106
[2]: https://azurestandard.slack.com/archives/general/p1439586136003133