### PR TITLE
public.json: /favorites?inline=... is a CSV array, not a single string

### DIFF
--- a/public.json
+++ b/public.json
@@ -3406,7 +3406,11 @@
             "in": "query",
             "description": "for convenience, include a full representation of the inlined property. Currently supports \"packaged-product\" and \"packaged-product.product\".",
             "required": false,
-            "type": "string"
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "csv"
           },
           {
             "name": "limit",


### PR DESCRIPTION
You should be able to do:

    /favorites?inline=packaged-product,packaged-product.product

although that's going to be the same as:

    /favorites?inline=packaged-product.product

The CSV-ness will be more important if the inline-able objects split.
For example, if we wanted to make packagedProduct.stock optional,
requests could look like:

    /favorites?inline=packaged-product.product,packaged-product.stock

The backend [already assumes the value is CSV][1].

[1]: https://github.com/azurestandard/beehive/pull/1715/commits/ae54f89994246e557438a44405b2cc4c0303f7b8#diff-afa3ac3d703b3410c74ee6769662e13dR203