### PR TITLE
public.json: Shift 'audited' requirement from productAudit to packagedProductAudit

### DIFF
--- a/public.json
+++ b/public.json
@@ -5337,8 +5337,7 @@
       "required": [
         "id",
         "name",
-        "packaging",
-        "audited"
+        "packaging"
       ]
     },
     "packagedProductAudit": {
@@ -5370,7 +5369,8 @@
         "code",
         "size",
         "packs",
-        "unit"
+        "unit",
+        "audited"
       ]
     },
     "updatePackagedProductAudit": {


### PR DESCRIPTION
This slipped through 2fd234af (move audited attribute from
productAudit to packagedProductAudit, 2016-02-02, #67).