### PR TITLE
public.json: Drop second newCreditCard.description

### DIFF
--- a/public.json
+++ b/public.json
@@ -3589,7 +3589,6 @@
     },
     "newCreditCard": {
       "description": "Azure does not store much credit card information internally (we use an external card processor), but we do need all of the information for the initial upload so we can pass it along to the external processor.",
-      "description": "a credit card (one of our supported payment methods)",
       "type": "object",
       "properties": {
         "type": {


### PR DESCRIPTION
Fix a copy-paste error from 168a97b4 (public.json: Add '{GET|POST}
/payment-methods' and 'GET /payment-method/{id}' endpoints,
2015-02-11).