### PR TITLE
public.json: Add 'POST /people'

### DIFF
--- a/public.json
+++ b/public.json
@@ -2821,6 +2821,38 @@
             }
           }
         }
+      },
+      "post": {
+        "summary": "Create a new person",
+        "operationId": "addPerson",
+        "tags": [
+          "person"
+        ],
+        "parameters": [
+          {
+            "name": "person",
+            "in": "body",
+            "description": "Person to add",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/updatePersonUserPassword"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "person response",
+            "schema": {
+              "$ref": "#/definitions/person"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
       }
     },
     "/person/{id}": {


### PR DESCRIPTION
The current registration endpoints are for unauthenticated users to
set up their own accounts, and they use an email-confirmation cycle to
avoid abuse.  When acting on behalf of customers, customer-service
will want to skip that confirmation cycle, and rely on their judgement
to avoid abuse.  There is currently a Beehive UI for creating new
customers [here](https://beehive.azurestandard.com/customer/create) that does not confirm email addresses (and we don't
even require email addresses).  In the 2016-04-25 software meeting, we
decided that shifting that functionality from Beehive to the website
(when driven by a user with sufficient permissions) would make the
customer-service workflow more consistent (they can live in the new
website with fewer trips back to Beehive).

The registration endpoints (initially from 0849a532 and cleaned up in
6740cf78 #9 and cde454569) include a few models (person, address,
drop-membership, ...), because we want to be able to collect all of
that before kicking off the email-confirmation cycle.  With a
confirmation-less approach we can be simpler, and just POST
updatePersonUserPassword to /people.  The caller can then POST to
/addresses, /drop-memberships, ... to create the other models.

I don't have a strong preference on updatePerson vs.
updatePersonUserPassword, since I expect most customer-service-created
people will initially have [unusable passwords](https://docs.djangoproject.com/en/1.9/ref/contrib/auth/#django.contrib.auth.models.User.set_unusable_password).  If the person
later decides they want to log in on their own, they can use the
password-reset functionality and their access to the configured email
address.  If they don't have an email address configured, they'll have
to call customer-service and authenticate using whatever scheme we use
over the phone ;).  But if we require user-password-confirmation to
update a person's password, we probably want to require
user-password-confirmation to create a user with an explicit password.

The ability to create users through the API will also make API testing
easier.
