### PR TITLE
public.json: Add packaging.servings-per-container

### DIFF
--- a/public.json
+++ b/public.json
@@ -6962,6 +6962,10 @@
           "description": "Bargain-bin notes for this packaged product",
           "type": "string"
         },
+        "servings-per-container": {
+          "description": "Servings per container.  The rest of the nutrition information is in product.nutrition-facts, but the number of servings per container depends on the packaging size.  For composite packaging (e.g. a 12 x 6 x 2 oz case), the value applies to the smallest component with a nutrition label (e.g. the 2 oz items, if they're labeled, or the 6 x 2 oz boxes, if they're labeled and the 2 oz items are not).",
+          "type": "string"
+        },
         "product": {
           "description": "the product that this packaging packages",
           "type": "integer",


### PR DESCRIPTION
On Thu, Jun 08, 2017 at 10:04:21AM -0700, Casey M. Bessette [wrote][1]:
> Had a hangout meeting with Stephen and Rebecca today about this.  Some pieces such as https://beehive.azurestandard.com/piece/20264 have Servings per Container added to the Nutritional Facts, e.g.,
>
> ```
> Serving Size: 1/4 cup (30 g)
> Servings Per Container: About 378 (25 lb. size)
> Servings Per Container: About 151 (10 lb. size)
> Servings Per Container: About 75 (5 lb. size)
> ...
> ```
>
> In this case you see it's per piece (not piece meta) data even though it's currently stored on piece meta.

On Thu, Jun 08, 2017 at 12:53:12PM -0700, Tom Peters [wrote][2]:
> Note that by [removing "Servings per Container" from `product.nutrition-facts`] the `Servings per Container` will be removed from the websites nutrition facts.  Granted it does not make sense there given the multiple package sizes.  I'll create a website issue to consider how to add the `Servings per Container` info back in when we get to redesigning the product detail page.
>
> @caseybessette: Even though the frontend does not need it yet would it make sense to add the new `servings_per_container` field to the packaged product json?

[1]: https://github.com/azurestandard/beehive/issues/2846#issue-234594433
[2]: https://github.com/azurestandard/beehive/issues/2846#issuecomment-307209353