### PR TITLE
public.json: Add person.password-usable

### DIFF
--- a/public.json
+++ b/public.json
@@ -9482,6 +9482,10 @@
           "description": "Whether or not this account is active.  Inactive users cannot log in.",
           "type": "boolean"
         },
+        "password-usable": {
+          "description": "Whether or not this account has a usable password.",
+          "type": "boolean"
+        },
         "email": {
           "description": "The person's preferred, error-less email address (set if the \"inline\" query parameter contains \"email\").",
           "type": "string",
@@ -9625,7 +9629,7 @@
           "type": "boolean"
         },
         "user-password": {
-          "description": "The authenticated person's password, required when changing password",
+          "description": "The authenticated person's password.  Required when changing password for users with a usable password.",
           "type": "string"
         },
         "notifications": {
@@ -9835,13 +9839,12 @@
           "$ref": "#/definitions/email"
         },
         "user-password": {
-          "description": "The authenticated person's password.",
+          "description": "The authenticated person's password.  Required for users with a usable password.",
           "type": "string"
         }
       },
       "required": [
-        "email",
-        "user-password"
+        "email"
       ]
     },
     "favorite": {

--- a/public.json
+++ b/public.json
@@ -9478,6 +9478,10 @@
         "name": {
           "type": "string"
         },
+        "active": {
+          "description": "Whether or not this account is active.  Inactive users cannot log in.",
+          "type": "boolean"
+        },
         "email": {
           "description": "The person's preferred, error-less email address (set if the \"inline\" query parameter contains \"email\").",
           "type": "string",


### PR DESCRIPTION
And don't require user-password for users without a usable password.  This makes it easier for customers who register without a password to initialize their password later, because their existing auth token (or a cookie obtained by logging in with that token) is now sufficient information for `PUT`ing a new password.  Previously, they'd have to go through the password-reset email cycle, [which was tedious][1].

This makes those accounts slightly more exposed to [ambient authority attacks][2] and cookie/token leakage.  But our API considers cookie/token possession sufficient for most operations already.  Users who want the stricter `user-password` protections for the extra-sensitive password and email updates are free to set a password, either at registration time or later, without us having to require that security for everyone.

I've also added a drive-by `person.active` as additional read-only metadata; details in 7bae1e1.

[1]: https://github.com/azurestandard/beehive/issues/3647
[2]: https://tools.ietf.org/html/rfc6265#section-8.2