### PR TITLE
Add status property to trip

### DIFF
--- a/public.yaml
+++ b/public.yaml
@@ -7116,6 +7116,14 @@ components:
             this will mostly be for delay causes (e.g. "High winds in Laramie"
             or "The truck broke down")
           type: string
+        status: 
+          description: current stage of a trip's lifecycle
+          type: string
+          enum:
+            - new
+            - verified
+            - sequenced
+            - shipped
       required:
         - id
         - route


### PR DESCRIPTION
Updates the spec for  https://github.com/azurestandard/beehive/pull/4414/commits/f2f91396286255fd95b77ef97891fa988826c70d.

Assuming we want to try and keep the spec accurate with the production API we should hold off on merging this until that (above mentioned PR) is deployed.