### PR TITLE
public.json: Add ?inline=person to /addresses

### DIFF
--- a/public.json
+++ b/public.json
@@ -5210,7 +5210,7 @@
           {
             "name": "inline",
             "in": "query",
-            "description": "for convenience, include a full representation of the inlined property.  Currently supports \"country\".",
+            "description": "for convenience, include a full representation of the inlined property.  Currently supports \"country\", \"person\", and descendants.",
             "required": false,
             "type": "array",
             "items": {
@@ -5276,6 +5276,17 @@
             "schema": {
               "$ref": "#/definitions/address"
             }
+          },
+          {
+            "name": "inline",
+            "in": "query",
+            "description": "for convenience, include a full representation of the inlined property.  Currently supports \"country\", \"person\", and descendants.",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "csv"
           }
         ],
         "responses": {
@@ -5309,6 +5320,17 @@
             "required": true,
             "type": "integer",
             "format": "int64"
+          },
+          {
+            "name": "inline",
+            "in": "query",
+            "description": "for convenience, include a full representation of the inlined property.  Currently supports \"country\", \"person\", and descendants.",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "csv"
           }
         ],
         "responses": {
@@ -5349,6 +5371,17 @@
             "schema": {
               "$ref": "#/definitions/address"
             }
+          },
+          {
+            "name": "inline",
+            "in": "query",
+            "description": "for convenience, include a full representation of the inlined property.  Currently supports \"country\", \"person\", and descendants.",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "csv"
           }
         ],
         "responses": {


### PR DESCRIPTION
So folks can go from a given address back to the associated person (e.g. “which customer is +1 800 555 0100?” could be `GET /address?telephone=%2b1%20800%20555%200100&inline=person.email`).  For example, this allows customer lookups by phone number for customer service reps fielding incoming SMS messages and/or voice calls.  This catches the API-spec up with azurestandard/beehive#3679.

I've also extended the address `?inline=…` support to the other address endpoints for symmetry.  I have work in flight for the last missing piece here (POST) with azurestandard/beehive#3683.