### PR TITLE
Add packs and unit to packagedProduct definition

### DIFF
--- a/public.json
+++ b/public.json
@@ -7338,6 +7338,14 @@
           "description": "Size of the product (e.g. 12 oz., or 6x12 oz.).",
           "type": "string"
         },
+        "packs": {
+          "description": "Package organization (e.g. \"4\", \"4x32.5\", or \"2x4x32.5\")",
+          "type": "string"
+        },
+        "unit": {
+          "description": "Unit of measurement (\"ounce\", \"liter\", etc.)",
+          "type": "string"
+        },
         "weight": {
           "$ref": "#/definitions/weight"
         },


### PR DESCRIPTION
Reopening #155, since GitHub closed that one after an accidental merge (which we've since rolled back).
