### PR TITLE
Use net-10-days and net-30-days slugs for generic payment methods.

### DIFF
--- a/public.json
+++ b/public.json
@@ -5680,8 +5680,8 @@
           "enum": [
             "cash-on-delivery",
             "hold-for-payment",
-            "net-10",
-            "net-30",
+            "net-10-days",
+            "net-30-days",
             "payroll-deduction"
           ]
         },


### PR DESCRIPTION
Instead of just net-10 and net-30.  These slugs have already been
exposed by the API.