### PR TITLE
public.json: Add person.order-place-issue

### DIFF
--- a/public.json
+++ b/public.json
@@ -5729,7 +5729,7 @@
           {
             "name": "inline",
             "in": "query",
-            "description": "for convenience, include additional information.  Currently supports \"email\" as described in the email model.",
+            "description": "for convenience, include additional information.  Currently supports \"email\" as described in the email model and \"order-place-issue\".",
             "required": false,
             "type": "array",
             "items": {
@@ -5800,7 +5800,7 @@
           {
             "name": "inline",
             "in": "query",
-            "description": "for convenience, include additional information.  Currently supports \"email\" as described in the email model.",
+            "description": "for convenience, include additional information.  Currently supports \"email\" as described in the email model and \"order-place-issue\".",
             "required": false,
             "type": "array",
             "items": {
@@ -5871,6 +5871,19 @@
         "operationId": "findPersonByAuth",
         "tags": [
           "person"
+        ],
+        "parameters": [
+          {
+            "name": "inline",
+            "in": "query",
+            "description": "for convenience, include additional information.  Currently supports \"email\" as described in the email model and \"order-place-issue\".",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "csv"
+          }
         ],
         "responses": {
           "200": {
@@ -9373,6 +9386,15 @@
           "items": {
             "$ref": "#/definitions/permission"
           }
+        },
+        "order-place-issue": {
+          "description": "If the person should be warned or blocked from placing orders, this property will be set with a slugged reason and recommended action.",
+          "type": "string",
+          "enum": [
+            "outstanding-balance-contact",
+            "outstanding-balance-pay",
+            "outstanding-balance-warn"
+          ]
         },
         "internal-notes": {
           "description": "free-form Markdown notes for any internal information that doesn't fit into an existing field.  Only Azure employees can view or edit this information, although it may be passed into the registerPerson endpoint when registering new people.",


### PR DESCRIPTION
If a customer has carried a sufficiently large balance for a sufficiently long time (as determined by the backend), we want to at least warn users instead of letting them silently checkout (and continue to grow their balance).  We have a few classes of customers for this situation:

* Some customers have fairly serious issues, and they should be encouraged to contact customer service to resolve the issue.  Until then, we will block attempts to place orders.

* Some customers have fairly standard issues, and they should be encouraged to settle their balance directly (e.g. via the “Make a Payment” button [here][1]).  They can also call customer service to sort things out that way.  Until their balance is resolved, we will block attempts to place orders.

* Some customers have special arrangements with Azure to enable them to carry balances while continuing to place new orders.  They should be warned about their outstanding balance, but will still be allowed to place their order.

The enum slugs all start with `outstanding-balance-` to future-proof against other cases where a customer should be blocked or warned from placing all orders.  We don't have those cases now, but using specific slugs leaves room for them if we get some in the future.

The expected workflow is that when users visit a view that allows them to place an order, the frontend will pull a fresh person to get the current value of this property.  If the property is set, the frontend will display an appropriate warning/error, disable the order-placing button, etc.  Because customers are likely to resolve these issues out of band (e.g. via a phone call), frontend warnings should include a suggestion to refresh the data if the customer considers it stale.

There are also related checks that are per-order (vs. per-customer).  For example. we allow customers to place orders after cutoff (but before verification) if their drop received short-drop notifications.  Because they are order-specific, they cannot be represented in this per-person property.  We discussed using `PUT /order/{id}?save=false` for this check, returning errors for these outstanding-balance cases.  That would have allowed us to get the currently-implemented per-order checks at that point as well.  The benefit of the per-customer property is that if at some point we decide to warn customers earlier (e.g. at login, or with a site-wide banner), this approach will work while a per-order approach would require at least an active order.

This property is based @caseybessette's suggestion [here][2].

[1]: https://www.azurestandard.com/my-account/account-balance
[2]: https://github.com/azurestandard/beehive/issues/3062#issuecomment-330681856