### PR TITLE
public.json: Move /emails/resend to /email/{id}/resend

### DIFF
--- a/public.json
+++ b/public.json
@@ -4647,38 +4647,6 @@
         }
       }
     },
-    "/emails/resend": {
-      "post": {
-        "summary": "Resend the confirmation email to the user.",
-        "operationId": "resendEmailConfirmation",
-        "tags": [
-          "email"
-        ],
-        "security": [],
-        "parameters": [
-          {
-            "name": "resend",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/resendRegistrationEmail"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Confirmation email resent",
-            "schema": {}
-          },
-          "default": {
-            "description": "Unexpected error.",
-            "schema": {
-              "$ref": "#/definitions/errorModel"
-            }
-          }
-        }
-      }
-    },
     "/email/{id}": {
       "get": {
         "summary": "Returns a email based on a single ID.",
@@ -4770,6 +4738,45 @@
         "responses": {
           "204": {
             "description": "Delete successful."
+          },
+          "default": {
+            "description": "Unexpected error.",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      }
+    },
+    "/email/{id}/resend": {
+      "post": {
+        "summary": "Resend the confirmation email to the user.",
+        "operationId": "resendEmailConfirmation",
+        "tags": [
+          "email"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of email whose confirmation will be re-sent.",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "resend",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/resendRegistrationEmail"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Confirmation email re-sent",
+            "schema": {}
           },
           "default": {
             "description": "Unexpected error.",
@@ -5180,7 +5187,7 @@
         ],
         "responses": {
           "204": {
-            "description": "Confirmation email resent",
+            "description": "Confirmation email re-sent",
             "schema": {}
           },
           "default": {
@@ -7894,13 +7901,12 @@
           "format": "url"
         },
         "token": {
-          "description": "The registrant's resend token",
+          "description": "The registrant's resend token.  If token is unset, the request must be authenticated with basic auth or a session cookie.",
           "type": "string"
         }
       },
       "required": [
-        "base-url",
-        "token"
+        "base-url"
       ]
     },
     "passwordResetRequest": {


### PR DESCRIPTION
Also remove the empty-security override, make resend tokens optional, and typo-fix "resent" -> "re-sent".

The old ID-less version matched /emails/confirm.  Confirmation shouldn't rely on the email ID for the reasons described in #149.  However, the frontend triggering resends should be able to use both tokens and the usual basic/cookie credentials to trigger a resend.  By shifting /emails/resend to /email/{id}/resent, we give frontend a way to pass the ID without passing the token (which encodes the ID, among other things).  Passing the token still works; folks who pass the token will now need to track both the token and the email ID, but both are part of the updatedEmail payload so that shouldn't be a problem.

Fixes #168.