### PR TITLE
public.json: Add ?inline=ancestors for /categories and /category/{id}

### DIFF
--- a/public.json
+++ b/public.json
@@ -2933,6 +2933,17 @@
             "collectionFormat": "csv"
           },
           {
+            "name": "inline",
+            "in": "query",
+            "description": "For convenience, include a full representation of the inlined property.  Currently supports \"ancestors\".",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "csv"
+          },
+          {
             "name": "limit",
             "in": "query",
             "description": "maximum number of results to return",
@@ -3024,6 +3035,17 @@
             "required": true,
             "type": "integer",
             "format": "int64"
+          },
+          {
+            "name": "inline",
+            "in": "query",
+            "description": "For convenience, include a full representation of the inlined property.  Currently supports \"ancestors\".",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "csv"
           }
         ],
         "responses": {


### PR DESCRIPTION
So that clients can walk back to the root category with a single API request.

Previous discussion in azurestandard/beehive#2785 and azurestandard/beehive#2868.