### PR TITLE
public.json: Add category.seo-name and category.description

### DIFF
--- a/public.json
+++ b/public.json
@@ -7928,6 +7928,10 @@
           "description": "A word or two naming the category.  A shortened version of the full name that drops any words already contained in the category's ancestors' short names.  This will be used in places where the ancestor short names are in close proximity (e.g. URL slugs) to avoid having the same word many times.",
           "type": "string"
         },
+        "description": {
+          "description": "A sentence or two with a stand-alone category description.  When this is unset, the nearest ancestor description is a reasonable fallback.",
+          "type": "string"
+        },
         "image": {
           "description": "A picture of this category.  When set for a fetched category, the value will be a URL.  When set for an uploaded category, file IDs and media URLs can be used interchangeably.",
           "type": "string"

--- a/public.json
+++ b/public.json
@@ -7925,7 +7925,11 @@
           "type": "string"
         },
         "short-name": {
-          "description": "A word or two naming the category.  A shortened version of the full name that drops any words already contained in the category's ancestors' short names.  This will be used in places where the ancestor short names are in close proximity (e.g. URL slugs) to avoid having the same word many times.",
+          "description": "A word or two naming the category.  A shortened version of the full name that drops any words already contained in the category's ancestors' short names.  This will be used in places where the ancestor short names are in close proximity (e.g. URL slugs) to avoid having the same word many times.  When this is unset, the name is a reasonable fallback",
+          "type": "string"
+        },
+        "seo-name": {
+          "description": "An SEO-optimized name for the category.  A lengthened version of the full name that includes additional keywords or rephrasing, suitable for use in a title tag.  When this is unset, the name is a reasonable fallback.",
           "type": "string"
         },
         "description": {


### PR DESCRIPTION
# seo-name

The website is [currently][1] setting a [`<title>` element][2] based on [hard-coded values][3] like this.  The values landed in the website via azurestandard/website@a801e764 citing azurestandard/website#654 and landing titles like:

> Organic Chicken & Animal Feed in Bulk - Organic Farming & Garden Supplies

[provided by Lee Ladyga][5].  That's a pretty long title; too long for our [sidebar listing sub-categories][6].  But the name in the sidebar is easier to read if it's not as compact as the short name, which we want to use for breadcrumbs, URL slugs, and such (azurestandard/website#1738).  So we have three different size needs:

* A longish form for `<title>` (`seo-name`).
* A medium form for the sidebar and other low-context locations (`name`).
* A short form for breadcrumbs, URL slugs, and other high-context locations (`short-name`).

I've gone with `seo-name` instead of `long-name` because @davidmcatee-azure [expects the values to be SEO-specific][8] (with too many keywords or odd phrasing to be worth displaying in other places?).

I've used `seo-name` rather than `seo-title`, because this value is covering the same idea as our existing `name` and `short-name`, and I like the `(*-)name` pattern.

I've also documented the `short-name` → `name` suggested fallback to keep up with the new `seo-name` → `name` suggested fallback.

# description

We'd removed a `category.description` property in 67cd688d, citing Susan saying we wouldn't need it.  But the website is [currently setting][9] a description [`<meta>`][10] [element][11] based on [hard-coded descriptions][3] like this.  The descriptions landed in the website via azurestandard/website@a801e764 citing azurestandard/website#654 and landing descriptions like:

> Azure Standard has natural and organic nutritional supplements, homeopathic and herbal remedies, organic protein powders, organic teas.

[provided by Lee Ladyga][5].  I haven't been able to find Google docs for the 172 limit, but [this article][12] suggests that around 2016-05-18 Google changed from displaying around 155-160 description characters to around 170-172 (at least for their mobile site, with more characters for their desktop site).

Since one use for this information is the content attribute in the `<meta>` element, we want plain text, not Markdown or anything richer.

Fixes #213.

[1]: https://github.com/azurestandard/website/blob/v1.7.8/src/index.html#L8
[2]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title
[3]: https://github.com/azurestandard/website/blob/v1.7.8/src/app.shop/shop_listing.index.controller.js#L506-L525
[5]: https://github.com/azurestandard/website/issues/654#issuecomment-241164075
[6]: https://github.com/azurestandard/website/blob/v1.7.8/src/app.shop/shop_listing.index.html#L84-L87
[8]: https://github.com/azurestandard/api-spec/issues/213#issuecomment-326638890
[9]: https://github.com/azurestandard/website/blob/v1.7.8/src/index.html#L8
[10]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta
[11]: https://support.google.com/webmasters/answer/35624?#1
[12]: https://www.seoinc.com/seo-blog/google-increases-title-meta-description-length/