### PR TITLE
public.json: Reword "per-unit" to "per-product" in the per-pound docs

### DIFF
--- a/public.json
+++ b/public.json
@@ -4622,7 +4622,7 @@
           "format": "float"
         },
         "per-pound": {
-          "description": "whether the price is per-pound or per-unit",
+          "description": "whether the 'dollars' price is per-pound or per-product",
           "type": "boolean"
         },
         "discount": {


### PR DESCRIPTION
Since 81687725 (add dollars-per-unit and unit fields to _price,
2016-04-06, #92) added fields using "unit" to mean "pounds", "quarts",
and such, the old "per-unit" phrasing in the per-pound docs might be
confusing.  Pick new wording to clarify that if per-pound is false, it
means that 'dollars' is per-product (e.g. $6.50 means "the three-pack
of coconut water is $15", not "one ounce of coconut water is $6.50").

This phrasing (and some other price docs) blur the distinction between
"products" (unsized in most of the API) and "packaging" (sized in most
of the API), but I've stuck with "product" here for consistency with
the other price docs.  I'd also be ok with "per-packaging", although
that might also get confusing for things like three-packs.