### PR TITLE
public.json: Inlines for product.packaging and packagedProduct.product

### DIFF
--- a/public.json
+++ b/public.json
@@ -2366,7 +2366,7 @@
           {
             "name": "inline",
             "in": "query",
-            "description": "for convenience, include a full representation of the inlined property. Currently supports \"brand\", \"packaging\", and descendants.",
+            "description": "for convenience, include a full representation of the inlined property. Currently supports the local \"description\" and \"favorites\" as well as \"brand\", \"packaging\", \"vendors\", and descendants.",
             "required": false,
             "type": "array",
             "items": {
@@ -2432,6 +2432,17 @@
             "description": "ID of product to fetch",
             "required": true,
             "type": "string"
+          },
+          {
+            "name": "inline",
+            "in": "query",
+            "description": "for convenience, include a full representation of the inlined property. Currently supports the local \"description\" and \"favorites\" as well as \"brand\", \"packaging\", \"vendors\", and descendants.",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "csv"
           }
         ],
         "responses": {
@@ -2564,7 +2575,7 @@
           {
             "name": "inline",
             "in": "query",
-            "description": "for convenience, include a full representation of the inlined property. Currently supports \"product\" and descendants.",
+            "description": "for convenience, include a full representation of the inlined property. Currently supports the local \"favorites\", \"next-purchase-arrival\", and \"quantity-on-next-purchase\" as well as \"product\", \"vendors\", and descendants.",
             "required": false,
             "type": "array",
             "items": {
@@ -2630,6 +2641,17 @@
             "description": "code of the packaged product to fetch",
             "required": true,
             "type": "string"
+          },
+          {
+            "name": "inline",
+            "in": "query",
+            "description": "for convenience, include a full representation of the inlined property. Currently supports the local \"favorites\", \"next-purchase-arrival\", and \"quantity-on-next-purchase\" as well as \"product\", \"vendors\", and descendants.",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "csv"
           }
         ],
         "responses": {
@@ -5517,6 +5539,17 @@
             "required": true,
             "type": "integer",
             "format": "int64"
+          },
+          {
+            "name": "inline",
+            "in": "query",
+            "description": "for convenience, include a full representation of the inlined property. Currently supports \"packaged-product\" and descendants.",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "csv"
           }
         ],
         "responses": {

--- a/public.json
+++ b/public.json
@@ -7025,8 +7025,6 @@
       "required": [
         "id",
         "name",
-        "size",
-        "price",
         "packaging"
       ]
     },

--- a/public.json
+++ b/public.json
@@ -2366,7 +2366,7 @@
           {
             "name": "inline",
             "in": "query",
-            "description": "for convenience, include a full representation of the inlined property. Currently supports \"packaging\" and descendants.",
+            "description": "for convenience, include a full representation of the inlined property. Currently supports \"brand\", \"packaging\", and descendants.",
             "required": false,
             "type": "array",
             "items": {
@@ -6986,7 +6986,9 @@
           "type": "string"
         },
         "brand": {
-          "$ref": "#/definitions/brand"
+          "description": "the brand associated with this product",
+          "type": "integer",
+          "format": "int64"
         },
         "directions": {
           "description": "product use directions (e.g., cooking suggestions)",

--- a/public.json
+++ b/public.json
@@ -2364,6 +2364,17 @@
             "format": "int64"
           },
           {
+            "name": "inline",
+            "in": "query",
+            "description": "for convenience, include a full representation of the inlined property. Currently supports \"packaging\" and descendants.",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "csv"
+          },
+          {
             "name": "limit",
             "in": "query",
             "description": "maximum number of results to return",
@@ -2549,6 +2560,17 @@
             "required": false,
             "type": "integer",
             "format": "int64"
+          },
+          {
+            "name": "inline",
+            "in": "query",
+            "description": "for convenience, include a full representation of the inlined property. Currently supports \"product\" and descendants.",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "csv"
           },
           {
             "name": "limit",
@@ -5396,7 +5418,7 @@
           {
             "name": "inline",
             "in": "query",
-            "description": "for convenience, include a full representation of the inlined property. Currently supports \"packaged-product\" and \"packaged-product.product\".",
+            "description": "for convenience, include a full representation of the inlined property. Currently supports \"packaged-product\" and descendants.",
             "required": false,
             "type": "array",
             "items": {
@@ -6884,10 +6906,9 @@
           "type": "string"
         },
         "product": {
-          "description": "the name and brand of the product that this packaged-product is associated with",
-          "schema": {
-            "$ref": "#/definitions/packagedProductProduct"
-          }
+          "description": "the product that this packaging packages",
+          "type": "integer",
+          "format": "int64"
         },
         "primary-category": {
           "description": "the id of the primary category for this packaged-product",
@@ -6897,30 +6918,11 @@
       },
       "required": [
         "code",
+        "product",
         "size",
         "price",
         "tags"
       ]
-    },
-    "packagedProductProduct": {
-      "description": "the ID, name, and brand of a product that a packaged-product is associated with",
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "integer",
-          "format": "int64"
-        },
-        "name": {
-          "description": "the product name",
-          "type": "string"
-        },
-        "brand": {
-          "description": "the brand that this product is associated with",
-          "schema": {
-            "$ref": "#/definitions/brand"
-          }
-        }
-      }
     },
     "packagedProductTag": {
       "description": "a type of packaged product or other boolean marker",
@@ -7006,7 +7008,8 @@
           "description": "packaged versions of this product",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/packagedProduct"
+            "type": "integer",
+            "format": "int64"
           }
         },
         "country-of-origin": {
@@ -7024,8 +7027,7 @@
       },
       "required": [
         "id",
-        "name",
-        "packaging"
+        "name"
       ]
     },
     "nutritionFacts": {


### PR DESCRIPTION
Details in the commit-messages (which also includes a drive-by fix for
product's required array).

This covers [this request](https://github.com/azurestandard/beehive/pull/1715#issuecomment-215227195) while setting up the product and
packaged-product endpoints to be a bit more structured and performant.
