### PR TITLE
public.json: Fix 'estimated-time' -> 'delivery-offset' for routeStop required

### DIFF
--- a/public.json
+++ b/public.json
@@ -6776,8 +6776,7 @@
         "id",
         "route",
         "drop",
-        "target-time",
-        "estimated-time"
+        "delivery-offset"
       ]
     },
     "stop": {


### PR DESCRIPTION
Correct a typo from d2a35b36 (`public.json`: Add `GET /route-stops` and `/route-stop/{id}` endpoints, 2015-05-07).