### PR TITLE
public.json: Add trip.shipped

### DIFF
--- a/public.json
+++ b/public.json
@@ -3945,6 +3945,11 @@
           "type": "string",
           "format": "date-time"
         },
+        "shipped": {
+          "description": "approximately when the truck left the warehouse.  This will always be set after the truck has left, and will be unset until then.",
+          "type": "string",
+          "format": "date-time"
+        },
         "delivery-start": {
           "description": "estimated stop-time for the first stop",
           "type": "string",


### PR DESCRIPTION
The [user-facing website specs][1] have, in section 9.7.1 (the
drop-coordinator's "Current Drop" page), a table of previous
deliveries to that drop.  Columns showing data in that table are:

* "Route" for trip.route.
* "Departure" for the trip.shipped added in this commit.
* "Delivered" for the stop.time associated with the given trip and
  drop.
* "Orders" for the number of orders associated with the given trip and
  drop.

[1]: https://docs.google.com/document/d/1dwayyitTQT5ma-UhFfkC16i6aVrJ2ArV-HnUdWyst10/edit#