### PR TITLE
public.json: Add pick-offset and similar to the route models

### DIFF
--- a/public.json
+++ b/public.json
@@ -3958,8 +3958,23 @@
           "type": "integer",
           "format": "int32"
         },
+        "pick-offset": {
+          "description": "number of days after cutoff for picking orders",
+          "type": "integer",
+          "format": "int32"
+        },
         "delivery-offset": {
-          "description": "number of days after cutoff before the first stop",
+          "description": "number of days after cutoff for the first delivery stop",
+          "type": "integer",
+          "format": "int32"
+        },
+        "backhaul-offset": {
+          "description": "number of days after cutoff for the first pickup stop",
+          "type": "integer",
+          "format": "int32"
+        },
+        "warehouse-arrival-offset": {
+          "description": "number of days after cutoff for the truck arriving at the warehouse",
           "type": "integer",
           "format": "int32"
         },
@@ -3997,8 +4012,23 @@
           "type": "integer",
           "format": "int32"
         },
+        "pick-offset": {
+          "description": "number of days after cutoff for picking orders",
+          "type": "integer",
+          "format": "int32"
+        },
         "delivery-offset": {
-          "description": "number of days after cutoff before the first stop",
+          "description": "number of days after cutoff for the first delivery stop",
+          "type": "integer",
+          "format": "int32"
+        },
+        "backhaul-offset": {
+          "description": "number of days after cutoff for the first pickup stop",
+          "type": "integer",
+          "format": "int32"
+        },
+        "warehouse-arrival-offset": {
+          "description": "number of days after cutoff for the truck arriving at the warehouse",
           "type": "integer",
           "format": "int32"
         },


### PR DESCRIPTION
Catch the route models (route and updateRoute) up with d0b5d33f (Merge
remote-tracking branch 'origin/mt/update-trip-api', 2015-12-03, #44).
We need the offsets to seed new trips.

I've left out the *-end offsets out, because James only wanted the
-end times for rare adjustments.  I prefer calculating them from the
route-stop offsets, and everyone seemed to be on board with that for
most cases.  When creating new trips, the end dates should be
calculated using either

a. new trip's *-start date-time + largest current route-stop delivery
   offset.
b. new trip's *-start date-time + difference between *-start and *-end
   date-times for the most-future existing trip on the route.

Whether a client uses (a) or (b) doesn't matter to me.

I've added a "delivery" qualifier to the description for
delivery-offset, to make the distinction between drops and pickups
we've setup (temporarily?) in d0b5d33f.

I've gone with integer-day offsets to match our current backend
implementation, but all of these offsets are between a cutoff
date-time and another date-time (e.g. delivery-start is a date-time),
so we should likely be using:

    "type": "string",
    "format": "duration"

like we have for routeStop.delivery-offset since d2a35b36
(public.json: Add 'GET /route-stops' and /route-stop/{id} endpoints,
2015-05-07).  To get something usable out the door faster, I'll defer
discussion on the best duration type until after the new logistics UI
is deployed.

Spun off of azurestandard/internal-website#64.