### PR TITLE
public.json: Split resendConfirmationEmail from resendRegistrationEmail

### DIFF
--- a/public.json
+++ b/public.json
@@ -8008,16 +8008,7 @@
           "format": "int64"
         },
         "context": {
-          "description": "The context in which the registration request is being made (to select between available notification templates).  Defaults to \"registration\".",
-          "format": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "registration",
-              "checkout",
-              "catalog-request"
-            ]
-          }
+          "$ref": "#/definitions/registrationContext"
         },
         "authentication-base-url": {
           "description": "Redirect URL for the authentication UI.  The authentication notification points customers at {authentication-base-url}{authentication-token} to authenticate a new session.",
@@ -8035,6 +8026,15 @@
         "email",
         "authentication-base-url",
         "confirmation-base-url"
+      ]
+    },
+    "registrationContext": {
+      "description": "The context in which the registration request is being made (to select between available notification templates).  Defaults to \"registration\".",
+      "type": "string",
+      "enum": [
+        "registration",
+        "checkout",
+        "catalog-request"
       ]
     },
     "registrationResponse": {
@@ -8062,6 +8062,9 @@
       "description": "A request for another registration email",
       "type": "object",
       "properties": {
+        "context": {
+          "$ref": "#/definitions/registrationContext"
+        },
         "authentication-base-url": {
           "description": "Redirect URL for the authentication UI.  The authentication notification points customers at {authentication-base-url}{authentication-token} to authenticate a new session.",
           "type": "string",

--- a/public.json
+++ b/public.json
@@ -4855,7 +4855,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/resendRegistrationEmail"
+              "$ref": "#/definitions/resendConfirmationEmail"
             }
           }
         ],
@@ -8062,18 +8062,25 @@
       "description": "A request for another registration email",
       "type": "object",
       "properties": {
-        "base-url": {
-          "description": "Redirect URL for the confirmation UI.  The confirmation email points customers at {base-url}{confirmation-token} to confirm their registration.",
+        "authentication-base-url": {
+          "description": "Redirect URL for the authentication UI.  The authentication notification points customers at {authentication-base-url}{authentication-token} to authenticate a new session.",
+          "type": "string",
+          "format": "url"
+        },
+        "confirmation-base-url": {
+          "description": "Redirect URL for the channel-confirmation UI.  The channel-confirmation notification points customers at {confirmation-base-url}{confirmation-token} to confirm the notification channel.",
           "type": "string",
           "format": "url"
         },
         "token": {
-          "description": "The registrant's resend token.  If token is unset, the request must be authenticated with basic auth or a session cookie.",
+          "description": "The registrant's resend token.",
           "type": "string"
         }
       },
       "required": [
-        "base-url"
+        "authentication-base-url",
+        "confirmation-base-url",
+        "token"
       ]
     },
     "token": {
@@ -8552,6 +8559,24 @@
       },
       "required": [
         "email"
+      ]
+    },
+    "resendConfirmationEmail": {
+      "description": "A request for another confirmation email",
+      "type": "object",
+      "properties": {
+        "base-url": {
+          "description": "Redirect URL for the confirmation UI.  The confirmation email points customers at {base-url}{confirmation-token} to confirm their email address.",
+          "type": "string",
+          "format": "url"
+        },
+        "token": {
+          "description": "The customer's resend token.  If token is unset, the request must be authenticated with basic auth or a session cookie.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "base-url"
       ]
     },
     "favorite": {


### PR DESCRIPTION
The registration-resend needs both authentication and confirmation base URLs to catch up with 33c0652 (#183).