### PR TITLE
public.json: Add .active to payment methods

### DIFF
--- a/public.json
+++ b/public.json
@@ -2541,6 +2541,13 @@
         ],
         "parameters": [
           {
+            "name": "active",
+            "in": "query",
+            "description": "only return (in)active payment methods",
+            "required": false,
+            "type": "boolean"
+          },
+          {
             "name": "filter-person",
             "in": "query",
             "description": "person IDs to filter by",
@@ -5023,6 +5030,10 @@
             "credit-card"
           ]
         },
+        "active": {
+          "description": "whether or not this payment method available for further activity",
+          "type": "boolean"
+        },
         "person": {
           "description": "person associated with this credit card",
           "type": "integer",
@@ -5053,6 +5064,7 @@
       "required": [
         "id",
         "type",
+        "active",
         "person",
         "name",
         "address",
@@ -5070,6 +5082,10 @@
           "enum": [
             "credit-card"
           ]
+        },
+        "active": {
+          "description": "whether or not this payment method available for further activity.  Defaults to true",
+          "type": "boolean"
         },
         "person": {
           "description": "person associated with this credit card",
@@ -5124,6 +5140,10 @@
             "payroll-deduction"
           ]
         },
+        "active": {
+          "description": "whether or not this payment method available for further activity",
+          "type": "boolean"
+        },
         "person": {
           "description": "person associated with this payroll deduction",
           "type": "integer",
@@ -5133,6 +5153,7 @@
       "required": [
         "id",
         "type",
+        "active",
         "person"
       ]
     },


### PR DESCRIPTION
This allows us to return historical payment methods (e.g. so customers
can see which method they used for a past payment), while still
allowing customers to distinguish between methods that can and cannot
be used for new payments.

The permissions around toggling .active will be complicated.  For
example, a customer should be allowed to change creditCard.active from
true to false if they want to disable a particular card.  In that
case, they should also be able to immediately change .active back to
true.  However, they should not be able to re-activate cards that have
expired, or re-activate payroll-deductions if they are no longer an
employee.  The backend may implement whatever restrictions it feels
are appropriate in this respect, and clients should be prepared to
handle assorted 400s when .active-changing requests violate a
backend-imposed restrictoon.

See also azurestandard/website#209 and azurestandard/beehive#1582.