### PR TITLE
add type to payment model

### DIFF
--- a/public.json
+++ b/public.json
@@ -5724,6 +5724,10 @@
           "type": "integer",
           "format": "int64"
         },
+        "type": {
+          "description": "The type of payment used",
+          "type": "string",
+        },
         "amount": {
           "description": "Amount to charge (or which was charged) in dollars",
           "type": "number",


### PR DESCRIPTION
adds the type of payment to the payment model to allow for
displaying the payment type as described in azurestandard/website#209