### PR TITLE
public.json: Fix 'permissions' -> 'permission' for definition key

### DIFF
--- a/public.json
+++ b/public.json
@@ -4377,7 +4377,7 @@
         "wholesale"
       ]
     },
-    "permissions": {
+    "permission": {
       "description": "an API authorization or authorization category",
       "type": "string",
       "enum": [


### PR DESCRIPTION
Fix a typo from e4fc603 (public.json: Add person.permissions,
2016-02-08, #71).