### PR TITLE
Add /trips?confirmed=(true|false) and /stops?short-drop=(true=false)

### DIFF
--- a/public.json
+++ b/public.json
@@ -919,6 +919,13 @@
             "format": "date-time"
           },
           {
+            "name": "confirmed",
+            "in": "query",
+            "description": "only return (un)confirmed trips",
+            "required": false,
+            "type": "boolean"
+          },
+          {
             "name": "limit",
             "in": "query",
             "description": "maximum number of results to return",
@@ -4678,6 +4685,11 @@
         },
         "cutoff": {
           "description": "cutoff for placing orders on this trip",
+          "type": "string",
+          "format": "date-time"
+        },
+        "confirmed": {
+          "description": "when the trip was reviewed and orders were either accepted or (for short drops) bumped to the next trip.  This will always be set before the trip is confirmed, and will be unset until then.  Customer service and customers who have received a short-drop notification can continue to manipulate placed orders in the window between cutoff and confirmation.",
           "type": "string",
           "format": "date-time"
         },

--- a/public.json
+++ b/public.json
@@ -2509,6 +2509,7 @@
               "enum": [
                 "cart",
                 "placed",
+                "confirmed",
                 "shipped",
                 "lost"
               ]
@@ -5348,6 +5349,7 @@
           "enum": [
             "cart",
             "placed",
+            "confirmed",
             "shipped",
             "lost"
           ]

--- a/public.json
+++ b/public.json
@@ -1284,6 +1284,13 @@
             "format": "date-time"
           },
           {
+            "name": "short-drop",
+            "in": "query",
+            "description": "only return stops which have (not) had short-drop warnings sent.",
+            "required": false,
+            "type": "boolean"
+          },
+          {
             "name": "limit",
             "in": "query",
             "description": "maximum number of results to return",
@@ -4818,7 +4825,7 @@
       ]
     },
     "stop": {
-      "description": "a trip stop or waypoint.  Stops are created for all route-stops when a trip is created for that route.  At verification time, stops that will not be visited (e.g. because they missed their order-minimum) are deleted",
+      "description": "a trip stop or waypoint.  Stops are created for all route-stops when a trip is created for that route.  At confirmation time, stops that will not be visited (e.g. because they missed their order-minimum) are deleted",
       "type": "object",
       "properties": {
         "id": {
@@ -4834,6 +4841,10 @@
           "description": "drop ID for the stop",
           "type": "integer",
           "format": "int64"
+        },
+        "short-drop": {
+          "description": "whether short-drop warnings were sent out for this stop.  If they were, customers can manipulate placed orders after cutoff time, although nobody can edit orders after the trip is confirmed.",
+          "type": "boolean"
         },
         "pickup": {
           "description": "pickup ID for the stop",

--- a/public.json
+++ b/public.json
@@ -4682,7 +4682,7 @@
           "format": "date-time"
         },
         "pick-date": {
-          "description": "date that orders for this trip should be picked",
+          "description": "date-time that orders for this trip should be picked",
           "type": "string",
           "format": "date-time"
         },
@@ -4702,17 +4702,17 @@
           "format": "date-time"
         },
         "backhaul-start": {
-          "description": "estimated date for the first backhaul",
+          "description": "estimated date-time for the first backhaul",
           "type": "string",
           "format": "date-time"
         },
         "backhaul-end": {
-          "description": "estimated date for the last backhaul",
+          "description": "estimated date-time for the last backhaul",
           "type": "string",
           "format": "date-time"
         },
         "warehouse-arrival": {
-          "description": "estimated date for warehouse arrival",
+          "description": "estimated date-time for warehouse arrival",
           "type": "string",
           "format": "date-time"
         }
@@ -4738,7 +4738,7 @@
           "format": "date-time"
         },
         "pick-date": {
-          "description": "date that orders for this trip should be picked",
+          "description": "date-time that orders for this trip should be picked",
           "type": "string",
           "format": "date-time"
         },
@@ -4753,17 +4753,17 @@
           "format": "date-time"
         },
         "backhaul-start": {
-          "description": "estimated date for the first backhaul",
+          "description": "estimated date-time for the first backhaul",
           "type": "string",
           "format": "date-time"
         },
         "backhaul-end": {
-          "description": "estimated date for the last backhaul",
+          "description": "estimated date-time for the last backhaul",
           "type": "string",
           "format": "date-time"
         },
         "warehouse-arrival": {
-          "description": "estimated date for warehouse arrival",
+          "description": "estimated date-time for warehouse arrival",
           "type": "string",
           "format": "date-time"
         }
@@ -6251,7 +6251,7 @@
           "format": "int64"
         },
         "expires": {
-          "description": "current expiration date for this session (http://tools.ietf.org/html/rfc6265#section-5.3, covering both Max-Age and Expires representations, unset if the session expires at browser-close)",
+          "description": "current expiration date-time for this session (http://tools.ietf.org/html/rfc6265#section-5.3, covering both Max-Age and Expires representations, unset if the session expires at browser-close)",
           "type": "string",
           "format": "date-time"
         }


### PR DESCRIPTION
This gives customer-service and short-drop members a way to find their
post-cutoff and pre-confirmation short stops for stoppage-time
shopping (see [here][1]).  It also gives folks with existing orders a
way to tell if they will be able to make post-cutoff edits to placed
orders or not, without having to push changes and watch for errors.
More details on the individual changes in the commit messages.

CC @MercenaryJosh, @davidmcatee-azure.

[1]: https://github.com/azurestandard/website/commit/5566db1cd84fffce7420bead6d52571697be3c62#commitcomment-17516147