### PR TITLE
public.json: Split order.fees into its own endpoint

### DIFF
--- a/public.json
+++ b/public.json
@@ -3069,6 +3069,103 @@
         }
       }
     },
+    "/order-fees": {
+      "get": {
+        "summary": "Returns all order fees from the system that the user has access to",
+        "operationId": "findOrderFees",
+        "tags": [
+          "order"
+        ],
+        "parameters": [
+          {
+            "name": "order",
+            "in": "query",
+            "description": "order IDs to filter by",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "collectionFormat": "csv"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "maximum number of results to return",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "start",
+            "in": "query",
+            "description": "offset to the first result to return.  Use negative numbers to offset from the end of the result list.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "order fee response",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/orderFee"
+              }
+            },
+            "headers": {
+              "Count": {
+                "description": "total number of matching results (how many you'd get if you could set an infinite `limit`)",
+                "type": "integer",
+                "format": "int32",
+                "minimum": 0
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      }
+    },
+    "/order-fee/{id}": {
+      "get": {
+        "summary": "Returns an order fee based on a single ID",
+        "operationId": "findOrderFeeById",
+        "tags": [
+          "order"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of order fee to fetch",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "order fee response",
+            "schema": {
+              "$ref": "#/definitions/orderFee"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      }
+    },
     "/vendors": {
       "get": {
         "summary": "Returns all vendors from the system that the user has access to",
@@ -5879,13 +5976,6 @@
           "description": "before shipping, the customer can use this to associate a payment-method with the order.  After shipping, it contains information about the charged payment",
           "$ref": "#/definitions/payment"
         },
-        "fees": {
-          "description": "additional charges beyond the order-line items themselves (estimated until picking time)",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/orderFee"
-          }
-        },
         "drop": {
           "description": "drop the order is destined for (unset for parcel-carrier orders)",
           "type": "integer",
@@ -6076,7 +6166,7 @@
       ]
     },
     "orderFee": {
-      "description": "An additional charge associated with an order.",
+      "description": "An additional charge associated with an order (estimated until picking time).",
       "type": "object",
       "properties": {
         "id": {


### PR DESCRIPTION
This allows the backend to use more expensive fee-estimation logic (e.g. hitting parcel-carrier APIs) without bogging down order manipulations.  We initially [expected order-manipulation hitting fee recalculation to be rare][1], but it turns out to be [unacceptably slow][2], and [we don't need the fee information most of the time][3] (or it's ok if the fee update shows up asynchronously a second or two so after the change that triggered it).

[1]: https://github.com/azurestandard/website/issues/186#issuecomment-213072160
[2]: https://github.com/azurestandard/website/issues/552#issue-165217215
[3]: https://github.com/azurestandard/website/issues/552#issuecomment-232406614