### PR TITLE
public.json: Adjust anyOf syntax to use schema and $ref

### DIFF
--- a/public.json
+++ b/public.json
@@ -3638,12 +3638,12 @@
     },
     "paymentMethod": {
       "anyOf": [
-        "creditCard"
+        {"$ref": "#definitions/creditCard"}
       ]
     },
     "newPaymentMethod": {
       "anyOf": [
-        "newCreditCard"
+        {"$ref": "#definitions/newCreditCard"}
       ]
     },
     "registration": {


### PR DESCRIPTION
I landed the previous syntax in 168a97b4 (public.json: Add '{GET|POST}
/payment-methods' and 'GET /payment-method/{id} ' endpoints,
2015-02-11), which pointed out that anyOf isn't valid Swagger 2.0.
But it's looking like the consensus is around including it in the next
Swagger release [1].  The JSON Schema example I was following [2]
didn't use $ref in their example, but they do use $ref in their allOf
example [3].  This commit updates the existing anyOf uses to match
that syntax.

[1]: https://github.com/swagger-api/swagger-spec/issues/57#issuecomment-56224153
[2]: http://spacetelescope.github.io/understanding-json-schema/reference/combining.html#anyof
[3]: http://spacetelescope.github.io/understanding-json-schema/reference/combining.html#allof