### PR TITLE
public.json: Add GET /orders?inline=... and /order/{id}?inline=...

### DIFF
--- a/public.json
+++ b/public.json
@@ -2450,6 +2450,17 @@
             "collectionFormat": "csv"
           },
           {
+            "name": "inline",
+            "in": "query",
+            "description": "for convenience, include a full representation of the inlined property.  Currently supports \"payment.payment-method\".",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "csv"
+          },
+          {
             "name": "limit",
             "in": "query",
             "description": "maximum number of results to return",
@@ -2515,6 +2526,17 @@
             "description": "override the HTTP Accept header to chose the response type.  Empty and unrecognized values will result in application/json.",
             "required": false,
             "type": "string"
+          },
+          {
+            "name": "inline",
+            "in": "query",
+            "description": "for convenience, include a full representation of the inlined property.  Currently supports \"payment.payment-method\".",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "csv"
           }
         ],
         "produces": [


### PR DESCRIPTION
For folks who don't want to make a separate request to get the
associated payment method.

I considered replacing order.payment with an ID and having inline
support for that too, but that would require splitting the "please
charge this order to ..." modeling from "we charged that order to ..."
modeling.  That's probably a worthwhile change to make, but I'm
punting on it for now.

This PR is an alternative to #112.