### PR TITLE
public.json: Add dropMembership.heavy

### DIFF
--- a/public.json
+++ b/public.json
@@ -5494,6 +5494,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "heavy": {
+          "description": "whether the member can get pallets, totes, barrels, and other heavy objects off a truck (defaults to false).",
+          "type": "boolean"
+        },
         "notifications": {
           "$ref": "#/definitions/dropMembershipNotifications"
         }
@@ -5528,6 +5532,10 @@
         },
         "pending": {
           "description": "whether the membership is pending (true) or accepted (false).",
+          "type": "boolean"
+        },
+        "heavy": {
+          "description": "whether the member can get pallets, totes, barrels, and other heavy objects off a truck (defaults to false).",
           "type": "boolean"
         },
         "notifications": {


### PR DESCRIPTION
On Fri, Sep 02, 2016 at 09:08:12AM -0700, Tom Peters wrote [1]:
> > Just so you know... We are prepping up to offer pallets, totes and
> > barrels on our website.  Especially totes and barrels will need a
> > dock or forklift or liftgate.  So when something over 110# is
> > ordered, a custom report that is run every day after cutoff will
> > show the customers that are able to receive these heavy items. If
> > not CC will need to call the customer and find out if they can.
> > This is pretty manual, but will get us started.  Eventually we
> > could warn customers when they place it in their cart, if they are
> > not approved for heavy delivery.  And or warn CC someone ordered a
> > heavy item.
> >
> > Soon I would like to add characteristics to our routes, like max
> > trailer weight and max pallets and if it has a liftgate.  If the
> > route had a lift gate, we wouldn't need to be concerned about if
> > the customer can handle heavy items.
> > Thanks,
> >
> > Benjamin Brewer | Innovation Team Lead

API change for azurestandard/beehive#2160.

[1]: https://github.com/azurestandard/beehive/issues/2160