### PR TITLE
public.json: Add dropMembership.pending

### DIFF
--- a/public.json
+++ b/public.json
@@ -332,6 +332,13 @@
             "collectionFormat": "csv"
           },
           {
+            "name": "pending",
+            "in": "query",
+            "description": "only return pending (true) or accepted (false) memberships",
+            "required": false,
+            "type": "boolean"
+          },
+          {
             "name": "inline",
             "in": "query",
             "description": "for convenience, include a full representation of the inlined property.  Currently supports \"customer\" and \"drop\".",
@@ -4514,6 +4521,10 @@
           "type": "integer",
           "format": "int64"
         },
+        "pending": {
+          "description": "whether the membership is pending (true) or accepted (false).",
+          "type": "boolean"
+        },
         "notifications": {
           "$ref": "#/definitions/dropMembershipNotifications"
         }
@@ -4522,6 +4533,7 @@
         "id",
         "customer",
         "drop",
+        "pending",
         "notifications"
       ]
     },
@@ -4539,13 +4551,18 @@
           "type": "integer",
           "format": "int64"
         },
+        "pending": {
+          "description": "whether the membership is pending (true) or accepted (false).",
+          "type": "boolean"
+        },
         "notifications": {
           "$ref": "#/definitions/dropMembershipNotifications"
         }
       },
       "required": [
         "customer",
-        "drop"
+        "drop",
+        "pending"
       ]
     },
     "newDropMembership": {


### PR DESCRIPTION
Allow provisional memberships (“Please let me in”) for folks joining
semi-open or closed drops.  Drop coordinators and/or customer-service
can hit:

    GET /drop-memberships?pending=true&...

to see who has asked to join drops (or, with `&drop={drop.id}`, who has
asked to join their drop).  They can fetch all memberships, pending or
accepted, by not specifying the `pending` parameter.  And they can
fetch only accepted memberships with `pending=false`.

Drop coordinators and/or customer-service can also accept requests by
PUTing with pending false.  And they can reject requests by DELETE'ing
the membership ([we aren't currently doing anything special for
rejections on the backend][1]).

I haven't setup a default value in `updateDropMembership` because the
reasonable choice depends on the drop being joined.  Folks joining an
open drop should set pending false (and the backend might 400 requests
that don't, because likely nobody will be checking to approve those
requests).  Folks joining semi-open or closed drops should set pending
to true, and the backend will 400 them if they don't.

Fixes #115.
Related to azurestandard/beehive#1476, azurestandard/beehive#1761, azurestandard/website#118.

[1]: https://github.com/azurestandard/beehive/issues/1761#issuecomment-217992838