### PR TITLE
public.json: Add sale model

### DIFF
--- a/public.json
+++ b/public.json
@@ -8199,7 +8199,7 @@
       "type": "object",
       "properties": {
         "dollars": {
-          "description": "price of the product in dollars",
+          "description": "Pre-sale price of the product in dollars.",
           "type": "number",
           "format": "float"
         },
@@ -8207,18 +8207,21 @@
           "description": "whether the 'dollars' price is per-pound or per-product",
           "type": "boolean"
         },
-        "discount": {
-          "description": "text for the discount (e.g. \"12%\", or \"$3.50\")",
-          "type": "string"
-        },
-        "dollars-per-unit": {
-          "description": "the per-unit price",
+        "units": {
+          "description": "The number of units contained in the 'dollars' price.  For example, if 'unit' is \"ounce\", and 'per-pound' is true, \"units\" will be 12.  Or if 'unit' is \"fluid-ounce\", 'per-pound' is false, and the product is a 14.5 floz bottle, then 'units' will be 14.5.",
           "type": "number",
           "format": "float"
         },
         "unit": {
-          "description": "The unit for the dollars-per-unit",
+          "description": "The unit for 'units'.  For example, \"pound\".",
           "type": "string"
+        },
+        "sales": {
+          "description": "An array of current sales.  Will be set if there are sales and unset if there are none.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definition/sale"
+          }
         }
       },
       "required": [
@@ -10009,6 +10012,29 @@
         "pdf",
         "epl2",
         "bartender"
+      ]
+    },
+    "sale": {
+      "description": "A sale for a packaged product.  Either 'dollar' or 'percent' will be set, but not both.  A single packaged product may have several sales for a given time and price-level, in which case only the largest applies.",
+      "type": "object",
+      "properties": {
+        "description": {
+          "description": "Text for the discount (e.g. \"2017 December\").",
+          "type": "string"
+        },
+        "dollar": {
+          "description": "Dollar discount from the base price.  For example, with 'dollar' set to 1.25 and a base price of $10, the sale price will be $8.75.",
+          "type": "number",
+          "format": "float"
+        },
+        "percent": {
+          "description": "Percent discount from the base price.  For example, with 'percent' set to 5 and a base price of $10, the sale price will be $9.50.  The sale price should be rounded to the nearest cent, rounding half to even.",
+          "type": "number",
+          "format": "float"
+        }
+      },
+      "required": [
+        "description"
       ]
     },
     "warehouse": {

--- a/public.json
+++ b/public.json
@@ -2470,6 +2470,122 @@
         }
       }
     },
+    "/sales": {
+      "get": {
+        "summary": "Returns all sales from the system that the user has access to",
+        "description": "Sales are ordered for decreasing start time, increasing price level, and increasing packaged product code.",
+        "operationId": "findSales",
+        "tags": [
+          "sale"
+        ],
+        "parameters": [
+          {
+            "name": "packaged-product",
+            "in": "query",
+            "description": "Packaged product codes to filter by.",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "csv"
+          },
+          {
+            "name": "price-level",
+            "in": "query",
+            "description": "Price levels to filter by.",
+            "required": false,
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/priceLevel"
+            },
+            "collectionFormat": "csv"
+          },
+          {
+            "name": "when",
+            "in": "query",
+            "description": "Filter sales active at a particular time.",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of results to return.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "start",
+            "in": "query",
+            "description": "Offset to the first result to return.  Use negative numbers to offset from the end of the result list.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sale response.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/sale"
+              }
+            },
+            "headers": {
+              "Count": {
+                "description": "Total number of matching results (how many you'd get if you could set an infinite `limit`).",
+                "type": "integer",
+                "format": "int32",
+                "minimum": 0
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error.",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      }
+    },
+    "/sale/{id}": {
+      "get": {
+        "summary": "Returns a sale based on a single ID, if the user has access to the sale",
+        "operationId": "findSaleById",
+        "tags": [
+          "sale"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of sale to fetch.",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sale response.",
+            "schema": {
+              "$ref": "#/definitions/sale"
+            }
+          },
+          "default": {
+            "description": "Unexpected error.",
+            "schema": {
+              "$ref": "#/definitions/errorModel"
+            }
+          }
+        }
+      }
+    },
     "/stops": {
       "get": {
         "summary": "Returns all stops from the system that the user has access to",
@@ -9928,7 +10044,8 @@
         },
         "audited": {
           "description": "a datetime denoting if and when the packaged-product was last audited",
-          "type": "date-time"
+          "type": "string",
+          "format": "date-time"
         }
       },
       "required": [
@@ -10018,9 +10135,29 @@
       "description": "A sale for a packaged product.  Either 'dollar' or 'percent' will be set, but not both.  A single packaged product may have several sales for a given time and price-level, in which case only the largest applies.",
       "type": "object",
       "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
         "description": {
           "description": "Text for the discount (e.g. \"2017 December\").",
           "type": "string"
+        },
+        "packaged-product": {
+          "type": "string"
+        },
+        "price-level": {
+          "$ref": "#/definitions/priceLevel"
+        },
+        "start": {
+          "description": "Start of sale, inclusive.  If unset, the sale started infinitely long ago.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "end": {
+          "description": "End of sale, exclusive.  If unset, the sale ends infinitely far in the future.",
+          "type": "string",
+          "format": "date-time"
         },
         "dollar": {
           "description": "Dollar discount from the base price.  For example, with 'dollar' set to 1.25 and a base price of $10, the sale price will be $8.75.",
@@ -10034,7 +10171,10 @@
         }
       },
       "required": [
-        "description"
+        "id",
+        "description",
+        "packaged-product",
+        "price-level"
       ]
     },
     "warehouse": {


### PR DESCRIPTION
With the coming price restructuring, we're going to be applying sales on the frontend.  This commit lets us do that independent of the other price restructuring.