### PR TITLE
public.json: Add stop.timezone

### DIFF
--- a/public.json
+++ b/public.json
@@ -5857,6 +5857,10 @@
           "type": "integer",
           "format": "int64"
         },
+        "timezone": {
+          "description": "IANA time zone location (https://www.iana.org/time-zones, e.g. America/Los_Angeles)",
+          "type": "string",
+        },
         "target-time": {
           "description": "planned stop time (fixed before the trip starts)",
           "type": "string",


### PR DESCRIPTION
As a read-only property, although we still haven't split this into
stop and updateStop.  This lets us figure out what the offset will be
if the frontend bumps a stop time forward by a day (or whatever) since
you might trip in or out of daylight savings time.