### PR TITLE
public.json: Add the 'email' format for affiliate-username

### DIFF
--- a/public.json
+++ b/public.json
@@ -9423,7 +9423,8 @@
         },
         "affiliate-username": {
           "description": "Affiliate username (email)",
-          "type": "string"
+          "type": "string",
+          "format": "email"
         },
         "is-allowed-to-be-affiliate": {
           "description": "Is allowed to be an affiliate.",


### PR DESCRIPTION
Like we already do for email.address, etc.