### PR TITLE
Add GET /*?pickup=... filtering where we have ?drop=... filtering

### DIFF
--- a/public.json
+++ b/public.json
@@ -874,6 +874,18 @@
             "collectionFormat": "csv"
           },
           {
+            "name": "pickup",
+            "in": "query",
+            "description": "pickup IDs to filter by",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "collectionFormat": "csv"
+          },
+          {
             "name": "stop",
             "in": "query",
             "description": "stop IDs to filter by",

--- a/public.json
+++ b/public.json
@@ -656,6 +656,18 @@
             "collectionFormat": "csv"
           },
           {
+            "name": "pickup",
+            "in": "query",
+            "description": "pickup IDs to filter by",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "collectionFormat": "csv"
+          },
+          {
             "name": "limit",
             "in": "query",
             "description": "maximum number of results to return",

--- a/public.json
+++ b/public.json
@@ -1123,6 +1123,18 @@
             "collectionFormat": "csv"
           },
           {
+            "name": "pickup",
+            "in": "query",
+            "description": "pickup IDs to filter by",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "collectionFormat": "csv"
+          },
+          {
             "name": "limit",
             "in": "query",
             "description": "maximum number of results to return",


### PR DESCRIPTION
We want to be able to discover these associations regardless of
whether goods are moving on or off the truck.  This is a follow-up to
#49.

The route-stops implementation is still in flight with
azurestandard/beehive@93c48a35 (apps/api/views/routestop.py: Add
/api/route-stops and /api/route-stop/{id}, 2015-05-11,
tk/trip-stop-api), so I expect that will remain unimplemented for a
while.  But the other two should be easy to add.
