### PR TITLE
public.json: Use country in address and address in ip2location

### DIFF
--- a/public.json
+++ b/public.json
@@ -4235,6 +4235,17 @@
             "collectionFormat": "csv"
           },
           {
+            "name": "inline",
+            "in": "query",
+            "description": "for convenience, include a full representation of the inlined property.  Currently supports \"country\".",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "csv"
+          },
+          {
             "name": "limit",
             "in": "query",
             "description": "maximum number of results to return",
@@ -5950,6 +5961,17 @@
             "description": "ipv4 address to lookup",
             "required": true,
             "type": "string"
+          },
+          {
+            "name": "inline",
+            "in": "query",
+            "description": "for convenience, include a full representation of the inlined property.  Currently supports \"address.country\".",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "csv"
           }
         ],
         "responses": {
@@ -8243,7 +8265,8 @@
         "postal-code": {
           "type": "string"
         },
-        "country-name": {
+        "country": {
+          "description": "ISO 3166-1 alpha-3 code for the country.  On push, you can set the alpha-2 code or case-insensitve name instead, or you can use an inline country object.",
           "type": "string"
         },
         "preference": {
@@ -8254,7 +8277,7 @@
       },
       "required": [
         "locality",
-        "country-name"
+        "country"
       ]
     },
     "country": {
@@ -8273,7 +8296,12 @@
           "description": "The country's ISO 3166-1 alpha-3 code",
           "type": "string"
         }
-      }
+      },
+      "required": [
+        "name",
+        "iso",
+        "iso3"
+      ]
     },
     "region": {
       "description": "a country region (US state or Canadian province)",
@@ -8740,32 +8768,15 @@
       "description": "location information for an ip address",
       "type": "object",
       "properties": {
-        "country-short": {
-          "type": "string"
-        },
-        "country-long": {
-          "type": "string"
-        },
-        "region": {
-          "type": "string"
-        },
-        "city": {
-          "type": "string"
-        },
-        "zipcode": {
-          "type": "string"
+        "address": {
+          "$ref": "#/definitions/address"
         },
         "geo": {
           "$ref": "#/definitions/geo"
         }
       },
       "required": [
-        "country_short",
-        "country_long",
-        "region",
-        "city",
-        "zipcode",
-        "ip",
+        "address",
         "geo"
       ]
     },


### PR DESCRIPTION
Reduce the number of places where we define similar-but-not-identical models for the same thing.  Use `?inline=…` to allow callers to push joins to the backend, avoiding multiple API calls for client-side joins.

CC @MercenaryJosh, @tompetersjr, since this touches the API which just landed in #175.

CC @davidmcatee-azure, since I'm not sure how much trouble updating the current frontend's address consumers to follow the address.country-name → address.country change will be.