### PR TITLE
Registration confirmation also performs login.

### DIFF
--- a/public.json
+++ b/public.json
@@ -4528,7 +4528,7 @@
             "required": true,
             "type": "object",
             "schema": {
-              "$ref": "#/definitions/registration"
+              "$ref": "#/definitions/registrationRequest"
             }
           }
         ],
@@ -4565,9 +4565,9 @@
         ],
         "responses": {
           "200": {
-            "description": "session response",
+            "description": "registration confirmation response",
             "schema": {
-              "$ref": "#/definitions/session"
+              "$ref": "#/definitions/registrationConfirmResponse"
             }
           },
           "default": {
@@ -6971,7 +6971,7 @@
         "payment-method"
       ]
     },
-    "registration": {
+    "registrationRequest": {
       "description": "A request for registering a new person",
       "type": "object",
       "properties": {
@@ -7017,6 +7017,18 @@
         "person",
         "email"
       ]
+    },
+    "registrationConfirmResponse": {
+      "description": "The response to a successful registration confirmation, including the person who registered and the session information",
+      "type": "object",
+      "properties": {
+        "person": {
+          "$ref": "#/definitions/person"
+        },
+        "session": {
+          "$ref": "#/definitions/session"
+        }
+      }
     },
     "resendRegistrationEmail": {
       "description": "A request for another registration email",

--- a/public.json
+++ b/public.json
@@ -7027,7 +7027,11 @@
         },
         "session": {
           "$ref": "#/definitions/session"
-        }
+        },
+        "required": [
+          "person",
+          "session"
+        ]
       }
     },
     "resendRegistrationEmail": {

--- a/public.json
+++ b/public.json
@@ -4548,7 +4548,8 @@
     },
     "/registration/confirm": {
       "post": {
-        "summary": "Complete an in-progress registration",
+        "summary": "Complete an in-progress registration, authenticate, and receive a session cookie",
+        "description": "The user account corresponding to the given registration token will be activated. Any errors associated with the user's primary email will be cleared. This will also authenticate the user and return a session cookie and session response in the same manner as the login endpoint.",
         "operationId": "confirmRegistration",
         "tags": [
           "registration"
@@ -4564,9 +4565,9 @@
         ],
         "responses": {
           "200": {
-            "description": "person response",
+            "description": "session response",
             "schema": {
-              "$ref": "#/definitions/person"
+              "$ref": "#/definitions/session"
             }
           },
           "default": {

--- a/public.json
+++ b/public.json
@@ -4549,7 +4549,7 @@
     "/registration/confirm": {
       "post": {
         "summary": "Complete an in-progress registration, authenticate, and receive a session cookie",
-        "description": "The user account corresponding to the given registration token will be activated. Any errors associated with the user's primary email will be cleared. This will also authenticate the user and return a session cookie and session response in the same manner as the login endpoint.",
+        "description": "The user account corresponding to the given registration token will be activated. Any errors associated with the user's primary email will be cleared. This will also authenticate the user and return a response containing the person activated and the session information, along with a new session cookie.",
         "operationId": "confirmRegistration",
         "tags": [
           "registration"


### PR DESCRIPTION
This change would allow clients to treat a successful /registration/confirm response as a successful login of the user that was activated. Login would only occur if activation was successful, so it would only work once per token as activation does.

This would allow for a more streamlined registration flow, as the front end will be able to immediately engage the user with links to add a drop, fill out profile information, etc., without them having to sign in first.

If possible, I would like to get this in as a precursor to azurestandard/website#653.