### PR TITLE
public.json: Add a payroll-deduction payment method

### DIFF
--- a/public.json
+++ b/public.json
@@ -5028,10 +5028,40 @@
         "expiration"
       ]
     },
+    "payrollDeduction": {
+      "description": "a payroll deduction (one of our supported payment methods)",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "type": {
+          "description": "string identifying this payment model",
+          "type": "string",
+          "enum": [
+            "payroll-deduction"
+          ]
+        },
+        "person": {
+          "description": "person associated with this payroll deduction",
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "person"
+      ]
+    },
     "paymentMethod": {
       "anyOf": [
         {
           "$ref": "#definitions/creditCard"
+        },
+        {
+          "$ref": "#definitions/payrollDeduction"
         }
       ]
     },


### PR DESCRIPTION
So employees can mark orders they want paid for out of their next
paycheck.

There is no newPayrollDeduction, because these methods are created via
the Beehive UI and not via the API (yet).  And employees will not be
creating these on their own behalf (while most customers create
credit-card methods by uploading their credit-card information on
their own behalf).

There's no special information associated with this method, but we'll
keep a person ID for symmetry with the credit-card type.