### PR TITLE
public.json: Add volume and weight to packaged-product

### DIFF
--- a/public.json
+++ b/public.json
@@ -3838,6 +3838,16 @@
           "description": "size of the product (e.g. 12 oz., or 6x12 oz.)",
           "type": "string"
         },
+        "weight": {
+          "description": "weight of this packaged product in pounds (estimated until picking time)",
+          "type": "integer",
+          "format": "float"
+        },
+        "volume": {
+          "description": "volume of this packaged product in cubic feet",
+          "type": "integer",
+          "format": "float"
+        },
         "price": {
           "#ref": "#/definitions/price"
         },


### PR DESCRIPTION
For azurestandard/website#143, we'll need to calculate order-line weight and volume, without creating an order-line via the API.