### PR TITLE
public.json: Make orderLine.price a total dollar value

### DIFF
--- a/public.json
+++ b/public.json
@@ -3481,8 +3481,9 @@
           "format": "float"
         },
         "price": {
-          "description": "per-product price (currently locked in when you place the order)",
-          "$ref": "#/definitions/price"
+          "description": "the total price for this line in dollars (estimated until picking time).  The per-unit price used to calculate this total is currently locked in when you place the order.",
+          "type": "number",
+          "format": "float"
         }
       },
       "required": [


### PR DESCRIPTION
Since 01861207 (public.json: Add person.price-level and a multi-level
price object, 2015-09-16, #29) the price structure is more involved,
and API implementations would have to build enough of the price
structure to put a price on post-price-freeze lines.  I think that is
the wrong approach, because as the price model becomes more dynamic,
the chance of one of the external variables changing increases.  For
example, it's not impossible (but maybe not very likely) that a
customer changes from retail to wholesale, but once we start including
per-route information, etc. in the pricing calculation, it becomes
harder to figure out what values we should be faking in the
reconstituted price object.  And it seems like wasted, brittle work to
go from a dollar price to a complicated price structure just so the
consumer can apply the algorithm to get back to a dollar value.

The more-detailed pricing information is already available in the
packaged-product structure associated with a given order-line, so this
commit drops including it in the line model itself.  If we decide that
separate fetches for the order line and associated (packaged-)product
are inefficient, we can always embed the associated product object in
the order-line model (but I don't see any benefit to just embedding
the price).

I got this representation wrong before, so I'd like a few sets of eyes
on this before we land it.