### PR TITLE
Make last-api-update camel case

### DIFF
--- a/public.json
+++ b/public.json
@@ -8898,7 +8898,7 @@
           "description": "Warehouse packing instructions",
           "type": "string"
         },
-        "last-api-update": {
+        "lastApiUpdate": {
           "description": "a datetime denoting when the order or its order-lines were last updated via the API",
           "type": "date-time"
         },


### PR DESCRIPTION
The immediate reasoning for this is that there's no clean way (that I've been able to find) to sort via hyphenated properties with AngularJS. Note that this aligns with our goal of transitioning all endpoint and property hyphenation to camel case.