### PR TITLE
Fix 'persion' typo and broken JSON from #71

### DIFF
--- a/public.json
+++ b/public.json
@@ -4969,7 +4969,7 @@
           "$ref": "#/definitions/personNotifications"
         },
         "permissions": {
-          "description": "API permissions for this persion",
+          "description": "API permissions for this person",
           "type": "array",
           "items": {
             "$ref": "#/definitions/permission"


### PR DESCRIPTION
Typos from #71.