### PR TITLE
public.json: Add order.checkout-payment

### DIFF
--- a/public.json
+++ b/public.json
@@ -3415,6 +3415,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "checkout-payment": {
+          "description": "before shipping, the customer can use this to associate a payment-method with the order.  After shipping, it contains information about the charged payment",
+          "$ref": "#/definitions/payment"
+        },
         "drop": {
           "description": "drop the order is destined for (unset for UPS orders)",
           "type": "integer",
@@ -3640,18 +3644,22 @@
       ]
     },
     "payment": {
-      "description": "A payment instance where an amount will be charged via a payment-method.",
+      "description": "A payment instance where an amount will be (or has been) charged via a payment-method.",
       "type": "object",
       "properties": {
         "payment-method": {
-          "description": "Payment-method ID to use",
+          "description": "Payment-method ID to use (or which was used)",
           "type": "integer",
           "format": "int64"
         },
         "amount": {
-          "description": "Amount to charge in dollars",
+          "description": "Amount to charge (or which was charged) in dollars",
           "type": "number",
           "format": "float"
+        },
+        "paid": {
+          "description": "Has the payment been charged?",
+          "type": "boolean"
         }
       },
       "required": [

--- a/public.json
+++ b/public.json
@@ -1921,20 +1921,13 @@
         ],
         "parameters": [
           {
-            "name": "payment-method",
-            "in": "query",
-            "description": "Payment method to use",
+            "name": "payment",
+            "in": "body",
+            "description": "Payment to create.  Amount and payment-method are both required.",
             "required": true,
-            "type": "integer",
-            "format": "int64"
-          },
-          {
-            "name": "amount",
-            "in": "query",
-            "description": "Amount to charge",
-            "required": true,
-            "type": "number",
-            "format": "float"
+            "schema": {
+              "$ref": "#definitions/payment"
+            }
           }
         ],
         "responses": {
@@ -3644,6 +3637,25 @@
     "newPaymentMethod": {
       "anyOf": [
         "newCreditCard"
+      ]
+    },
+    "payment": {
+      "description": "A payment instance where an amount will be charged via a payment-method.",
+      "type": "object",
+      "properties": {
+        "payment-method": {
+          "description": "Payment-method ID to use",
+          "type": "integer",
+          "format": "int64"
+        },
+        "amount": {
+          "description": "Amount to charge in dollars",
+          "type": "number",
+          "format": "float"
+        }
+      },
+      "required": [
+        "payment-method"
       ]
     },
     "registration": {


### PR DESCRIPTION
So customers can associate a payment method (e.g. a credit card) to be used
for paying off the order (by PUTing or POSTing orders with
checkout-payment.payment-method set).  After shipping, checkout-payment
will just become a record of whether or not they associated a payment
method with the order (e.g. they may have not associated a payment method,
and just covered the order with previous credits from POST /payments or
some such).

This adds a specification for the implemetation that landed in
azurestandard/beehive@34e7a19c (apps/api/views/order.py: Add
order.payment fields, 2015-04-23).  The first commit just sets the
stage, but will require minor edits to API consumers.