### PR TITLE
public.json: Add ?accept=<mime> to GET /order/{id}

### DIFF
--- a/public.json
+++ b/public.json
@@ -2202,7 +2202,19 @@
             "required": true,
             "type": "integer",
             "format": "int64"
+          },
+          {
+            "name": "accept",
+            "in": "query",
+            "description": "override the HTTP Accept header to chose the response type.  Empty and unrecognized values will result in application/json.",
+            "required": false,
+            "type": "string"
           }
+        ],
+        "produces": [
+          "application/json",
+          "application/pdf",
+          "text/csv"
         ],
         "responses": {
           "200": {


### PR DESCRIPTION
JavaScript makes it easy to set headers on an `XMLHttpRequest` or
similar, but it's hard to set headers like that in an `<a href="…">`
link (there is an advisory [`type` attribute][1], but it's just a hint,
not a suggestion for the `Accept` header that the agent should use when
following that link).  You may be able to work around this with some
draft [File API][3] [blob manipulation][2] or by [reading the data into
memory and building a][4] [data URI][5], but those are both more trouble
than getting a PDF or CSV order representation should require.

This commit adds a new `accept` query parameter, so clients that have
trouble setting an `Accept` header have an alternative channel for
supplying that information.

It also documents (with a [per-operation `produces`][6]) the supported
MIME types for the order response.  The PDF MIME type is from [RFC
3778][7] and the CSV is from [RFC 4180][8].

[1]: https://www.w3.org/TR/html5/links.html#attr-hyperlink-type
[2]: http://stackoverflow.com/a/35632133
[3]: https://w3c.github.io/FileAPI/#dfn-createObjectURL
[4]: http://stackoverflow.com/a/20361958
[5]: http://tools.ietf.org/html/rfc2397
[6]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#fixed-fields-5
[7]: http://tools.ietf.org/html/rfc3778
[8]: http://tools.ietf.org/html/rfc4180