### PR TITLE
public.json: Add /favorites?active={true|false}

### DIFF
--- a/public.json
+++ b/public.json
@@ -3327,6 +3327,13 @@
               "format": "int64"
             },
             "collectionFormat": "csv"
+          },
+          {
+            "name": "active",
+            "in": "query",
+            "description": "only return favorites associated with (in)active packaged products.  For example, we sometimes discontinue products and then pick them back up later.  In this context, \"active\" means \"for sale to at least some customers\".",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "responses": {


### PR DESCRIPTION
This is a more limited version of `/packaged-products?tag=…`, since
[implementing that for more remote models has been troublesome][1].
The idea with this filter is that we can [preserve favorites
associated with discontinued products in the database but easily avoid
those favorites in the client][2].  Then if/when the product is picked
up again, the client using `active=true` would automatically pick it
back up.

I expect most clients will want to set `active=true`, but the
only-active functionality is behind a query parameter to keep the
stock `/favorites` from becoming too magical (with entries appearing
and disappearing based on associated-packaging status).  Having a
query parameter also makes it easy for clients who care to find and
delete inactive favorites on their own.

[1]: https://github.com/azurestandard/beehive/issues/956
[2]: https://github.com/azurestandard/beehive/pull/1618#discussion_r56353877