### PR TITLE
public.json: Allow order.trip for parcel-carrier orders

### DIFF
--- a/public.json
+++ b/public.json
@@ -5384,12 +5384,12 @@
           "format": "date-time"
         },
         "target-delivery": {
-          "description": "planned delivery time (fixed before the trip starts, and unset for UPS orders)",
+          "description": "planned delivery time (fixed before the trip starts, and unset for parcel-carrier orders)",
           "type": "string",
           "format": "date-time"
         },
         "estimated-delivery": {
-          "description": "estimated delivery time (updated after the trip starts until the order is delivered, and unset for UPS orders)",
+          "description": "estimated delivery time (updated after the trip starts until the order is delivered, and unset for parcel-carrier orders)",
           "type": "string",
           "format": "date-time"
         },
@@ -5410,17 +5410,17 @@
           }
         },
         "drop": {
-          "description": "drop the order is destined for (unset for UPS orders)",
+          "description": "drop the order is destined for (unset for parcel-carrier orders)",
           "type": "integer",
           "format": "int64"
         },
         "trip": {
-          "description": "trip delivering the order (automatically populated for for UPS orders)",
+          "description": "trip delivering the order (automatically populated for for parcel-carrier orders)",
           "type": "integer",
           "format": "int64"
         },
         "address": {
-          "description": "UPS delivery location (unset for truck orders)",
+          "description": "parcel-carrier delivery location (unset for truck orders)",
           "$ref": "#/definitions/address"
         }
       },

--- a/public.json
+++ b/public.json
@@ -5415,7 +5415,7 @@
           "format": "int64"
         },
         "trip": {
-          "description": "trip delivering the order (unset for UPS orders)",
+          "description": "trip delivering the order (automatically populated for for UPS orders)",
           "type": "integer",
           "format": "int64"
         },


### PR DESCRIPTION
The old website exposes this information with text like:

> You can continue modifying this order until May 16, 2016 at 6 p.m.

This change exposes parcel-carrier cutoff information to customers, so they can figure out when orders will cutoff (last call for (un)placing orders on that trip).

This could also allow customers to place orders on future parcel-carrier trips, although the Angular UI isn't planning on supporting that, and the backend might 400 such attempts.

I'm leaving order.drop unset for parcel-carrier orders, because it doesn't add any useful information (order.address already has the delivery location).

Also change “UPS” to the more generic “parcel-carrier”.