### PR TITLE
public.json: Add customer.email to /drop-memberships?inline=...

### DIFF
--- a/public.json
+++ b/public.json
@@ -348,7 +348,7 @@
           {
             "name": "inline",
             "in": "query",
-            "description": "for convenience, include a full representation of the inlined property.  Currently supports \"customer\" and \"drop\".",
+            "description": "for convenience, include a full representation of the inlined property.  Currently supports \"customer\", \"customer.email\", and \"drop\".",
             "required": false,
             "type": "array",
             "items": {

--- a/public.json
+++ b/public.json
@@ -4039,6 +4039,7 @@
         "tags": [
           "email"
         ],
+        "security": [],
         "parameters": [
           {
             "name": "token",
@@ -4071,6 +4072,7 @@
         "tags": [
           "email"
         ],
+        "security": [],
         "parameters": [
           {
             "name": "resend",


### PR DESCRIPTION
Folks will often want to see preferred contact information for drop members.  For example, the drop-membership pending-approval UI uses membership.customer.email since it landed in azurestandard/internal-website@64a77a59 (add drop-memberhip module, 2016-07-30).

Also stop requiring auth for email resend/confirm endpoints (motivation in the commit message).