### PR TITLE
public.json: Add order.notes

### DIFF
--- a/public.json
+++ b/public.json
@@ -6014,6 +6014,10 @@
         "address": {
           "description": "parcel-carrier delivery location (unset for truck orders)",
           "$ref": "#/definitions/address"
+        },
+        "notes": {
+          "description": "Additional information about the order, including special instructions for Azure's pickers",
+          "type": "string"
         }
       },
       "required": [
@@ -6058,6 +6062,10 @@
         "address": {
           "description": "parcel-carrier delivery location (unset for truck orders)",
           "$ref": "#/definitions/address"
+        },
+        "notes": {
+          "description": "Additional information about the order, including special instructions for Azure's pickers",
+          "type": "string"
         }
       },
       "required": [


### PR DESCRIPTION
On Wed, Jul 06, 2016 at 02:33:14PM -0700, Joe Isitt [wrote][1]:
> New system doesn't allow customers to add order notes like they did
> in the old site.  I presume it was planned this way, however a CSR
> pointed out today that these fields are used for error repairs and
> other things.

The backend will implement this by exposing
OrderShipment.special_instructions.

[1]: https://github.com/azurestandard/website/issues/507