### PR TITLE
public.json: Add order.fees

### DIFF
--- a/public.json
+++ b/public.json
@@ -3419,6 +3419,13 @@
           "description": "before shipping, the customer can use this to associate a payment-method with the order.  After shipping, it contains information about the charged payment",
           "$ref": "#/definitions/payment"
         },
+        "fees": {
+          "description": "additional charges beyond the order-line items themselves (estimated until picking time)",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/orderFee"
+          }
+        },
         "drop": {
           "description": "drop the order is destined for (unset for UPS orders)",
           "type": "integer",
@@ -3490,6 +3497,47 @@
         "quantity-ordered",
         "weight",
         "volume"
+      ]
+    },
+    "orderFee": {
+      "description": "An additional charge associated with an order.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "order": {
+          "description": "Order that the fee belongs to",
+          "type": "integer",
+          "format": "int64"
+        },
+        "type": {
+          "description": "An array of properties for this number",
+          "$ref": "#/definitions/orderFeeType"
+        },
+        "amount": {
+          "description": "Dollar value for the fee",
+          "type": "number",
+          "format": "float"
+        },
+        "notes": {
+          "description": "Additional information about the reason or amount for the fee",
+          "type": "string"
+        }
+      },
+      "required": [
+        "order",
+        "type",
+        "amount"
+      ]
+    },
+    "orderFeeType": {
+      "description": "A property for an order fee",
+      "type": "string",
+      "enum": [
+        "shipping",
+        "small-order"
       ]
     },
     "accountEntry": {

--- a/public.json
+++ b/public.json
@@ -3415,6 +3415,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "checkout-payment": {
+          "description": "before shipping, the customer can use this to associate a payment-method with the order.  After shipping, it contains information about the charged payment",
+          "$ref": "#/definitions/payment"
+        },
         "drop": {
           "description": "drop the order is destined for (unset for UPS orders)",
           "type": "integer",
@@ -3640,18 +3644,22 @@
       ]
     },
     "payment": {
-      "description": "A payment instance where an amount will be charged via a payment-method.",
+      "description": "A payment instance where an amount will be (or has been) charged via a payment-method.",
       "type": "object",
       "properties": {
         "payment-method": {
-          "description": "Payment-method ID to use",
+          "description": "Payment-method ID to use (or which was used)",
           "type": "integer",
           "format": "int64"
         },
         "amount": {
-          "description": "Amount to charge in dollars",
+          "description": "Amount to charge (or which was charged) in dollars",
           "type": "number",
           "format": "float"
+        },
+        "paid": {
+          "description": "Has the payment been charged?",
+          "type": "boolean"
         }
       },
       "required": [

--- a/public.json
+++ b/public.json
@@ -1921,20 +1921,13 @@
         ],
         "parameters": [
           {
-            "name": "payment-method",
-            "in": "query",
-            "description": "Payment method to use",
+            "name": "payment",
+            "in": "body",
+            "description": "Payment to create.  Amount and payment-method are both required.",
             "required": true,
-            "type": "integer",
-            "format": "int64"
-          },
-          {
-            "name": "amount",
-            "in": "query",
-            "description": "Amount to charge",
-            "required": true,
-            "type": "number",
-            "format": "float"
+            "schema": {
+              "$ref": "#definitions/payment"
+            }
           }
         ],
         "responses": {
@@ -3644,6 +3637,25 @@
     "newPaymentMethod": {
       "anyOf": [
         "newCreditCard"
+      ]
+    },
+    "payment": {
+      "description": "A payment instance where an amount will be charged via a payment-method.",
+      "type": "object",
+      "properties": {
+        "payment-method": {
+          "description": "Payment-method ID to use",
+          "type": "integer",
+          "format": "int64"
+        },
+        "amount": {
+          "description": "Amount to charge in dollars",
+          "type": "number",
+          "format": "float"
+        }
+      },
+      "required": [
+        "payment-method"
       ]
     },
     "registration": {


### PR DESCRIPTION
Builds on #39, so review/merge that first.

Existing fees in the database look like:

    {"order": 123, "type": "shipping", "amount": 0.39, "notes": "8.50%"}
    {"order": 456, "type": "small-order", "amount": 2.50, "notes": "Automatically Added"}

I'm not wild about the “Automatically Added” (do we have fees that are
manually assessed?), but having room for an optional note of some kind
makes sense.

Shipping and small-order fees are the only ones I know of, but we can
easily extend this to new fees by adding entries to orderFeeType.

The explicit orderFee.id, orderFee.order, and use of an array for
order.fees instead of an object are setting us up for an `/order-fee`
endpoint if we decide to move fee management into the API
(e.g. letting internal UIs POST fees to orders, or DELETE fees from
orders).

I haven't required orderFee.id at the moment, because we currently
handle [UPS shipping outside of our fee model][1].  If we do decide to
add an API for manipulating order-fee instances we'll need to collapse
that into our existing order-fee table.

Survey of Beehive's fee structure:

* Invoice template uses [UPS-specific shipping][2] and then [general
  fees][3].
* [Fee types][4] (Beehive uses “reason”, but I've gone with “type” in
  the API to match the existing paymentMethod.type and telephone.type)
  are:
  * `ORDER_FEE_REASON_LATE` (never used.  `git grep
    ORDER_FEE_REASON_LATE` turns up no consumers, and
    `OrderFee.objects.filter(reason=ORDER_FEE_REASON_LATE).count()`
    returns zero.
  * `ORDER_FEE_REASON_SHIPPING_TRUCK` is a [per-route shipping fee][5]
    (so “shipping”).
  * `ORDER_FEE_REASON_SMALL_ORDER` is a [charge for small orders we
    ship ourselves][6] (so “small-order”).
  * `ORDER_FEE_REASON_SHIPPING_UPS` is a [charge for small UPS
    orders][7] (so “small-order”).

Fixes #37.

[1]: https://github.com/azurestandard/beehive/blob/554325e15c86087d4dc79f6ffab1687a72a7c2e2/apps/orders/models.py#L1766
[2]: https://github.com/azurestandard/beehive/blob/554325e15c86087d4dc79f6ffab1687a72a7c2e2/apps/customers/templates/customers/website/invoice.html#L13
[3]: https://github.com/azurestandard/beehive/blob/554325e15c86087d4dc79f6ffab1687a72a7c2e2/apps/customers/templates/customers/website/invoice.html#L14
[4]: https://github.com/azurestandard/beehive/blob/554325e15c86087d4dc79f6ffab1687a72a7c2e2/apps/orders/constants.py#L37-L46
[5]: https://github.com/azurestandard/beehive/blob/554325e15c86087d4dc79f6ffab1687a72a7c2e2/apps/orders/models.py#L1018-L1023
[6]: https://github.com/azurestandard/beehive/blob/554325e15c86087d4dc79f6ffab1687a72a7c2e2/apps/orders/models.py#L1199-L1203
[7]: https://github.com/azurestandard/beehive/blob/554325e15c86087d4dc79f6ffab1687a72a7c2e2/apps/orders/models.py#L1195-L1198