### PR TITLE
public.json: Add stop.shipping-fee

### DIFF
--- a/public.json
+++ b/public.json
@@ -6770,6 +6770,9 @@
           "description": "offset from midnight on the morning of the trips's delivery start until the usual delivery time for this drop",
           "type": "string",
           "format": "duration"
+        },
+        "drop-shipping-fee": {
+          "$ref": "#/definitions/dropShippingFee"
         }
       },
       "required": [
@@ -6824,6 +6827,9 @@
           "description": "actual stop time (set after the stop is reached)",
           "type": "string",
           "format": "date-time"
+        },
+        "drop-shipping-fee": {
+          "$ref": "#/definitions/dropShippingFee"
         }
       },
       "required": [
@@ -7701,6 +7707,17 @@
         "shipping",
         "small-order"
       ]
+    },
+    "dropShippingFee": {
+      "description": "information for calculating shipping costs for orders delivered to a stop",
+      "type": "object",
+      "properties": {
+        "percent": {
+          "description": "the `shipping` order fee is the total order-line price over all lines on the order, multiplied by this percentage, and then rounded to the nearest cent.",
+          "type": "number",
+          "format": "float"
+        }
+      }
     },
     "vendor": {
       "description": "a company that sells products to Azure",

--- a/public.json
+++ b/public.json
@@ -6776,8 +6776,7 @@
         "id",
         "route",
         "drop",
-        "target-time",
-        "estimated-time"
+        "delivery-offset"
       ]
     },
     "stop": {


### PR DESCRIPTION
So users can calculate shipping fees will be without changing the order and hitting `/order-fees`.  The backend [currently hard-codes this at 8.5%][1] and allows the setting to be toggled at the [route-stop][2] level [with a route-level mask][3], so I have not added the new property to `updateStop`.

[1]: https://github.com/azurestandard/beehive/blob/3f30eac07f26dfa62785f4e6999d5562adafbba0/apps/drops/models.py#L983-L984
[2]: https://github.com/azurestandard/beehive/blob/3f30eac07f26dfa62785f4e6999d5562adafbba0/apps/drops/models.py#L839
[3]: https://github.com/azurestandard/beehive/blob/3f30eac07f26dfa62785f4e6999d5562adafbba0/apps/routes/models.py#L206-L210