### PR TITLE
public.json: Add a per-customer rewards rate

### DIFF
--- a/public.json
+++ b/public.json
@@ -9748,6 +9748,11 @@
         "price-level": {
           "$ref": "#/definitions/priceLevel"
         },
+        "rewards-rate": {
+          "description": "Rewards rate (as a percentage) for this customer.  For products without custom rewards rates, the rewards earned for the product will be the price (after sales) * `rewards-rate` / 100, rounded to the nearest cent, rounding half to even.",
+          "type": "integer",
+          "format": "int32"
+        },
         "notifications": {
           "$ref": "#/definitions/personNotifications"
         },


### PR DESCRIPTION
This is something like `person.price-level`, allowing users to calculate the rewards they'll earn for a particular product before they add an order-line.  Once they've added an order line, they can use `orderLine.rewards`.

In our previous modeling from 6074db6 (#230), we assumed a single standard rate across all customers.  In recent discussion, we have decided to relax that, and allow for per-customer rewards rates.  The new property allows customers (and customer service) to determine that rate.

We'll want follow-up work to adjust the price changes from 6074db6 to account for this change, now that `_price.rewards` is no longer a thing.  But I'm not clear enough on what those changes will look like yet, so we're punting them to follow-up work.

I've gone with integer percentages based on:

On Thu, Jun 07, 2018 at 04:13:22PM -0700, Tom Peters [wrote][1]:
> I had a call with David S, David C, David M and Isaac today and David S agreed to doing the following on top of the MAP calculation:
>
> - After calculating MAP reward amount convert that to a percent.  Then round that to the nearest percent with a 2% (2% being the standard discount variable) minimum.  Then convert that to the reward amount.
>
> This allows us to display something like "Bonus 2x" or "Bonus 6.5x" on things.

That's for the MAP rates (at that point I don't think we were thinking about floating the "standard" rate at that point), but I expect the integer percentage argument also applies here.

[1]: https://github.com/azurestandard/beehive/issues/3786#issuecomment-395594649