### PR TITLE
public.json: Split out email addresses into their own endpoints

### DIFF
--- a/public.json
+++ b/public.json
@@ -3687,6 +3687,38 @@
             }
           }
         }
+      },
+      "post": {
+        "summary": "Create a new address",
+        "operationId": "addAddress",
+        "tags": [
+          "address"
+        ],
+        "parameters": [
+          {
+            "name": "address",
+            "in": "body",
+            "description": "address to add",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/address"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "address response",
+            "schema": {
+              "$ref": "#/definitions/address"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
       }
     },
     "/address/{id}": {
@@ -3712,6 +3744,74 @@
             "schema": {
               "$ref": "#/definitions/address"
             }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Update an existing address",
+        "operationId": "updateAddress",
+        "tags": [
+          "address"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of address to update",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "address",
+            "in": "body",
+            "description": "Address to update",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/address"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "address response",
+            "schema": {
+              "$ref": "#/definitions/address"
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete an existing address",
+        "operationId": "deleteAddress",
+        "tags": [
+          "address"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of address to delete",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "delete successful"
           },
           "default": {
             "description": "unexpected error",

--- a/public.json
+++ b/public.json
@@ -3935,6 +3935,236 @@
         }
       }
     },
+    "/emails": {
+      "get": {
+        "summary": "Returns all emails from the system that the user has access to.",
+        "description": "Emails associated with a person are ordered by decreasing preference.  The ordering between emails associated with different people or (for the same person) with the same preference value is undefined.",
+        "operationId": "findEmails",
+        "tags": [
+          "email"
+        ],
+        "parameters": [
+          {
+            "name": "filter-person",
+            "in": "query",
+            "description": "Person IDs to filter by.",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "collectionFormat": "csv"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of results to return.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "start",
+            "in": "query",
+            "description": "Offset to the first result to return.  Use negative numbers to offset from the end of the result list.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Email response.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/email"
+              }
+            },
+            "headers": {
+              "Count": {
+                "description": "Total number of matching results (how many you'd get if you could set an infinite `limit`).",
+                "type": "integer",
+                "format": "int32",
+                "minimum": 0
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error.",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a new email.",
+        "operationId": "addEmail",
+        "tags": [
+          "email"
+        ],
+        "parameters": [
+          {
+            "name": "email",
+            "in": "body",
+            "description": "Email to add.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/updateEmailUserPassword"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Email response.  An email with a confirmation URL will be mailed to the address, and new emails will be unconfirmed until the token is submitted via emailConfirmation.",
+            "schema": {
+              "$ref": "#/definitions/email"
+            }
+          },
+          "default": {
+            "description": "Unexpected error.",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      }
+    },
+    "/email/{id}": {
+      "get": {
+        "summary": "Returns a email based on a single ID.",
+        "operationId": "findEmailById",
+        "tags": [
+          "email"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of email to fetch.",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Email response.",
+            "schema": {
+              "$ref": "#/definitions/email"
+            }
+          },
+          "default": {
+            "description": "Unexpected error.",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Update an existing email.",
+        "operationId": "updateEmail",
+        "tags": [
+          "email"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of email to update.",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "email",
+            "in": "body",
+            "description": "Email to update.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/updateEmailUserPassword"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Email response.  An email with a confirmation URL will be mailed to the address, and updated emails will be unconfirmed until the token is submitted via emailConfirmation.",
+            "schema": {
+              "$ref": "#/definitions/email"
+            }
+          },
+          "default": {
+            "description": "Unexpected error.",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete an existing email.",
+        "operationId": "deleteEmail",
+        "tags": [
+          "email"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of email to delete.",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Delete successful."
+          },
+          "default": {
+            "description": "Unexpected error.",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      }
+    },
+    "/email/{id}/confirm": {
+      "post": {
+        "summary": "Complete an in-progress email confirmation.",
+        "operationId": "emailConfirmation",
+        "tags": [
+          "email"
+        ],
+        "parameters": [
+          {
+            "name": "token",
+            "in": "body",
+            "description": "The confirmation token from addEmail or updateEmail.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Email response.",
+            "schema": {
+              "$ref": "#/definitions/email"
+            }
+          },
+          "default": {
+            "description": "Unexpected error.",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      }
+    },
     "/people": {
       "get": {
         "summary": "Returns all people from the system that the user has access to",
@@ -6681,7 +6911,7 @@
           "format": "url"
         },
         "person": {
-          "description": "The registrant's personal information.  Name, email, and password are required.",
+          "description": "The registrant's personal information.  Name and password are required.",
           "type": "object",
           "schema": {
             "$ref": "#/definitions/updatePerson"
@@ -6693,6 +6923,11 @@
           "schema": {
             "$ref": "#/definitions/address"
           }
+        },
+        "email": {
+          "description": "The registrant's primary email address.  Will have a preference level of 100.",
+          "type": "string",
+          "format": "email"
         },
         "telephone": {
           "description": "The registrant's telephone numbers (currently only supports 'voice' and 'text' types)",
@@ -6709,7 +6944,8 @@
       },
       "required": [
         "base-url",
-        "person"
+        "person",
+        "email"
       ]
     },
     "resendRegistrationEmail": {
@@ -6821,10 +7057,6 @@
         "name": {
           "type": "string"
         },
-        "email": {
-          "type": "string",
-          "format": "email"
-        },
         "can-email": {
           "description": "Can Azure contact this person for reasons other than registration",
           "type": "boolean"
@@ -6875,10 +7107,6 @@
           "description": "Password for authentication",
           "type": "string"
         },
-        "email": {
-          "type": "string",
-          "format": "email"
-        },
         "can-email": {
           "description": "Can Azure contact this person for reasons other than registration?  Defaults to true when creating a person",
           "type": "boolean"
@@ -6914,10 +7142,6 @@
           "description": "Password for authentication",
           "type": "string"
         },
-        "email": {
-          "type": "string",
-          "format": "email"
-        },
         "can-email": {
           "description": "Can Azure contact this person for reasons other than registration",
           "type": "boolean"
@@ -6938,7 +7162,7 @@
           "type": "boolean"
         },
         "user-password": {
-          "description": "The authenticated person's password, required when changing password or email",
+          "description": "The authenticated person's password, required when changing password",
           "type": "string"
         },
         "notifications": {
@@ -7099,6 +7323,67 @@
       "required": [
         "latitude",
         "longitude"
+      ]
+    },
+    "email": {
+      "description": "An email address.",
+      "type": "object",
+      "properties": {
+        "address": {
+          "type": "string",
+          "format": "email"
+        },
+        "person": {
+          "description": "Person associated with this email.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "error": {
+          "description": "Reason for not using this address (e.g. \"unconfirmed\", \"email bounced on 2016-08-15\").",
+          "type": "string"
+        },
+        "preference": {
+          "description": "Ordering precedence for the findEmails.",
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "required": [
+        "address"
+      ]
+    },
+    "updateEmailUserPassword": {
+      "description": "A request for adding or updating an email address with the logged in user's password",
+      "type": "object",
+      "properties": {
+        "base-url": {
+          "description": "Redirect URL for the confirmation UI.  The confirmation email points customers at {base-url}{confirmation-token} to confirm their registration.",
+          "type": "string",
+          "format": "url"
+        },
+        "address": {
+          "type": "string",
+          "format": "email"
+        },
+        "person": {
+          "description": "Person associated with this email.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "preference": {
+          "description": "Ordering precedence for the findEmails.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "user-password": {
+          "description": "The authenticated person's password.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "base-url",
+        "address",
+        "user-password"
       ]
     },
     "favorite": {


### PR DESCRIPTION
This gives us a convenient place to store errors (e.g. per-address bounce
reports) and lets us access multiple addresses per person
(although the backend currently caps that at three emails per person).
Multiple emails per person allows you to include others (e.g. family
members) in cutoff-notifcations and the like, although only the primary
address (with the highest preference) is used for password-reset, login,
and the like.

Also fill in the address API to catch up with the current
implementation, because I'm using the address API to template the new
email API.

Related issues: azurestandard/beehive#510, azurestandard/beehive#1806, azurestandard/website#624.