### PR TITLE
Add computed total properties to order endpoint

### DIFF
--- a/public.json
+++ b/public.json
@@ -8906,23 +8906,38 @@
           "description": "Optional computed properties included via the \"computed\" parameter.",
           "type": "object",
           "properties": {
-            "totalLinePrice": {
-              "description": "Dollar value for the sum of all orderlines.",
+            "totalItemPriceOrdered": {
+              "description": "Dollar value for the sum of all ordered items (does not include potential fees).",
               "type": "number",
               "format": "float"
             },
-            "totalFees": {
-              "description": "Dollar value for the sum of all order fees.",
+            "totalItemPriceShipped": {
+              "description": "Dollar value for the sum of all shipped items (does not include potential fees).",
               "type": "number",
               "format": "float"
             },
-            "totalWeight": {
+            "totalWeightOrdered": {
               "description": "Total weight (in pounds) of all ordered items.",
               "type": "number",
               "format": "float"
             },
-            "totalVolume": {
+            "totalWeightShipped": {
+              "description": "Total weight (in pounds) of all shipped items.",
+              "type": "number",
+              "format": "float"
+            },
+            "totalVolumeOrdered": {
               "description": "Total volume (in cubic feet) of all ordered items.",
+              "type": "number",
+              "format": "float"
+            },
+            "totalVolumeShipped": {
+              "description": "Total volume (in cubic feet) of all shipped items.",
+              "type": "number",
+              "format": "float"
+            },
+            "totalFees": {
+              "description": "Dollar value for the sum of all order fees (pre or post shipment, dependent on order status).",
               "type": "number",
               "format": "float"
             }

--- a/public.json
+++ b/public.json
@@ -8901,6 +8901,32 @@
         "last-api-update": {
           "description": "a datetime denoting when the order or its order-lines were last updated via the API",
           "type": "date-time"
+        },
+        "computed": {
+          "description": "Optional computed properties included via the \"computed\" parameter.",
+          "type": "object",
+          "properties": {
+            "totalLinePrice": {
+              "description": "Dollar value for the sum of all orderlines.",
+              "type": "number",
+              "format": "float"
+            },
+            "totalFees": {
+              "description": "Dollar value for the sum of all order fees.",
+              "type": "number",
+              "format": "float"
+            },
+            "totalWeight": {
+              "description": "Total weight of all ordered items.",
+              "type": "number",
+              "format": "float"
+            },
+            "totalVolume": {
+              "description": "Total volume of all ordered items.",
+              "type": "number",
+              "format": "float"
+            }
+          }
         }
       },
       "required": [

--- a/public.json
+++ b/public.json
@@ -8917,12 +8917,12 @@
               "format": "float"
             },
             "totalWeight": {
-              "description": "Total weight of all ordered items.",
+              "description": "Total weight (in pounds) of all ordered items.",
               "type": "number",
               "format": "float"
             },
             "totalVolume": {
-              "description": "Total volume of all ordered items.",
+              "description": "Total volume (in cubic feet) of all ordered items.",
               "type": "number",
               "format": "float"
             }


### PR DESCRIPTION
Note that this is the first of our new "computed" concept (distinct from "inline"). To recap the difference (from notes taken via discussion that resulting in the concept): 

Use `inline` for nested properties.
Use `computed` for computed properties (returned JSON nested inside a `computed` property)

Also note that I've used camel case here, as I understood we wanted to do all future API-related development using it (and will at some point convert existing hyphenation to it).