### PR TITLE
public.json: Add order.target-delivery and .estimated-delivery

### DIFF
--- a/public.json
+++ b/public.json
@@ -3506,6 +3506,16 @@
           "type": "string",
           "format": "date-time"
         },
+        "target-delivery": {
+          "description": "planned delivery time (fixed before the trip starts, and unset for UPS orders)",
+          "type": "string",
+          "format": "date-time"
+        },
+        "estimated-delivery": {
+          "description": "estimated delivery time (updated after the trip starts until the order is delivered, and unset for UPS orders)",
+          "type": "string",
+          "format": "date-time"
+        },
         "delivered": {
           "description": "when the order was delivered",
           "type": "string",


### PR DESCRIPTION
Based on `stop.target-time` and `stop.estimated-time`, which is where
this information will come from after the trip is verified (which is
when the stops are created).  Before that, both fields will be:

    trip.delivery-start + route-stop.delivery-offset

using the order's trip and the route-stop associated with the order's
`trip.route` and `drop`.  UPS orders have neither a trip or drop, and
customers are encouraged to use their UPS tracking number to retrieve
this sort of information directly from UPS.

This information is currently available via the stop, route-stop, and
trip endpoints, but logic to handle:

1. Are we post-verification (or post-shipping, or something in that
   timeframe)?
   * Yes: lookup the stop.
   * No: lookup the trip and route-stop.

will have to live somewhere.  We don't know of any other `/orders`
consumers at the moment, so including the logic on the server side
seems reasonable.  If it turns out that filling in this information is
too expensive, we may remove these fields and implement the logic in
[azure-angular-providers][1], which will make `/orders` faster but
require more API round-trips to extract this data.

[1]: https://github.com/azurestandard/azure-angular-providers