### PR TITLE
public.json: Add /products?detailed=true

### DIFF
--- a/public.json
+++ b/public.json
@@ -1512,6 +1512,13 @@
             "type": "string"
           },
           {
+            "name": "detailed",
+            "in": "query",
+            "description": "include properties with large payloads that are probably only useful for product-detail views (e.g. description, directions, ingredients, ...).  This is false by default to reduce the size of responses that will only be used for product-list views.",
+            "required": false,
+            "type": "boolean"
+          },
+          {
             "name": "limit",
             "in": "query",
             "description": "maximum number of results to return",


### PR DESCRIPTION
To provide a single endpoint:

```
/products?detailed=true&packaged-product={code}
```

that will return all the interesting information about a product (including its in-house and discontinued pieces).  More details in azurestandard/azure-angular-providers@30f479fd (Merge remote-tracking branch 'origin/dm/fix-double-algolia-product-requests, 2016-07-12, azurestandard/azure-angular-providers#56).
