### PR TITLE
public.json: Convert int to float for orderLine.quantity-shipped

### DIFF
--- a/public.json
+++ b/public.json
@@ -7607,8 +7607,8 @@
         },
         "quantity-shipped": {
           "description": "number of product instances delivered",
-          "type": "integer",
-          "format": "int32"
+          "type": "number",
+          "format": "float"
         },
         "weight": {
           "description": "weight of the shipped products in pounds (estimated until picking time)",


### PR DESCRIPTION
Catching up with azurestandard/beehive#1801.

On Tue, Apr 05, 2016 at 04:53:20PM -0700, Stephen Hainline [wrote][1]:
> Currently, if a customer orders a 3/pack and we only have two, the picker can pick 2 and short the rest without resistance from the picking interface.  The result of this is that the customer is getting free product.  There is currently a setting somewhere, probably in products to Allow Partial Sale.  However, this does not seem to be working in practical reality and the customers are not getting charged per Carmen.  They are requesting some kind of resolution to this.

[1]: https://github.com/azurestandard/beehive/issues/1687