### PR TITLE
public.json: Split reward.balance into total-credit and total-debit

### DIFF
--- a/public.json
+++ b/public.json
@@ -5250,9 +5250,9 @@
             "collectionFormat": "csv"
           },
           {
-            "name": "balance",
+            "name": "totals",
             "in": "query",
-            "description": "Add the `balance` and `pending` properties to returned entries.",
+            "description": "Add the `total-credit`, `total-debit`, and `total-pending` properties to returned entries.",
             "required": false,
             "type": "boolean"
           },
@@ -9510,14 +9510,20 @@
           "type": "integer",
           "format": "int64"
         },
-        "balance": {
-          "description": "Settled reward balance after this reward entry.",
+        "total-credit": {
+          "description": "Settled credit total through this reward entry.",
           "type": "number",
           "format": "float",
           "minimum": 0
         },
-        "pending": {
-          "description": "Total pending debits through this reward entry.",
+        "total-debit": {
+          "description": "Settled debit total through this reward entry.",
+          "type": "number",
+          "format": "float",
+          "minimum": 0
+        },
+        "total-pending": {
+          "description": "Pending debit total through this reward entry.",
           "type": "number",
           "format": "float",
           "minimum": 0


### PR DESCRIPTION
This allows us to show things like "lifetime rewards", so folks can see the total impact of the rewards program on their account.  You can retrieve the previous balance value with `credit-total - debit-total`.

We don't want to do this for `accountEntry`, because we don't expect to break that down for folks (e.g. no "lifetime dollars sent to Azure" UI).