### PR TITLE
public.json: Add limit=none support for /brands

### DIFF
--- a/public.json
+++ b/public.json
@@ -660,10 +660,20 @@
           {
             "name": "limit",
             "in": "query",
-            "description": "maximum number of results to return",
+            "description": "Maximum number of results to return.",
             "required": false,
-            "type": "integer",
-            "format": "int32"
+            "oneOf": [
+              {
+                "type": "integer",
+                "format": "int32"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "none"
+                ]
+              }
+            ]
           },
           {
             "name": "start",
@@ -685,7 +695,7 @@
             },
             "headers": {
               "Count": {
-                "description": "total number of matching results (how many you'd get if you could set an infinite `limit`)",
+                "description": "Total number of matching results (how many you'd get if you set `limit` to `none`).",
                 "type": "integer",
                 "format": "int32",
                 "minimum": 0


### PR DESCRIPTION
I'm not sure if this is entirely legal Swagger, but it gets the idea across.

@davidmcatee-azure [wants this because it's more convenient than paging][1].  The [brands API is cheap][2], so I'm not worried about the load of unlimited `/brands` requests.

I want to keep the default limit lower than the cap to make it less likely that users accidentally submit expensive requests.  If you want a high-limit or unlimited response, you need to ask for it explicitly.

[Potential APIs][3] for explicitly unlimited responses:

a. Pick an absurdly high number (`?limit=999999999`).
b. Use a sentinal value (`?limit=null`, `?limit=none`, `?limit=unlimited`, `?limit=-1`, …).

I don't have a personal preference, but @davidmcatee-azure [liked `?limit=none`][4], so that's what I'm using here.

Part of azurestandard/beehive#2984.

[1]: https://github.com/azurestandard/beehive/pull/2960#issuecomment-318811267
[2]: https://github.com/azurestandard/beehive/pull/2960#issuecomment-319154398
[3]: https://github.com/azurestandard/beehive/pull/2960#issuecomment-319166816
[4]: https://github.com/azurestandard/beehive/issues/2984#issuecomment-319780972