### PR TITLE
person: Add .internal-notes

### DIFF
--- a/public.json
+++ b/public.json
@@ -7970,8 +7970,7 @@
         },
         "token": {
           "description": "Resend token.  Can be sent to resendRegistrationEmail to trigger a new registration notification.",
-          "type": "string",
-          "format": "url"
+          "type": "string"
         },
         "required": [
           "session",
@@ -8461,8 +8460,7 @@
       "properties": {
         "token": {
           "description": "Resend token for resendEmailConfirmation (not the same as the confirmation token emailed to the user, which is for emailConfirmation).  Unset if a confirmation email was not set (more details on this in updateEmail).",
-          "type": "string",
-          "format": "url"
+          "type": "string"
         },
         "email": {
           "$ref": "#/definitions/email"

--- a/public.json
+++ b/public.json
@@ -7968,13 +7968,17 @@
         "session": {
           "$ref": "#/definitions/session"
         },
-        "token": {
+        "auth-token": {
+          "description": "Auth token.  Can be sent to login to authenticate a new session.",
+          "type": "string"
+        },
+        "resend-token": {
           "description": "Resend token.  Can be sent to resendRegistrationEmail to trigger a new registration notification.",
           "type": "string"
         },
         "required": [
           "session",
-          "token"
+          "resend-token"
         ]
       }
     },

--- a/public.json
+++ b/public.json
@@ -8154,6 +8154,10 @@
           "items": {
             "$ref": "#/definitions/permission"
           }
+        },
+        "internal-notes": {
+          "description": "free-form Markdown notes for any internal information that doesn't fit into an existing field.  Only Azure employees can view or edit this information, although it may be passed into the registerPerson endpoint when registering new people.",
+          "type": "string"
         }
       },
       "required": [


### PR DESCRIPTION
Our backend has several ways to store notes associated with a given user:

1. In an append-only array of internal notes with no UI for editing existing notes (via the Django comments app).
2. In an internal, editable text field usually used for billing notes.
3. In an editable text field for default shipping instructions, which the customer and internal users can see.

This commit exposes (2).  Our immediate use-case is for recording promotion codes and similar at registration time so we can create credits for signing bonuses and the like.

Also two API fixups to match our current implementation, since some changes were made without a leading API-spec PR.