### PR TITLE
WIP: public.json: Add /person/{id}/prices for requesting per-customer prices

### DIFF
--- a/public.json
+++ b/public.json
@@ -5087,6 +5087,78 @@
         }
       }
     },
+    "/person/{id}/prices": {
+      "get": {
+        "summary": "Returns all prices from the system for a given person",
+        "operationId": "findPersonPricesById",
+        "tags": [
+          "person",
+          "price"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of person whose prices are being requested.",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "product",
+            "in": "query",
+            "description": "Product IDs to filter by.",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "csv"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of results to return.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "start",
+            "in": "query",
+            "description": "Offset to the first result to return.  Use negative numbers to offset from the end of the result list.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Price response.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/price"
+              }
+            },
+            "headers": {
+              "Count": {
+                "description": "Total number of matching results (how many you'd get if you could set an infinite `limit`).",
+                "type": "integer",
+                "format": "int32",
+                "minimum": 0
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error.",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      }
+    },
     "/session": {
       "get": {
         "summary": "Returns information about the current cookie-based session",
@@ -6928,7 +7000,7 @@
           "format": "float"
         },
         "price": {
-          "#ref": "#/definitions/price"
+          "#ref": "#/definitions/priceBase"
         },
         "stock": {
           "description": "amount of stock available for purchase.  This includes breakdown ancestors.  For example, if we have a single 4 x 6 x 14 oz case in the warehouse, the 4 x 6 x 14 oz packaging will have 1 stock, the 6 x 14 oz packagaging will have 4 stock, and the 14 oz packaging will have 24 stock.",
@@ -7002,7 +7074,6 @@
           "type": "string",
           "enum": [
             "status",
-            "price-level",
             "characteristic"
           ]
         }
@@ -7188,46 +7259,6 @@
         "name"
       ]
     },
-    "_price": {
-      "description": "a helper object for 'price'",
-      "type": "object",
-      "properties": {
-        "dollars": {
-          "description": "price of the product in dollars",
-          "type": "number",
-          "format": "float"
-        },
-        "per-pound": {
-          "description": "whether the 'dollars' price is per-pound or per-product",
-          "type": "boolean"
-        },
-        "discount": {
-          "description": "text for the discount (e.g. \"12%\", or \"$3.50\")",
-          "type": "string"
-        },
-        "dollars-per-unit": {
-          "description": "the per-unit price",
-          "type": "number",
-          "format": "float"
-        },
-        "unit": {
-          "description": "The unit for the dollars-per-unit",
-          "type": "string"
-        }
-      },
-      "required": [
-        "dollars"
-      ]
-    },
-    "priceLevel": {
-      "description": "a customer property to pick the right price from 'price'",
-      "type": "string",
-      "enum": [
-        "retail",
-        "wholesale",
-        "member"
-      ]
-    },
     "permission": {
       "description": "an API authorization or authorization category",
       "type": "string",
@@ -7237,28 +7268,70 @@
       ]
     },
     "price": {
-      "description": "product price information",
+      "description": "Customer-specific packaged-product price information.",
       "type": "object",
       "properties": {
-        "retail": {
-          "description": "pricing for retail customers",
-          "schema": {
-            "$ref": "#/definitions/_price"
-          }
+        "packaged-product": {
+          "description": "Packaged product code that this price applies to.",
+          "type": "string"
         },
-        "wholesale": {
-          "description": "pricing for wholesale customers",
-          "schema": {
-            "$ref": "#/definitions/_price"
-          }
+        "dollars": {
+          "description": "A customer's custom price for the packaged product in dollars",
+          "type": "string"
         },
-        "member": {
-          "description": "pricing for member customers",
-          "schema": {
-            "$ref": "#/definitions/_price"
+        "min": {
+          "description": "The minimum orderLine.quantity-ordered (inclusive) for which this price applies.  If min is unset, there is no lower bound.  For example, if min is 3, the price will apply to an order line if quantity-ordered is 3 or 4 but not if quantity-ordered is 1 or 2.",
+          "type": "string"
+        },
+        "max": {
+          "description": "The maximum orderLine.quantity-ordered (inclusive) for which this price applies.  If max is unset, there is no upper bound.  For example, if max is 3, the price will apply to an order line if quantity-ordered is 2 or 3 but not if quantity-ordered is 4 or 5.",
+          "type": "string"
+        },
+        "description": {
+          "description": "A collection of price descriptions.  This is an array, because there may be multiple descriptions if the price is due to stackable adjustments.",
+          "type": "array",
+          "items": {
+            "description": "A short phrase describing the price.  For example, \"June sale\".",
+            "type": "string"
           }
         }
-      }
+      },
+      "required": [
+        "packaged-product",
+        "dollars"
+      ]
+    },
+    "priceBase": {
+      "description": "Base price (not customer-specific) for a packaged product.",
+      "type": "object",
+      "properties": {
+        "default": {
+          "description": "Default price of the product in dollars.  This applies to customers that have no customer-specific pricing for the packaged product.",
+          "type": "number",
+          "format": "float"
+        },
+        "msrp": {
+          "description": "Manufactured default price of the packaged product in dollars.",
+          "type": "number",
+          "format": "float"
+        },
+        "per-pound": {
+          "description": "Whether the 'default' and 'msrp' prices are per-pound or per-product.",
+          "type": "boolean"
+        },
+        "dollars-per-unit": {
+          "description": "The per-unit price for FIXME (default?  msrp?).",
+          "type": "number",
+          "format": "float"
+        },
+        "unit": {
+          "description": "The unit for the dollars-per-unit.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "default"
+      ]
     },
     "category": {
       "description": "a category available for sale",
@@ -8251,9 +8324,6 @@
         "allow-social-media": {
           "description": "Does this person want social media links to display",
           "type": "boolean"
-        },
-        "price-level": {
-          "$ref": "#/definitions/priceLevel"
         },
         "notifications": {
           "$ref": "#/definitions/personNotifications"


### PR DESCRIPTION
The current retail/wholesale/member categorization is too coarse, and the business folks want a way to have per-customer deals for customers (or groups of customers) on packaged products (or groups of packaged products).  With this commit, we remove the old price-levels and replace them with a single `basePrice` for each packaged-product.  Individual customers (or customer service representatives acting on behalf of customers) can hit the new `/prices` endpoint to find packaged-products where they have a custom price that's not the default.  This commit covers use cases like “all employees get 10% off everything”, “all members of drop 12 get $5 off food→flour packaged-products”, and “customer 34 gets $3 off FL006”.

One future use case might be promotional codes, where users who push a promo code (to an as-yet-unspecified API endpoint) would pick up the reduced price.

Caching this sort of thing is going to be tricky, because the parameters that a custom price depends on are unclear.  Based on a dev meeting with @tompetersjr, @shofetim, @caseybessette, and @davidmcatee-azure today, we're expecting prices returned by this endpoint to generally be valid until midnight, which we can represent with the usual cache-control HTTP headers.  It's not clear to me yet if having a custom price returned to you via the API guarantees you at least that price until the cache expires.  For example,

1. You hit /prices and are quoted $10 for FL006 (because you're a member of drop 12, although the API doesn't tell you this).  The default price for FL006 is $12.
2. You leave drop 12.
3. You add an order-line for FL006 to your placed order scheduled to be delivered to drop 34.

Can the backend give you the $12 per-unit price on your order-line?  Must it remember that you had a valid-until-midnight $10 quote and give you that instead?  Will we never adjust custom-price logic on the backend in ways that might violate a claimed valid-until-midnight cache statement (this might be tricky if we base prices on the current, possibly estimated, landed cost)?

The query filtering is by product instead of packaged-product because users are expected to always want to know the prices (custom or otherwise) for all packaging associated with a given product.  The frontend may display this information as a price range (or a price-per-unit range) even if the customer is not shown a separate price for each packaging.

FIXME: Will we have any products where we are going to price them by weight, but the MSRP is fixed (not by weight) or vice versa?  Or will we always agree with the manufacturer about whether a given packaged-product should be by weight or not?

FIXME: What values do we want per-unit numbers for?  MSRP-per-unit?  Azure-default-retail-per-unit?  Your-customer-specific-price-per-unit?

FIXME: Would we ever want different wholesale/retail MSRPs?

FIXME: Do we need a way to tag sale items for Algolia filtering?  The price-level-based `on-sale-*` tags I'm removing in this commit currently back https://www.azurestandard.com/shop/tag/on-sale.  What are we doing without that page now that “what products are on sale?” becomes a per-customer question?  Do all “deals” count as “sales”, or are “sales” a subset of “deals”, or are “sales” and “deals” completely independent things?

Fixes azurestandard/beehive#2864.