### PR TITLE
Remove accept-cash-on-delivery from drop definition.

### DIFF
--- a/public.json
+++ b/public.json
@@ -2923,10 +2923,6 @@
             ]
           }
         },
-        "accept-cash-on-delivery": {
-          "description": "does this drop accept COD orders?",
-          "type": "boolean"
-        },
         "fees": {
           "$fees": "#definitions/dropFees"
         },


### PR DESCRIPTION
According to a Hangout with Tom, we no longer need to support this
concept.