### PR TITLE
public.json: Add orderLine.warnings

### DIFF
--- a/public.json
+++ b/public.json
@@ -6197,6 +6197,14 @@
           "description": "the total price for this line in dollars (estimated until picking time).  The per-unit price used to calculate this total is currently locked in when you place the order.",
           "type": "number",
           "format": "float"
+        },
+        "warnings": {
+          "description": "An array of warnings about this product.",
+          "type": "array",
+          "items": {
+            "description": "Warnings about products that a customer can associate with this order, but maybe should not (e.g. that is is likely to expire before reaching the customer)",
+            "type": "string"
+          }
         }
       },
       "required": [


### PR DESCRIPTION
So we can return should-not-buy warnings like:

> {product.code} is likely to expire before it gets to {drop.name}
> ({drop.id}) via {route.code}.

This will help with cart rendering and quick-add.  More discussion
[here][1] and [here][2].

[1]: https://github.com/azurestandard/website/issues/754#issuecomment-238982722
[2]: https://github.com/azurestandard/website/issues/718#issuecomment-237717173