### PR TITLE
public.json: JSON fixups for payment-method DELETE

### DIFF
--- a/public.json
+++ b/public.json
@@ -3588,7 +3588,6 @@
           }
         }
       },
-    "/payment-method/{id}": {
       "delete": {
         "summary": "Deactivates a payment method based on a single ID",
         "operationId": "deactivatePaymentMethodById",
@@ -3608,7 +3607,6 @@
         "responses": {
           "204": {
             "description": "deactivate successful"
-            }
           },
           "default": {
             "description": "unexpected error",


### PR DESCRIPTION
There was already a `/payment-method/{id}` key for GET (Circle also had some indent complaints in #136).

This method deactivates the method (instead of deleting it), because we keep old method information around for displaying old invoices.

We will also allow customers to associate inactive (but unexpired) credit cards with orders to support the “‘Save card for future purchases’ false” workflow.