### PR TITLE
public.json: Drop GET for /registration/confirm and /password/confirm

### DIFF
--- a/public.json
+++ b/public.json
@@ -3049,36 +3049,6 @@
       }
     },
     "/registration/confirm": {
-      "get": {
-        "summary": "Complete an in-progress registration",
-        "operationId": "confirmRegistrationGet",
-        "tags": [
-          "registration"
-        ],
-        "parameters": [
-          {
-            "name": "token",
-            "in": "query",
-            "description": "The registrant's confirmation token",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "person response",
-            "schema": {
-              "$ref": "#/definitions/person"
-            }
-          },
-          "default": {
-            "description": "unexpected error",
-            "schema": {
-              "$ref": "#/definitions/errorModel"
-            }
-          }
-        }
-      },
       "post": {
         "summary": "Complete an in-progress registration",
         "operationId": "confirmRegistration",
@@ -3173,43 +3143,6 @@
       }
     },
     "/password/confirm": {
-      "get": {
-        "summary": "Complete an in-progress password reset",
-        "operationId": "passwordResetGet",
-        "tags": [
-          "password"
-        ],
-        "parameters": [
-          {
-            "name": "token",
-            "in": "query",
-            "description": "The password-reset confirmation token",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "password",
-            "in": "query",
-            "description": "The new password",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "person response",
-            "schema": {
-              "$ref": "#/definitions/person"
-            }
-          },
-          "default": {
-            "description": "unexpected error",
-            "schema": {
-              "$ref": "#/definitions/errorModel"
-            }
-          }
-        }
-      },
       "post": {
         "summary": "Complete an in-progress password reset",
         "operationId": "passwordResetConfirmation",


### PR DESCRIPTION
The GET versions were added in 182d6c9 (public.json: Add 'GET
/registration/confirm?token=...', 2015-09-03, #19) and a94f2e29
(public.json: Add 'POST /password/reset' and 'POST /password/confirm',
2015-11-13, #52) to give folks something they could paste into their
browser.  We don't need that though, because clients can set base-url
to generate links to a non-API page, and have that non-API page POST
to the API ([Slack discussion][1]).  Users are unlikely to GET the API
directly, because the returned JSON isn't very user-friendly.

[1]: https://azurestandard.slack.com/archives/general/p1458760386001170