### PR TITLE
public.json: Require updateTrip.delivery-start

### DIFF
--- a/public.json
+++ b/public.json
@@ -3357,7 +3357,8 @@
       },
       "required": [
         "route",
-        "cutoff"
+        "cutoff",
+        "delivery-start"
       ]
     },
     "routeStop": {


### PR DESCRIPTION
This brings updateTrip in line with the trip model (the only
difference is updateTrip not requiring an ID).  We need delivery-start
when creating a trip, because stop-time estimates are based on that
delivery-start date, and there's not much point in scheduling a trip
that cannot make stop-time estimates.  And there's work in progress to
move stop-creation from verification time up to trip-creation time, in
which case "there's not much point" becomes "the POST will crash".