### PR TITLE
public.json: Add category.featured

### DIFF
--- a/public.json
+++ b/public.json
@@ -1827,7 +1827,7 @@
     },
     "/categories": {
       "get": {
-        "summary": "Returns all categories from the system",
+        "summary": "Returns all categories from the system, ordered by decreasing 'featured' values",
         "operationId": "findCategories",
         "tags": [
           "category"
@@ -4655,6 +4655,11 @@
             "description": "a keyword for this category",
             "type": "string"
           }
+        },
+        "featured": {
+          "description": "ordering precedence for likely customer interest.  Defaults to zero.",
+          "type": "integer",
+          "format": "int32"
         }
       },
       "required": [


### PR DESCRIPTION
Similar to address.preference, but this is set by Azure on categories
shared by all users, while address.preference is set by customers on
their own addresses.  I've tried to reflect that shift by changing the
attribute name from 'preference' to 'featured'.

An example use-case would be to fetch the top N child categories of a
given parent, without having to care about the details behind the
definition of "top".