### PR TITLE
public.json: Add packagedProduct.gtin13 and ?gtin13=... filters

### DIFF
--- a/public.json
+++ b/public.json
@@ -1358,6 +1358,18 @@
             "type": "string"
           },
           {
+            "name": "gtin13",
+            "in": "query",
+            "description": "packaged-product 13-digit Global Trade Item Numbers to filter by",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "collectionFormat": "csv"
+          },
+          {
             "name": "brand",
             "in": "query",
             "description": "brand IDs to filter by",
@@ -1535,6 +1547,18 @@
             "name": "product",
             "in": "query",
             "description": "product IDs to filter by",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "collectionFormat": "csv"
+          },
+          {
+            "name": "gtin13",
+            "in": "query",
+            "description": "13-digit Global Trade Item Numbers to filter by",
             "required": false,
             "type": "array",
             "items": {
@@ -4420,6 +4444,10 @@
       "type": "object",
       "properties": {
         "code": {
+          "type": "string"
+        },
+        "gtin13": {
+          "description": "13-digit Global Trade Item Number (https://schema.org/gtin13)",
           "type": "string"
         },
         "size": {


### PR DESCRIPTION
On Thu, Apr 28, 2016 at 02:24:35PM -0700, Tom Peters [wrote][1]:
> Rebecca reported that there was talk of UPC/Barcodes being
> searchable.

This makes a lot of sense to me, especially for wholesalers and such
who want to scan a barcode to order more of a product they're running
low on.  The new field and semantics [follow][2] [schema.org][3].

Internally, we allow a product to have several barcodes, and I'm fine
supporting all GTIN-13-compatible barcodes for search.  But for
compatibility with schema.org we should just be returning the primary
barcode here.

[1]: https://github.com/azurestandard/website/issues/304
[2]: https://schema.org/Product
[3]: https://schema.org/gtin13