### PR TITLE
public.json: Per-storage entries for order.cases-shipped

### DIFF
--- a/public.json
+++ b/public.json
@@ -6460,14 +6460,13 @@
           "description": "parcel-carrier delivery location (unset for truck orders)",
           "$ref": "#/definitions/address"
         },
+        "cases-shipped": {
+          "description": "Quantity of shipped boxes and bulk stock",
+          "$ref": "#/definitions/orderCases"
+        },
         "notes": {
           "description": "Warehouse packing instructions",
           "type": "string"
-        },
-        "cases-shipped": {
-          "description": "quantity of shipped boxes and bulk stock",
-          "type": "integer",
-          "format": "int32"
         }
       },
       "required": [
@@ -6567,6 +6566,32 @@
         "change",
         "reason"
       ]
+    },
+    "orderCases": {
+      "description": "Quantity of shipped boxes and bulk stock",
+      "type": "object",
+      "properties": {
+        "dry": {
+          "description": "Quantity of shipped boxes and bulk stock with the dry climate",
+          "type": "integer",
+          "format": "int32"
+        },
+        "chilled": {
+          "description": "Quantity of shipped boxes and bulk stock with the chilled climate",
+          "type": "integer",
+          "format": "int32"
+        },
+        "frozen": {
+          "description": "Quantity of shipped boxes and bulk stock with the frozen climate",
+          "type": "integer",
+          "format": "int32"
+        },
+        "greenhouse": {
+          "description": "Quantity of shipped boxes and bulk stock with the greenhouse climate",
+          "type": "integer",
+          "format": "int32"
+        }
+      }
     },
     "orderLine": {
       "description": "a per-product entry in an order",

--- a/public.json
+++ b/public.json
@@ -5313,16 +5313,10 @@
           "type": "boolean"
         },
         "storage": {
-          "description": "storage facilities available at this drop",
+          "description": "storage environments available at this drop",
           "type": "array",
           "items": {
-            "description": "facility name",
-            "type": "string",
-            "enum": [
-              "dry",
-              "refregerator",
-              "freezer"
-            ]
+            "$ref": "#/definitions/storage"
           }
         },
         "fees": {
@@ -5412,16 +5406,10 @@
           ]
         },
         "storage": {
-          "description": "storage facilities available at this drop",
+          "description": "storage environments available at this drop",
           "type": "array",
           "items": {
-            "description": "facility name",
-            "type": "string",
-            "enum": [
-              "dry",
-              "refregerator",
-              "freezer"
-            ]
+            "$ref": "#/definitions/storage"
           }
         },
         "fees": {
@@ -5924,6 +5912,16 @@
         "estimated-time"
       ]
     },
+    "storage": {
+      "description": "An environment for storing products",
+      "type": "string",
+      "enum": [
+        "dry",
+        "chilled",
+        "frozen",
+        "greenhouse"
+      ]
+    },
     "packagedProduct": {
       "description": "a particular packaged form of a product",
       "type": "object",
@@ -6126,15 +6124,9 @@
           "description": "country of origin for this product",
           "type": "string"
         },
-        "storage-climate": {
-          "description": "the climate at which this product must be stored",
-          "type": "string",
-          "enum": [
-            "dry",
-            "chilled",
-            "frozen",
-            "greenhouse"
-          ]
+        "storage": {
+          "description": "The environment in which this product must be stored",
+          "$ref": "#/definitions/storage"
         }
       },
       "required": [


### PR DESCRIPTION
Drop coordinators are used to seeing these counts broken down by climate, with [separate counts for greenhouse, frozen, and dry/chilled][1].

Also unifies the storage types so `drop.storage` and `product.storage` (was `product.storage-climate`) share the same enum.  Before we land this, we should check and see if drops can opt in/out of storing greenhouse products.

[1]: https://github.com/azurestandard/beehive/blob/226ec6956970fa83c220c4ee4b05d6e35cf27294/apps/shipping/templates/shipping/pdfs/cover_sheets.html#L83-L103