### PR TITLE
public.json: Create stops at trip-creation time

### DIFF
--- a/public.json
+++ b/public.json
@@ -3529,7 +3529,7 @@
       ]
     },
     "routeStop": {
-      "description": "a template used to create stops when a trip is verified",
+      "description": "a template used to create stops when a trip is created",
       "type": "object",
       "properties": {
         "id": {
@@ -3560,7 +3560,7 @@
       ]
     },
     "stop": {
-      "description": "a trip stop or waypoint on a verified trip",
+      "description": "a trip stop or waypoint.  Stops are created for all route-stops when a trip is created for that route.  At verification time, stops that will not be visited (e.g. because they missed their order-minimum) are deleted",
       "type": "object",
       "properties": {
         "id": {


### PR DESCRIPTION
Consider the following example:

* Route r1 has trips t1 and t2 before cutoff.
* Route r1 has drops d1 and d2 associated with it through route-stops
  (r1,d1) and (r1,d2).

So possible stops are (t1,d1), (t1,d2), (t2,d1), and (t2,d2).  The old
workflow created those stops at verification time, so pre-verification
delivery estimates were based on the route-stops (r1,d1) and (r2,d2).
If logistics wanted to shift the delivery estimate for (t1,d1) before
that stop was created at t1-verification time, they'd update (r1,d1),
which would also shift (t2,d1).

[In the 2015-04-27 meeting][1], David wanted to keep that per-route
timing without allowing per-trip timing changes (e.g. shifting (t1,d1)
without shifting (t2,d1) before either trip was verified).

[By 2015-12-15][2], the requested business logic changed to require
per-trip timing changes.  So this commit updates the descriptions to
describe the new stop lifecycle.  Now logistics seeking to shift the
(t1,d1) stop will actually have a (t1,d1) stop to update directly, and
updating (r1,d1) will only affect trips that haven't yet been created.

We're deleting unverified stops at verification time (instead of
flagging them with `.verified = false` or similar, #59), because we
don't have a use-case that needs to know about those stops.  In the
absence of such a use-case, deletion seems like a simpler model, but
if we get a use-case, we'll switch to the flag approach.

[1]: https://github.com/azurestandard/beehive/issues/918#issuecomment-103148376
[2]: https://azurestandard.slack.com/archives/general/p1450220697003732