### PR TITLE
public.json: Add /people?email=... and ?username=...

### DIFF
--- a/public.json
+++ b/public.json
@@ -2093,6 +2093,29 @@
         ],
         "parameters": [
           {
+            "name": "username",
+            "in": "query",
+            "description": "usernames to filter by",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "csv"
+          },
+          {
+            "name": "email",
+            "in": "query",
+            "description": "email addresses to filter by",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "email"
+            },
+            "collectionFormat": "csv"
+          },
+          {
             "name": "drop",
             "in": "query",
             "description": "drop IDs to filter by",


### PR DESCRIPTION
The API is built around numeric person IDs (e.g. /person/{id}), which
is fine.  But since email addresses and usernames can also be used to
login (see /login's username property), it would be nice to be able to
map those other values back to IDs.  As one example, this will let you
act on behalf of another user who says "my username is 'alice'",
without you having to go back and ask "but what's your person ID?"
(instead you can ask the API ;).