### PR TITLE
public.json: person.price-level is not an array

### DIFF
--- a/public.json
+++ b/public.json
@@ -4928,11 +4928,7 @@
           "type": "boolean"
         },
         "price-level": {
-          "description": "Which 'price' entry applies to this person",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/priceLevel"
-          }
+          "$ref": "#/definitions/priceLevel"
         },
         "notifications": {
           "$ref": "#/definitions/personNotifications"


### PR DESCRIPTION
This snuck in with 01861207 (public.json: Add person.price-level and a
multi-level price object, 2015-09-16, #29), but a person can only
belong to one price-level at a time.  And our currently-implemented
API uses a single entry:

    $ curl -su wking:... https://api.azurestandard.com/person | jq .
    {
      ...
      "price-level": "retail",
      ...
    }