### PR TITLE
public.json: Add dropMembership.active

### DIFF
--- a/public.json
+++ b/public.json
@@ -308,6 +308,13 @@
         ],
         "parameters": [
           {
+            "name": "active",
+            "in": "query",
+            "description": "only return (in)active memberships",
+            "required": false,
+            "type": "boolean"
+          },
+          {
             "name": "drop",
             "in": "query",
             "description": "drop IDs to filter by",
@@ -5089,6 +5096,10 @@
           "type": "integer",
           "format": "int64"
         },
+        "active": {
+          "description": "whether or not this membership is active.  Pending memberships are active, and the usual flow for semi-open drops is (active true, pending true) -> (active true, pending false) -> (active false, pending false).",
+          "type": "boolean"
+        },
         "pending": {
           "description": "whether the membership is pending (true) or accepted (false).",
           "type": "boolean"
@@ -5106,6 +5117,7 @@
         "id",
         "customer",
         "drop",
+        "active",
         "pending",
         "created",
         "notifications"
@@ -5125,6 +5137,10 @@
           "type": "integer",
           "format": "int64"
         },
+        "active": {
+          "description": "whether or not this membership is active.",
+          "type": "boolean"
+        },
         "pending": {
           "description": "whether the membership is pending (true) or accepted (false).",
           "type": "boolean"
@@ -5135,7 +5151,8 @@
       },
       "required": [
         "customer",
-        "drop"
+        "drop",
+        "active"
       ]
     },
     "newDropMembership": {

--- a/public.json
+++ b/public.json
@@ -5135,8 +5135,7 @@
       },
       "required": [
         "customer",
-        "drop",
-        "pending"
+        "drop"
       ]
     },
     "newDropMembership": {


### PR DESCRIPTION
Like 1accb50 (public.json: Add .active to payment methods, 2016-04-27,
#106), this gives a way to remember previous memberships.  Inactive
members can no longer place orders on drop, but drop coordinators
still have some access to inactive member information (e.g. their
name) so they can render old orders (azurestandard/website#726).  Also
related to azurestandard/website#365.

Require `updateDropMembership.active` to make the PUT endpoint more
explicit and less PATCH-like.  But don't require
`updateDropMembership.pending` to match the implementation landed in
azurestandard/beehive#1846.

More details in the commit messages.