### PR TITLE
public.json: Add person.permissions

### DIFF
--- a/public.json
+++ b/public.json
@@ -4377,6 +4377,14 @@
         "wholesale"
       ]
     },
+    "permissions": {
+      "description": "an API authorization or authorization category",
+      "type": "string",
+      "enum": [
+        "staff",
+        "superuser"
+      ]
+    },
     "price": {
       "description": "product price information",
       "type": "object",
@@ -4932,6 +4940,12 @@
         },
         "notifications": {
           "$ref": "#/definitions/personNotifications"
+        "permissions": {
+          "description": "API permissions for this persion",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/permission"
+          }
         }
       },
       "required": [


### PR DESCRIPTION
Add a way to retrieve permissions for your authenticated user
(`/person`) or someone else (`/person/{id}`).  This currently has very
coarse permissions for whether the person is staff or a superuser
(with all permissions), so we can do things like only exposing the
internal-website UI to staff (internal-website#48).  Moving forward,
we can fill this in with entries like `create-address`,
`update-address`, and `delete-address` for folks who can CrUD
`/addresses`, etc.  That level of granularity will take time, but this
setting will let us add per-endpoint permissions and migrate per-UI
checks [as we see fit][2].

There's some discussion in internal-website#48 about where to put this
information, with `/session` and a new `/permissions` being floated.  I've
gone with `/person` here, because:

* It's an endpoint we were hitting already, so clients don't need a
  separate request.  Filling this in with permission data shouldn't
  make the endpoint much slower.

* It allows authorized users to request permission for other people,
  which can help answer questions like “why can't Alice view the
  logistics UI”.

[2]: https://github.com/azurestandard/internal-website/issues/48#issuecomment-179975949