### PR TITLE
add dollars-per-unit and unit fields to _price

### DIFF
--- a/public.json
+++ b/public.json
@@ -4616,6 +4616,15 @@
         "discount": {
           "description": "text for the discount (e.g. \"12%\", or \"$3.50\")",
           "type": "string"
+        },
+        "dollars-per-unit": {
+          "description": "the per-unit price",
+          "type": "number",
+          "format": "float"
+        },
+        "unit": {
+          "description": "The unit for the dollars-per-unit",
+          "type": "string"
         }
       },
       "required": [


### PR DESCRIPTION
In order to facilitate displaying as-low-as pricing on the front end,
include the calculated price per unit. This will allow the front end to
select which packaging has the lowest price per unit and keeps the
separate pricing levels.

resolves #90