### PR TITLE
public.json: Add GET /drop-memberships?inline=... and /drop-membership/{id}?inline=...

### DIFF
--- a/public.json
+++ b/public.json
@@ -332,6 +332,17 @@
             "collectionFormat": "csv"
           },
           {
+            "name": "inline",
+            "in": "query",
+            "description": "for convenience, include a full representation of the inlined property.  Currently supports \"customer\" and \"drop\".",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "csv"
+          },
+          {
             "name": "limit",
             "in": "query",
             "description": "maximum number of results to return",
@@ -422,6 +433,17 @@
             "required": true,
             "type": "integer",
             "format": "int64"
+          },
+          {
+            "name": "inline",
+            "in": "query",
+            "description": "for convenience, include a full representation of the inlined property.  Currently supports \"customer\" and \"drop\".",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "csv"
           }
         ],
         "responses": {

--- a/public.json
+++ b/public.json
@@ -4498,15 +4498,20 @@
       },
       "required": [
         "id",
-        "notifications",
         "customer",
-        "drop"
+        "drop",
+        "notifications"
       ]
     },
     "updateDropMembership": {
       "description": "a drop membership to update",
       "type": "object",
       "properties": {
+        "customer": {
+          "description": "customer that has the drop membership",
+          "type": "integer",
+          "format": "int64"
+        },
         "drop": {
           "description": "the drop this membership is for",
           "type": "integer",
@@ -4514,11 +4519,6 @@
         },
         "notifications": {
           "$ref": "#/definitions/dropMembershipNotifications"
-        },
-        "customer": {
-          "description": "customer that has the drop membership",
-          "type": "integer",
-          "format": "int64"
         }
       },
       "required": [


### PR DESCRIPTION
Also a drive-by cleanup.  Spun off from [here][1].

[1]: https://github.com/azurestandard/website/issues/326#issuecomment-216697217