### PR TITLE
public.json: Fix integer -> number type for float formats

### DIFF
--- a/public.json
+++ b/public.json
@@ -4576,12 +4576,12 @@
         },
         "weight": {
           "description": "weight of the shipped products in pounds (estimated until picking time)",
-          "type": "integer",
+          "type": "number",
           "format": "float"
         },
         "volume": {
           "description": "volume of the shipped products in cubic feet (estimated until picking time)",
-          "type": "integer",
+          "type": "number",
           "format": "float"
         },
         "price": {


### PR DESCRIPTION
Comply with [the OpenAPI (previously Swagger) spec][1], fixing bugs
from 3e3b6084 (public.json: Add /order-lines and /order-line/{id},
2014-12-02) and a5e85e83 (public.json: Add orderLine.volume,
2015-09-18, #30).

[1]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types