### PR TITLE
Logistics APIs for purchases and pickups

### DIFF
--- a/public.json
+++ b/public.json
@@ -2646,6 +2646,123 @@
         }
       }
     },
+    "/vendors": {
+      "get": {
+        "summary": "Returns all vendors from the system that the user has access to",
+        "description": "Vendors are ordered for increasing ID (creation time)",
+        "operationId": "findVendors",
+        "tags": [
+          "vendor"
+        ],
+        "parameters": [
+          {
+            "name": "active",
+            "in": "query",
+            "description": "only return (in)active vendors",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "manager",
+            "in": "query",
+            "description": "person IDs to filter by, selecting vendors that these vendor employees manage",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "collectionFormat": "csv"
+          },
+          {
+            "name": "buyer",
+            "in": "query",
+            "description": "person IDs to filter by, selecting vendors that these Azure employees buy from",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "collectionFormat": "csv"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "maximum number of results to return",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "start",
+            "in": "query",
+            "description": "offset to the first result to return.  Use negative numbers to offset from the end of the result list.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "vendor response",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/vendor"
+              }
+            },
+            "headers": {
+              "Count": {
+                "description": "total number of matching results (how many you'd get if you didn't set `limit`)",
+                "type": "integer",
+                "format": "int32",
+                "minimum": 0
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      }
+    },
+    "/vendor/{id}": {
+      "get": {
+        "summary": "Returns a vendor based on a single ID",
+        "operationId": "findVendorById",
+        "tags": [
+          "vendor"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of vendor to fetch",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "vendor response",
+            "schema": {
+              "$ref": "#/definitions/vendor"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      }
+    },
     "/account-entries": {
       "get": {
         "summary": "Returns all credits and debits from the system that the user has access to",
@@ -5354,6 +5471,37 @@
       "enum": [
         "shipping",
         "small-order"
+      ]
+    },
+    "vendor": {
+      "description": "a company that sells products to Azure",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "active": {
+          "description": "whether or not this vendor is actively supplying purchases",
+          "type": "boolean"
+        },
+        "url": {
+          "description": "homepage for the vendor",
+          "type": "string",
+          "format": "url"
+        },
+        "account": {
+          "description": "vendor's identifier for Azure",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "active"
       ]
     },
     "accountEntry": {

--- a/public.json
+++ b/public.json
@@ -2084,6 +2084,148 @@
         }
       }
     },
+    "/purchases": {
+      "get": {
+        "summary": "Returns all purchases from the system that the user has access to",
+        "description": "Purchases are ordered for increasing ID (creation time)",
+        "operationId": "findPurchases",
+        "tags": [
+          "purchase"
+        ],
+        "parameters": [
+          {
+            "name": "vendor",
+            "in": "query",
+            "description": "vendor IDs to filter by",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "collectionFormat": "csv"
+          },
+          {
+            "name": "pickup",
+            "in": "query",
+            "description": "pickup IDs to filter by",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "collectionFormat": "csv"
+          },
+          {
+            "name": "trip",
+            "in": "query",
+            "description": "trip IDs to filter by",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "collectionFormat": "csv"
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "purchase-status string to filter by",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "open",
+                "submitted",
+                "confirmed",
+                "shipped",
+                "delivered",
+                "reconciled",
+                "paid"
+              ]
+            },
+            "collectionFormat": "csv"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "maximum number of results to return",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "start",
+            "in": "query",
+            "description": "offset to the first result to return.  Use negative numbers to offset from the end of the result list.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "purchase response",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/purchase"
+              }
+            },
+            "headers": {
+              "Count": {
+                "description": "total number of matching results (how many you'd get if you didn't set `limit`)",
+                "type": "integer",
+                "format": "int32",
+                "minimum": 0
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      }
+    },
+    "/purchase/{id}": {
+      "get": {
+        "summary": "Returns a purchase based on a single ID",
+        "operationId": "findPurchaseById",
+        "tags": [
+          "purchase"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of purchase to fetch",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "purchase response",
+            "schema": {
+              "$ref": "#/definitions/purchase"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      }
+    },
     "/orders": {
       "get": {
         "summary": "Returns all orders from the system that the user has access to",
@@ -4800,6 +4942,74 @@
       "required": [
         "id",
         "name"
+      ]
+    },
+    "purchase": {
+      "description": "a purchase order placed by Azure",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "vendor": {
+          "description": "vendor supplying the order",
+          "type": "integer",
+          "format": "int64"
+        },
+        "status": {
+          "description": "purchase's lifecycle stage",
+          "type": "string",
+          "enum": [
+            "open",
+            "submitted",
+            "confirmed",
+            "shipped",
+            "delivered",
+            "labeled",
+            "reconciled",
+            "paid"
+          ]
+        },
+        "submitted": {
+          "description": "when the purchase was submitted",
+          "type": "string",
+          "format": "date-time"
+        },
+        "confirmed": {
+          "description": "when the purchase was confirmed",
+          "type": "string",
+          "format": "date-time"
+        },
+        "delivered": {
+          "description": "when the purchase was delivered",
+          "type": "string",
+          "format": "date-time"
+        },
+        "reconciled": {
+          "description": "when the purchase was reconciled",
+          "type": "string",
+          "format": "date-time"
+        },
+        "pickup": {
+          "description": "drop the purchase is destined for (only set for backhaul purchases)",
+          "type": "integer",
+          "format": "int64"
+        },
+        "trip": {
+          "description": "trip delivering the purchase (only set for backhaul purchases)",
+          "type": "integer",
+          "format": "int64"
+        },
+        "notes": {
+          "description": "free-form Markdown notes for any purchase information that doesn't fit into an existing field",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "vendor",
+        "status"
       ]
     },
     "order": {

--- a/public.json
+++ b/public.json
@@ -508,6 +508,133 @@
         }
       }
     },
+    "/pickups": {
+      "get": {
+        "summary": "Returns all pickups from the system that the user has access to",
+        "operationId": "findPickups",
+        "tags": [
+          "pickup"
+        ],
+        "parameters": [
+          {
+            "name": "active",
+            "in": "query",
+            "description": "only return (in)active pickups",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "route",
+            "in": "query",
+            "description": "route names to filter by",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "csv"
+          },
+          {
+            "name": "trip",
+            "in": "query",
+            "description": "trip IDs to filter by",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "collectionFormat": "csv"
+          },
+          {
+            "name": "vendor",
+            "in": "query",
+            "description": "vendor IDs to filter by",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "collectionFormat": "csv"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "maximum number of results to return",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "start",
+            "in": "query",
+            "description": "offset to the first result to return.  Use negative numbers to offset from the end of the result list.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pickup response",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/pickup"
+              }
+            },
+            "headers": {
+              "Count": {
+                "description": "total number of matching results (how many you'd get if you didn't set `limit`)",
+                "type": "integer",
+                "format": "int32",
+                "minimum": 0
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      }
+    },
+    "/pickup/{id}": {
+      "get": {
+        "summary": "Returns a pickup based on a single ID, if the user has access to the pickup",
+        "operationId": "findPickupById",
+        "tags": [
+          "pickup"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pickup to fetch",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pickup response",
+            "schema": {
+              "$ref": "#/definitions/pickup"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      }
+    },
     "/routes": {
       "get": {
         "summary": "Returns all routes from the system that the user has access to",
@@ -4286,6 +4413,50 @@
           }
         }
       }
+    },
+    "pickup": {
+      "description": "a purchase-pickup location",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "vendors": {
+          "description": "vendors supplying this pickup",
+          "type": "array",
+          "items": {
+            "description": "vendor ID",
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "geo": {
+          "$ref": "#/definitions/geo"
+        },
+        "active": {
+          "description": "whether or not this pickup is actively supplying purchases",
+          "type": "boolean"
+        },
+        "notes": {
+          "description": "free-form Markdown notes for any pickup information that doesn't fit into an existing field",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "vendors",
+        "address",
+        "geo",
+        "active"
+      ]
     },
     "route": {
       "description": "an order-delivery truck route",

--- a/public.json
+++ b/public.json
@@ -1220,6 +1220,18 @@
             "collectionFormat": "csv"
           },
           {
+            "name": "pickup",
+            "in": "query",
+            "description": "pickup IDs to filter by",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "collectionFormat": "csv"
+          },
+          {
             "name": "target-time-after",
             "in": "query",
             "description": "only return stops with a target time after or on this date",


### PR DESCRIPTION
This reverts #45 and takes another pass at the purchase/pickup
modeling now that I understand it better.  See [here][1] for an
overview of our current database representation.  The API I'm
proposing makes the following adjustments to those database models:

* Squashes `BackhaulPickup` and `Purchase` into the purchase API (like
  `Order` and `OrderShipment` are squashed into `Order`).
  `BackhaulPickup` is one-to-one with `Purchase`, so this squash can
  be lossless.

* Exposes `VendorContact` through the pickup API.  I expect there will
  be the same sort of confusion here that we got from the `Product` →
  packaged-product and `PieceMeta` → product renaming, but I think
  ‘pickup’ is a clear echo of ‘drop’ and ‘vendor-contact’ doesn't
  strike me as a physical location that could be shared by several
  vendors.  This also shifts the route association

Further details in the commit messages.

I'd *like* to have both route-drop and route-pickup associations
managed via the route-stop API (which is why it's not the route-drop
API ;), but that may be too much of a stretch for our current database
models.  On the other hand (as I point out [here][1], the current
database models for pickup logistics don't make all that much sense,
and we have more flexibility changing logistics modeling and UIs than
we do for changing customer-facing modeling and UIs.

[1]: https://github.com/azurestandard/beehive/blob/tk/model-docs/docs/modeling/logistics.md