### PR TITLE
Make Route Fields Required

### DIFF
--- a/public.yaml
+++ b/public.yaml
@@ -6997,6 +6997,10 @@ components:
         - cutoff-frequency
         - delivery-offset
         - internal
+        - hub
+        - driverName
+        - driverPhone
+        - notes
     updateRoute:
       description: an order-delivery truck route's updated values
       type: object


### PR DESCRIPTION
To be consistant with other endpoints the new route fields
added in PR #261 should be required on the route model

- hub
- driverName
- driverPhone
- notes