### PR TITLE
public.json: Document audience for drop.notes

### DIFF
--- a/public.json
+++ b/public.json
@@ -6300,7 +6300,7 @@
           }
         },
         "notes": {
-          "description": "free-form Markdown notes for any drop information that doesn't fit into an existing field",
+          "description": "free-form Markdown notes for any member-oriented drop information that doesn't fit into an existing field.  This information is public for open and semi-open drops, and visible to all members for closed drops",
           "type": "string"
         },
         "sells-finished-goods-to-azure": {
@@ -6367,7 +6367,7 @@
           "$fees": "#definitions/dropFees"
         },
         "notes": {
-          "description": "free-form Markdown notes for any drop information that doesn't fit into an existing field",
+          "description": "free-form Markdown notes for any member-oriented drop information that doesn't fit into an existing field.  This information is public for open and semi-open drops, and visible to all members for closed drops",
           "type": "string"
         }
       },


### PR DESCRIPTION
The previous language wasn't clear if this information was for Azure only, or whether members should also be able to read it.

On Tue, Jan 17, 2017 at 04:50:27PM -0800, Nick Gall [wrote][1]:
> > The front end does indeed hide the notes on open drops for everyone.  Are we sure we only want to show open drop notes to the primary contact, coordinator, and customer service? @nickgall's OP wasn't clear on that point.  If so, then this is only a simple front end change.  If not, back end changes will be required to broaden access to notes.
>
> We will want to show these notes publicly; for both semi-open and open drops.  We'll have an employee review all the notes to make sure they are appropriate via a (yet to be created?) report.

I'm guessing on the closed drops, but if the open and semi-open notes are public, it makes sense to me that the closed drop notes should be visible to members.

[1]: https://github.com/azurestandard/website/issues/1178#issuecomment-273349002