### PR TITLE
Add orderParcelCarrierEstimate.message.

### DIFF
--- a/public.json
+++ b/public.json
@@ -8438,11 +8438,13 @@
           "description": "The estimated latest delivery date (inclusive) for the covered order-lines.",
           "type": "string",
           "format": "date"
+        },
+        "message": {
+          "description": "An optional message that should be displayed to the customer when this service estimate is available for selection.",
+          "type": "string"
         }
       },
       "required": [
-        "cost",
-        "climate",
         "service"
       ]
     },


### PR DESCRIPTION
And make the `cost` and `climate` properties optional since they will
not be provided for the UPS Freight and Azure Wholesale Team services.

Related to azurestandard/website#1673.