### PR TITLE
public.json: Fill in POST/PUT/DELETE for stop and support propagation

### DIFF
--- a/public.json
+++ b/public.json
@@ -1166,6 +1166,13 @@
             "schema": {
               "$ref": "#/definitions/updateStop"
             }
+          },
+          {
+            "name": "persist",
+            "in": "query",
+            "description": "if true, calculate the offset between the trips's delivery start and this stop's estimated time.  For any pre-cutoff trips associated with this stop's trip's route which cutoff later than this stop's trip, create a stop for this location (drop or pickup) if it does not already exist and update that stop's target and estimated times to have the same offset from that stops's trip's delivery start.  Also create a route-stop association, if it does not already exist, for this location on this stop's trip's route and update that route-stop with the same delivery offset.",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "responses": {
@@ -1239,6 +1246,13 @@
             "schema": {
               "$ref": "#/definitions/updateStop"
             }
+          },
+          {
+            "name": "persist",
+            "in": "query",
+            "description": "if true, calculate the offset between the trips's delivery start and this stop's estimated time.  For any pre-cutoff trips associated with this stop's trip's route which cutoff later than this stop's trip, create a stop for this location (drop or pickup) if it does not already exist and update that stop's target and estimated times to have the same offset from that stops's trip's delivery start.  Also create a route-stop association, if it does not already exist, for this location on this stop's trip's route and update that route-stop with the same delivery offset.",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "responses": {
@@ -1270,6 +1284,13 @@
             "required": true,
             "type": "integer",
             "format": "int64"
+          },
+          {
+            "name": "persist",
+            "in": "query",
+            "description": "if true, for any pre-cutoff trips associated with this stop's trip's route which cutoff later than this stop's trip, delete any stops for this location (drop or pickup).  Also delete any route-stop associations for this location on this stop's trip's route.",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "responses": {

--- a/public.json
+++ b/public.json
@@ -1183,6 +1183,46 @@
             }
           }
         }
+      },
+      "put": {
+        "summary": "Update an existing stop",
+        "operationId": "updateStop",
+        "tags": [
+          "stop"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of stop to update",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "stop",
+            "in": "body",
+            "description": "stop to update",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/updateStop"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "stop response",
+            "schema": {
+              "$ref": "#/definitions/stop"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
       }
     },
     "/audit/products": {
@@ -4410,6 +4450,47 @@
       },
       "required": [
         "id",
+        "trip",
+        "target-time",
+        "estimated-time"
+      ]
+    },
+    "updateStop": {
+      "description": "an update to a trip stop or waypoint",
+      "type": "object",
+      "properties": {
+        "trip": {
+          "description": "trip ID for the stop",
+          "type": "integer",
+          "format": "int64"
+        },
+        "drop": {
+          "description": "drop ID for the stop",
+          "type": "integer",
+          "format": "int64"
+        },
+        "pickup": {
+          "description": "pickup ID for the stop",
+          "type": "integer",
+          "format": "int64"
+        },
+        "target-time": {
+          "description": "planned stop time (fixed before the trip starts)",
+          "type": "string",
+          "format": "date-time"
+        },
+        "estimated-time": {
+          "description": "estimated stop time (updated after the trip starts until the stop is reached)",
+          "type": "string",
+          "format": "date-time"
+        },
+        "time": {
+          "description": "actual stop time (set after the stop is reached)",
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "required": [
         "trip",
         "target-time",
         "estimated-time"

--- a/public.json
+++ b/public.json
@@ -1250,7 +1250,14 @@
           {
             "name": "persist",
             "in": "query",
-            "description": "if true, calculate the offset between the trips's delivery start and this stop's estimated time.  For any pre-cutoff trips associated with this stop's trip's route which cutoff later than this stop's trip, create a stop for this location (drop or pickup) if it does not already exist and update that stop's target and estimated times to have the same offset from that stops's trip's delivery start.  Also create a route-stop association, if it does not already exist, for this location on this stop's trip's route and update that route-stop with the same delivery offset.",
+            "description": "if true, calculate the offset between the trips's delivery start and this stop's estimated time.  For any pre-cutoff trips associated with this stop's trip's route which cutoff later than this stop's trip, create a stop for this location (drop or pickup) if it does not already exist and update that stop's target and estimated times to have the same offset from that stops's trip's delivery start.  Also create a route-stop association, if it does not already exist, for this location on this stop's trip's route and update that route-stop with the same delivery offset.  If propagate is set, apply the persistance logic to the later stops on the trip as well.",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "propagate",
+            "in": "query",
+            "description": "if true, calculate the change from the existing estimated time.  Shift the estimated time of all later stops on the trip by the same amount.  For pre-cutoff trips, also shift the target times.",
             "required": false,
             "type": "boolean"
           }

--- a/public.json
+++ b/public.json
@@ -1255,6 +1255,34 @@
             }
           }
         }
+      },
+      "delete": {
+        "summary": "Delete an existing stop",
+        "operationId": "deleteStop",
+        "tags": [
+          "stop"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of stop to delete",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "delete successful"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
       }
     },
     "/audit/products": {

--- a/public.json
+++ b/public.json
@@ -1150,6 +1150,38 @@
             }
           }
         }
+      },
+      "post": {
+        "summary": "Create a new stop on a trip",
+        "operationId": "addStop",
+        "tags": [
+          "stop"
+        ],
+        "parameters": [
+          {
+            "name": "stop",
+            "in": "body",
+            "description": "stop to add",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/updateStop"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "stop response",
+            "schema": {
+              "$ref": "#/definitions/stop"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
       }
     },
     "/stop/{id}": {


### PR DESCRIPTION
This requires backend tooling for azurestandard/internal-website#51
(as discussed with @tompetersjr and @jeffstrickler on 2016-02-10),
which allows for simpler client-side code.  Details in the commit
messages.