### PR TITLE
public.json: Fix orderFee.type.description

### DIFF
--- a/public.json
+++ b/public.json
@@ -4090,7 +4090,7 @@
           "format": "int64"
         },
         "type": {
-          "description": "An array of properties for this number",
+          "description": "Fee type slug",
           "$ref": "#/definitions/orderFeeType"
         },
         "amount": {


### PR DESCRIPTION
The value from 64bc196a (public.json: Add order.fees, 2015-10-02, #40)
was just copy/pasted from telephone.type.description.