### PR TITLE
public.json: Add vendor.indie

### DIFF
--- a/public.json
+++ b/public.json
@@ -6734,6 +6734,10 @@
           "type": "string",
           "format": "url"
         },
+        "indie": {
+          "description": "whether or not this vendor is a privately held company",
+          "type": "boolean"
+        },
         "account": {
           "description": "vendor's identifier for Azure",
           "type": "string"


### PR DESCRIPTION
From [here][1]:

> Azure is a proudly independent company that supports other small,
> independent businesses. The Azure Indie Partner Program is designed
> to support companies that share our passion for a free and
> independent supply chain.
>
> These are forward-thinking, independently owned, health-conscious
> companies that deserve your business. They’re not just concerned
> with short-term profits. They’re passionate about making a
> difference in the world over the long run.

API change for azurestandard/beehive#2233.

[1]: https://www.azurestandard.com/healthy-living/indie-partner-program/