### PR TITLE
public.json: Include breakdown ancestors in packagedProduct.stock

### DIFF
--- a/public.json
+++ b/public.json
@@ -4932,7 +4932,7 @@
           "#ref": "#/definitions/price"
         },
         "stock": {
-          "description": "amount of stock available for purchase",
+          "description": "amount of stock available for purchase.  This includes breakdown ancestors.  For example, if we have a single 4 x 6 x 14 oz case in the warehouse, the 4 x 6 x 14 oz packaging will have 1 stock, the 6 x 14 oz packagaging will have 4 stock, and the 14 oz packaging will have 24 stock.",
           "type": "integer",
           "format": "int32"
         },


### PR DESCRIPTION
The previous spec wording was unclear, but the current site includes
breakdown ancestors, so we want to mimic that here [1].  You can
almost figure out the ancestor-included values from the direct values
(e.g. if we set 0 stock for the 6 x 14 and 14 oz packaging in the new
doc example), but the API doesn't clarify what can be broken down into
what.

[1]: https://github.com/azurestandard/beehive/issues/1780