### PR TITLE
public.json: Fix 'product' -> 'packaged-product' in orderLine required

### DIFF
--- a/public.json
+++ b/public.json
@@ -4921,7 +4921,7 @@
       "required": [
         "id",
         "order",
-        "product",
+        "packaged-product",
         "quantity-ordered",
         "weight",
         "volume"


### PR DESCRIPTION
This was missed in 2b0dc9ac (public.json: Adjust products to key on
ID, and not packaging code, 2015-02-18) and the subsequent e87fa01f
(public.json: Fix 'package-product' -> 'packaged-product' typo,
2015-02-19).