### PR TITLE
public.json: Add GET ...?inline=email to /people and /person/{id}

### DIFF
--- a/public.json
+++ b/public.json
@@ -4217,6 +4217,17 @@
             "collectionFormat": "csv"
           },
           {
+            "name": "inline",
+            "in": "query",
+            "description": "for convenience, include additional information.  Currently supports \"email\" as described in the email model.",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "csv"
+          },
+          {
             "name": "limit",
             "in": "query",
             "description": "maximum number of results to return",
@@ -4275,6 +4286,17 @@
             "required": true,
             "type": "integer",
             "format": "int64"
+          },
+          {
+            "name": "inline",
+            "in": "query",
+            "description": "for convenience, include additional information.  Currently supports \"email\" as described in the email model.",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "csv"
           }
         ],
         "responses": {
@@ -7091,6 +7113,11 @@
         },
         "name": {
           "type": "string"
+        },
+        "email": {
+          "description": "The person's preferred, error-less email address (set if the \"inline\" query parameter contains \"email\").",
+          "type": "string",
+          "format": "email"
         },
         "can-email": {
           "description": "Can Azure contact this person for reasons other than registration",


### PR DESCRIPTION
We're not sure what the business logic is for multiple errorless emails.  Our backend (Beehive) has (for a while now) sent all customer email to all addresses that looked remotely valid.  With azurestandard/beehive#2105, Beehive keeps track of per-address errors and sends mail to all addresses that don't have errors.  The frontend, however, has traditionally only shown drop coordinators a single email address per customer.  It's not clear to Casey, David McAtee, or me whether the different frontend handling is intentional or an oversight from the transition that shifted the backend from one to three email addresses per customer.  We'll talk about this more on Monday, but for
now, this commit gives the frontend an easy way to preserve its current functionality despite the new email API.

This branch is a merge commit because I'm pulling the old person.email entries out of the Git history, and want to keep `git blame` working for them ;).