### PR TITLE
public.json: Fix 'cutoff' -> 'target' time ordering for /stops

### DIFF
--- a/public.json
+++ b/public.json
@@ -742,7 +742,7 @@
     "/stops": {
       "get": {
         "summary": "Returns all stops from the system that the user has access to",
-        "description": "Stops are ordered for decreasing cutoff time",
+        "description": "Stops are ordered for decreasing target time",
         "operationId": "findStops",
         "tags": [
           "stop"


### PR DESCRIPTION
Stops don't have cutoff times, and the current API implementation
orders them by target time.