### PR TITLE
public.json: Rename 'cart' -> 'open' for order status

### DIFF
--- a/public.json
+++ b/public.json
@@ -2493,7 +2493,7 @@
             "items": {
               "type": "string",
               "enum": [
-                "cart",
+                "open",
                 "placed",
                 "shipped",
                 "lost"
@@ -5436,7 +5436,7 @@
           "description": "order's lifecycle stage",
           "type": "string",
           "enum": [
-            "cart",
+            "open",
             "placed",
             "shipped",
             "lost"


### PR DESCRIPTION
David McAtee proposed this change, which brings the phrasing more in
line with purchase.status and fits better with a shopping model that
could include multiple pre-cutoff orders.  It went over well at the
2016-06-03 developer meeting and the 2016-06-06 software meeting.

See azurestandard/website#425.