### PR TITLE
public.json: Allow username and person IDs in password resets

### DIFF
--- a/public.json
+++ b/public.json
@@ -6443,9 +6443,8 @@
           "format": "url"
         },
         "email": {
-          "description": "The email address for the person whose password will be reset",
-          "type": "string",
-          "format": "email"
+          "description": "The email address for the person whose password will be reset.  Instead of the email address, you may also use your username or person ID here",
+          "type": "string"
         }
       },
       "required": [


### PR DESCRIPTION
Because, while you need an email address in order to receive the reset
token, you may not remember which address you've given Azure.  I'm
keeping 'email' as the property name here (both for backward compat
and because it is the most closely tied to the token delivery), but
the new description borrows from login's 'username' property to allow
the other common identifiers.

With this approach, the backend has to figure out whether the uploaded
identifier is an email, username, or person ID, but that logic has to
happen somewhere, and the API is smaller if we push it to the backend.
If we wanted the type-detection to happen in the frontend, we'd have
to use oneOf or similar JSON Schema stuff.  I like it when the API is
explicit, because it allows for a simpler backend and UIs that
distinguish between the different types, but the backend
implementation to do this autodetection is already coded up
(azurestandard/beehive#1921).