### PR TITLE
public.json: Add /categories?active=(true|false)

### DIFF
--- a/public.json
+++ b/public.json
@@ -2835,6 +2835,13 @@
             "collectionFormat": "csv"
           },
           {
+            "name": "active",
+            "in": "query",
+            "description": "only return (in)active categories",
+            "required": false,
+            "type": "boolean"
+          },
+          {
             "name": "product",
             "in": "query",
             "description": "product IDs to filter by",


### PR DESCRIPTION
Since folks listing child categories should have an easy way to filter out the inactive ones.

Spun off from azurestandard/internal-website#166.