### PR TITLE
public.json: Add /emails/resend and adjust email requirements

### DIFF
--- a/public.json
+++ b/public.json
@@ -4020,8 +4020,71 @@
           "200": {
             "description": "Email response.  An email with a confirmation URL will be mailed to the address, and new emails will be unconfirmed until the token is submitted via emailConfirmation.",
             "schema": {
+              "$ref": "#/definitions/updatedEmail"
+            }
+          },
+          "default": {
+            "description": "Unexpected error.",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      }
+    },
+    "/emails/confirm": {
+      "post": {
+        "summary": "Complete an in-progress email confirmation.",
+        "operationId": "emailConfirmation",
+        "tags": [
+          "email"
+        ],
+        "parameters": [
+          {
+            "name": "token",
+            "in": "body",
+            "description": "The confirmation token from addEmail or updateEmail.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Email response.",
+            "schema": {
               "$ref": "#/definitions/email"
             }
+          },
+          "default": {
+            "description": "Unexpected error.",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      }
+    },
+    "/emails/resend": {
+      "post": {
+        "summary": "Resend the confirmation email to the user.",
+        "operationId": "resendEmailConfirmation",
+        "tags": [
+          "email"
+        ],
+        "parameters": [
+          {
+            "name": "resend",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/resendRegistrationEmail"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Confirmation email resent",
+            "schema": {}
           },
           "default": {
             "description": "Unexpected error.",
@@ -4091,9 +4154,9 @@
         ],
         "responses": {
           "200": {
-            "description": "Email response.  An email with a confirmation URL will be mailed to the address, and updated emails will be unconfirmed until the token is submitted via emailConfirmation.",
+            "description": "Email response.  If the address changed or the email had an earlier error, an email with a confirmation URL will be mailed to the address.  Changed addresses will be unconfirmed until the token is submitted via emailConfirmation.",
             "schema": {
-              "$ref": "#/definitions/email"
+              "$ref": "#/definitions/updatedEmail"
             }
           },
           "default": {
@@ -4123,38 +4186,6 @@
         "responses": {
           "204": {
             "description": "Delete successful."
-          },
-          "default": {
-            "description": "Unexpected error.",
-            "schema": {
-              "$ref": "#/definitions/errorModel"
-            }
-          }
-        }
-      }
-    },
-    "/email/{id}/confirm": {
-      "post": {
-        "summary": "Complete an in-progress email confirmation.",
-        "operationId": "emailConfirmation",
-        "tags": [
-          "email"
-        ],
-        "parameters": [
-          {
-            "name": "token",
-            "in": "body",
-            "description": "The confirmation token from addEmail or updateEmail.",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Email response.",
-            "schema": {
-              "$ref": "#/definitions/email"
-            }
           },
           "default": {
             "description": "Unexpected error.",
@@ -7329,6 +7360,10 @@
       "description": "An email address.",
       "type": "object",
       "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
         "address": {
           "type": "string",
           "format": "email"
@@ -7349,7 +7384,9 @@
         }
       },
       "required": [
-        "address"
+        "id",
+        "address",
+        "person"
       ]
     },
     "updateEmailUserPassword": {
@@ -7383,7 +7420,25 @@
       "required": [
         "base-url",
         "address",
+        "person",
         "user-password"
+      ]
+    },
+    "updatedEmail": {
+      "description": "An updated (but unconfirmed) email response.",
+      "type": "object",
+      "properties": {
+        "token": {
+          "description": "Resend token for resendEmailConfirmation (not the same as the confirmation token emailed to the user, which is for emailConfirmation).  Unset if a confirmation email was not set (more details on this in updateEmail).",
+          "type": "string",
+          "format": "url"
+        },
+        "email": {
+          "$ref": "#/definitions/email"
+        }
+      },
+      "required": [
+        "email"
       ]
     },
     "favorite": {


### PR DESCRIPTION
Return resend tokens from POST and PUT, and add an `/emails/resend` endpoint to receive those tokens.  This allows the following workflow:

1. User submits new / updated email.

2. Frontend shows user:

   > You've submitted your update and will receive a confirmation
   >  email shortly.  You can click here to resend the email.

   POSTing the resend token to `/emails/resend` if the user clicks.

3. User gets the confirmation email and visits the confirmation URL.

4. Frontend gets the confirmation token from the URL, and submits
   token to `/emails/confirm`.  On success, frontend shows the user:

   > Email update confirmed.

   and whatever else it wants to say.

The frontend can skip step 2 and show the user something else if they don't want to support resends.

The confirmation email is not sent and the resend token is not set if a PUT does not update the address and the email has no earlier error.  In those cases, the resulting email will *still* have no error, so there's nothing to confirm.  In the updated-address case, the updated email will have an 'unconfirmed' error, and in the earlier-error case, the updated email will still have that earlier error; the confirmation email gives you a way to clear both.

Also:

* Add `email.id` (to support `/email/{id}`).
* Require `email.person` and `updateEmailUserPassword.person` (to avoid orphaned addresses).
* Move `/email/{id}/confirm` to `/emails/confirm`.  The backend will have to lookup the ID using the token.  The `{id}` version works well enough for PUT, but doesn't work for POST, because the caller has to   setup base-url before they know the email ID.  The workflow would have been:

    1. User POSTs a new email.
    2. User gets a confirmation email wit a confirmation URL.
    3. User follows confirmation URL.
    4. Code behind confirmation URL extracts the token from the URL, determines the email ID somehow, and POSTs the token to `/email/{id}/confirm`.

  but "code behind confirmation URL determines the email ID somehow" is unclear, while "API backend determines the email ID from the token" is possible (because the backend controls the token generation, could use a backing database, etc.).

A fixup for #147.