### PR TITLE
public.json: Add 'GET /audit/product/{id}' and .clear-audited

### DIFF
--- a/public.json
+++ b/public.json
@@ -1245,6 +1245,46 @@
         }
       }
     },
+    "/audit/product/{id}": {
+      "get": {
+        "summary": "Returns a product based on a single ID",
+        "operationId": "findProductAuditById",
+        "tags": [
+          "audit",
+          "product"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of product to fetch",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "audited",
+            "in": "query",
+            "description": "When set, the packaging array only contains (un)audited packaging.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "product audit response",
+            "schema": {
+              "$ref": "#/definitions/productAudit"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      }
+    },
     "/audit/packaged-product/{code}": {
       "post": {
         "summary": "Audit an existing packaged-product",
@@ -5648,6 +5688,10 @@
         "unit": {
           "description": "the new unit of measurement.  Ideally one of \"\", or \"\", but you can use another unit if none of those fit.",
           "type": "string"
+        },
+        "clear-audited": {
+          "description": "If true, clear the audited date-time for this packaged-product.  If false (the default), set the audited date-time to the current time.",
+          "type": "boolean"
         }
       },
       "required": [


### PR DESCRIPTION
Colin [raised a question about handling products whose packaging has incompatible units][1], because it's hard to compare prices between packaging like that.  The choices are:

a. Allow incompatible units in the database, and handle inconsistencies when rendering that packaging in the API implementation.

b. Refuse incompatible units at data-entry time, so there are no audited inconsistencies in the database.

Either way, the rendering will have to handle products which do not have completely audited packaging, but (b) makes it easier for auditors to find and fix such occurrences while also protecting packaging-managers from typos.  And packaging-managers are the most likely to be able to resolve the inconsistency, so showing them the error shortens that bugfix cycle a lot ;).

On Fri, Mar 25, 2016 at 11:24:50AM -0700, Tom Peters [wrote][2]:
> I think it would be best to enforce at data-entry time.

The drawback to the data-entry-time check is that it's hard to switch a product from one set of audited units to an incompatible set.  For example, if product 12 has packaging 34, 56, and 78.

1. Set 34 and 56's units to `ounce`.
2. Realize that product 12 should be measured by volume and not by mass, and try to set 34's units to `fluid-ounce`, but the API rejects the request (because product 12 has other packaging with audited `ounce` units.

With the changes in this commit, the you can fix the issue with:

3. Calling `GET /audit/product/12?audited=true` to get existing audited packaging.
4. Calling `POST /audit/packaged-product/{code}` for each audited packaging from (3), round-tripping their `packs` and `unit` values    and setting `clear-audited` true.  After this, there will be no audited packaging for product 12.
5. Re-trying (2), which will succeed now that there are no audited inconsistencies.

You could handle this case in fewer requests with a single endpoint to clear audited from all packing associated with a product:

    POST /audit/product/12/clear-audited

but the approach taken by this commit allows you to be more granular in your clearing.  That can be useful for other cases (e.g. you notice `.packs` is wrong, but aren't sure what the right value should be).  And I don't expect this to happen so frequently that we care strongly about minimizing requests for the workflow.

[1]: https://github.com/azurestandard/beehive/pull/1362/files#r57466647
[2]: https://github.com/azurestandard/beehive/pull/1362/files#r57473677