### PR TITLE
public.json: Make order.notes description more specific

### DIFF
--- a/public.json
+++ b/public.json
@@ -6048,7 +6048,7 @@
           "$ref": "#/definitions/address"
         },
         "notes": {
-          "description": "Additional information about the order, including special instructions for Azure's pickers",
+          "description": "Warehouse packing instructions",
           "type": "string"
         }
       },


### PR DESCRIPTION
On Wed, Jul 27, 2016 at 09:02:00AM -0700, Tom Peters [wrote][1]:
> Note that the label on this field should now be `Warehouse Packing
> Instructions` according to this email from Debbie.
>
> > I know the software team is working on adding special
> > instructions.  As we make this addition to the site, please know
> > that people sometimes use those to communicate with Azure
> > management or customer service. This requires the warehouse to
> > send us the message.
> >
> > Could you change the TEXT for that box to "Warehouse Packing
> > Instructions", which is really all we want that box utilized for -
> > to communicate with the warehouse during picking and packaging.

This commit updates the description to match, since we didn't have such a specific workflow description in f648ee30 (public.json: Add order.notes, 2016-07-14, #134).

[1]: https://github.com/azurestandard/website/issues/507#issuecomment-235633318