### PR TITLE
public.json: Add RFM, first-order-placed, etc. to person

### DIFF
--- a/public.json
+++ b/public.json
@@ -9570,6 +9570,16 @@
           "format": "int32",
           "minimum": 1,
           "maximum": 5
+        },
+        "first-order-placed": {
+          "description": "When this customer's first order was placed.  This timestamp does not change once set, even if the initial order is subsequently deleted.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "last-order-placed": {
+          "description": "When this customer's most recent order was placed.  This timestamp includes all open-to-placed transitions, regardless of whether the related order is subsequently deleted.",
+          "type": "string",
+          "format": "date-time"
         }
       },
       "required": [

--- a/public.json
+++ b/public.json
@@ -9549,6 +9549,27 @@
         "accepted-affiliate-terms": {
           "description": "Has accepted the affiliate terms of service.  This can only be set to true if is-allowed-to-be-affiliate value is true.",
           "type": "boolean"
+        },
+        "recency": {
+          "description": "Order recency ranking.  Higher rankings for customers with more recent orders.",
+          "type": "integer",
+          "format": "int32",
+          "minimum": 1,
+          "maximum": 5
+        },
+        "frequency": {
+          "description": "Order frequency ranking.  Higher rankings for customers with more frequent orders.",
+          "type": "integer",
+          "format": "int32",
+          "minimum": 1,
+          "maximum": 5
+        },
+        "monetary": {
+          "description": "Order value ranking.  Higher rankings for customers with larger orders.",
+          "type": "integer",
+          "format": "int32",
+          "minimum": 1,
+          "maximum": 5
         }
       },
       "required": [


### PR DESCRIPTION
[As][2] [requested][1] by @davidcross so the frontend can slot in tailored home page content.  Personally, I'd be happier [if the place times only included orders which remained in the database][3], but that's not my call.

We also discussed using cookies for this information, but decided on person properties so customer service can see the same home page as a customer when they are acting on the customer's behalf (`?superuser-for=...`).

[1]: https://github.com/azurestandard/website/issues/2161
[2]: https://github.com/azurestandard/beehive/issues/3735
[3]: https://github.com/azurestandard/beehive/issues/3735#issuecomment-385823868