### PR TITLE
public.json: Remove vestigial 'name' from dropMembership.required

### DIFF
--- a/public.json
+++ b/public.json
@@ -4100,7 +4100,6 @@
       },
       "required": [
         "id",
-        "name",
         "notifications",
         "customer",
         "drop"


### PR DESCRIPTION
This came in with 8a05c761 (add drop membership endpoints and
definitions, 2016-01-27, #66), and we just missed the required value
when rerolling to [drop the dropMembership.name property][1].

[1]: https://github.com/azurestandard/api-spec/pull/66#issuecomment-178158238