### PR TITLE
public.json: Fix 'get' -> 'post' for /login and /logout

### DIFF
--- a/public.json
+++ b/public.json
@@ -2955,7 +2955,7 @@
       }
     },
     "/login": {
-      "get": {
+      "post": {
         "summary": "Authenticate and receive a session cookie",
         "operationId": "login",
         "tags": [
@@ -3000,7 +3000,7 @@
       }
     },
     "/logout": {
-      "get": {
+      "post": {
         "summary": "Clears the current cookie-based session",
         "operationId": "logout",
         "tags": [


### PR DESCRIPTION
These landed in 61bba865 (public.json: Add a POST-based /login
endpoint, 2015-05-20) and 7ac3aa3f (public.json: Add a /logout
endpoint, 2015-05-27).  The /login case was clearly (from the commit
message) an accidental copy/paste error, and I expect the latter was
too.  The GET -> POST change respects [RFC 7231's safe methods][1].

[1]: http://tools.ietf.org/html/rfc7231#section-4.2.1