### PR TITLE
public.json: Add updatePackagedProductAudit.size

### DIFF
--- a/public.json
+++ b/public.json
@@ -7042,6 +7042,10 @@
           "description": "the new unit of measurement.  Ideally one of \"\", or \"\", but you can use another unit if none of those fit.",
           "type": "string"
         },
+        "size": {
+          "description": "override the auto-generated size (based on packs and unit) with a custom name.  This can be useful for adding packaging information (e.g. \"32 floz glass\" to distinguish glass from plastic vinegar bottles).",
+          "type": "string"
+        },
         "clear-audited": {
           "description": "If true, clear the audited date-time for this packaged-product.  If false (the default), set the audited date-time to the current time.",
           "type": "boolean"


### PR DESCRIPTION
To allow for non-size distinctions between packaging without having to
split them into separate product families.  The vinegar example is for
CO463, but this change will also be useful for variable-weight
packaging such as MT159 (6 x 6-10 lb turkey).