### PR TITLE
public.json: Change registration base-url to authentication-base-url

### DIFF
--- a/public.json
+++ b/public.json
@@ -7891,11 +7891,6 @@
       "description": "A request for registering a new person",
       "type": "object",
       "properties": {
-        "base-url": {
-          "description": "Redirect URL for the confirmation UI.  The confirmation email points customers at {base-url}{confirmation-token} to confirm their registration.",
-          "type": "string",
-          "format": "url"
-        },
         "person": {
           "description": "The registrant's personal information.  'name' is required.",
           "type": "object",
@@ -7930,12 +7925,35 @@
           "description": "The registrant's chosen drop",
           "type": "integer",
           "format": "int64"
+        },
+        "context": {
+          "description": "The context in which the registration request is being made (to select between available notification templates).  Defaults to \"registration\".",
+          "format": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "registration",
+              "checkout",
+              "catalog-request"
+            ]
+          }
+        },
+        "authentication-base-url": {
+          "description": "Redirect URL for the authentication UI.  The authentication notification points customers at {authentication-base-url}{authentication-token} to authenticate a new session.",
+          "type": "string",
+          "format": "url"
+        },
+        "confirmation-base-url": {
+          "description": "Redirect URL for the channel-confirmation UI.  The channel-confirmation notification points customers at {confirmation-base-url}{confirmation-token} to confirm the notification channel.",
+          "type": "string",
+          "format": "url"
         }
       },
       "required": [
-        "base-url",
         "person",
-        "email"
+        "email",
+        "authentication-base-url",
+        "confirmation-base-url"
       ]
     },
     "registrationResponse": {


### PR DESCRIPTION
And `confirmation-base-url`, since we now have two different tokens that we might be mailing the registrant.

I've gone with “channel” instead of “email” in the description, because we might to authenticate additional channels besides email (e.g. SMS) in the future.