### PR TITLE
Allow sorting drops by distance.

### DIFF
--- a/public.json
+++ b/public.json
@@ -678,6 +678,11 @@
             "collectionFormat": "csv"
           },
           {
+            "name": "sort",
+            "in": "query",
+            "description": "Order results by this field.  Only one special sort field is supported, \"distance(lat:45.45|lon:-121.13)\", which will sort drops by increasing distance from the lat and lon combination."
+          },
+          {
             "name": "limit",
             "in": "query",
             "description": "maximum number of results to return",


### PR DESCRIPTION
The general `sort` query parameter means additionally sort fields can be
added in the future.  Since the distance needs to be calculated from a
lat + lon input, a special format is used here.

Fixes #179.