### PR TITLE
public.json: Remove trailing comma in payment.type

### DIFF
--- a/public.json
+++ b/public.json
@@ -5726,7 +5726,7 @@
         },
         "type": {
           "description": "The type of payment used",
-          "type": "string",
+          "type": "string"
         },
         "amount": {
           "description": "Amount to charge (or which was charged) in dollars",


### PR DESCRIPTION
[Typo][1] from 4a700af (add type to payment model, 2016-05-06, #112).

[1]: https://circleci.com/gh/azurestandard/api-spec/270