### PR TITLE
Improve formatting consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
-Azure Standard's APIs in [Swagger][].
+OpenAPI 3.0 Specification for Azure Standard's API.
 
-Libraries
-=========
+## Style Guide
+
+`summary` values are essentially headings. The first character of the string should always be capitalized. They should never end in a period.
+
+`description` values should be formatted with normal sentence formatting. They should always end with a period. Markdown is supported for rich-text formatting.
+
+## Libraries
 
 The following libraries wrap this API for easy consumption:
 
-* [azure-angular-providers][] for AngularJS.
-
-[Swagger]: http://swagger.io/
-[azure-angular-providers]: https://github.com/azurestandard/azure-angular-providers
+- [azure-angular-providers](https://github.com/azurestandard/azure-angular-providers) for AngularJS

--- a/public.yaml
+++ b/public.yaml
@@ -2,7 +2,8 @@ openapi: 3.0.0
 info:
   version: 1.0.0-oas3
   title: Azure Standard Public API
-  description: The public API behind Azure's website.
+  description: |-
+    The public API behind Azure's website.
   contact:
     name: Azure Standard Customer Service
     email: info@azurestandard.com
@@ -23,31 +24,36 @@ paths:
       parameters:
         - name: person
           in: query
-          description: Person ID of the referring user.
+          description: |-
+            Person ID of the referring user.
           required: true
           schema:
             type: integer
             format: int64
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: Affiliate referral response.
+          description: |-
+            Affiliate referral response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -59,7 +65,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/affiliateReferral'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -73,24 +80,28 @@ paths:
       parameters:
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: BartenderHost response.
+          description: |-
+            BartenderHost response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -102,7 +113,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/bartenderHost'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -114,13 +126,15 @@ paths:
         - bartender
       responses:
         '200':
-          description: BarTender host response.
+          description: |-
+            BarTender host response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/bartenderHost'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -130,7 +144,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/bartenderHost'
-        description: BarTender host to add.
+        description: |-
+          BarTender host to add.
         required: true
   '/bartender-host/{code}':
     get:
@@ -141,19 +156,22 @@ paths:
       parameters:
         - name: code
           in: path
-          description: Code of BarTender host to fetch.
+          description: |-
+            Code of BarTender host to fetch.
           required: true
           schema:
             type: string
       responses:
         '200':
-          description: BarTender host response.
+          description: |-
+            BarTender host response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/bartenderHost'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -166,19 +184,22 @@ paths:
       parameters:
         - name: code
           in: path
-          description: Code of BarTender host to update.
+          description: |-
+            Code of BarTender host to update.
           required: true
           schema:
             type: string
       responses:
         '200':
-          description: BarTender host response.
+          description: |-
+            BarTender host response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/bartenderHost'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -188,7 +209,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/bartenderHost'
-        description: Updated BarTender host parameters (can optionally include 'code').
+        description: |-
+          Updated BarTender host parameters (can optionally include 'code').
         required: true
     delete:
       summary: Delete an existing BarTender host
@@ -198,15 +220,18 @@ paths:
       parameters:
         - name: code
           in: path
-          description: Code of BarTender host to delete.
+          description: |-
+            Code of BarTender host to delete.
           required: true
           schema:
             type: string
       responses:
         '204':
-          description: Delete successful.
+          description: |-
+            Delete successful.
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -220,24 +245,28 @@ paths:
       parameters:
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: BartenderTemplate response.
+          description: |-
+            BartenderTemplate response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -249,7 +278,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/bartenderTemplate'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -261,13 +291,15 @@ paths:
         - bartender
       responses:
         '200':
-          description: BarTender template response.
+          description: |-
+            BarTender template response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/bartenderTemplate'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -277,7 +309,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/bartenderTemplate'
-        description: BarTender template to add.
+        description: |-
+          BarTender template to add.
         required: true
   '/bartender-template/{id}':
     get:
@@ -288,20 +321,23 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of BarTender template to fetch.
+          description: |-
+            ID of BarTender template to fetch.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: BarTender template response.
+          description: |-
+            BarTender template response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/bartenderTemplate'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -314,20 +350,23 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of BarTender template to update.
+          description: |-
+            ID of BarTender template to update.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: BarTender template response.
+          description: |-
+            BarTender template response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/bartenderTemplate'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -337,7 +376,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/bartenderTemplate'
-        description: Updated BarTender template parameters (can optionally include 'id').
+        description: |-
+          Updated BarTender template parameters (can optionally include 'id').
         required: true
     delete:
       summary: Delete an existing BarTender template
@@ -347,16 +387,19 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of BarTender template to delete.
+          description: |-
+            ID of BarTender template to delete.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '204':
-          description: Delete successful.
+          description: |-
+            Delete successful.
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -370,24 +413,28 @@ paths:
       parameters:
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: BartenderPrintConfiguration response.
+          description: |-
+            BartenderPrintConfiguration response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -399,7 +446,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/bartenderPrintConfiguration'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -411,13 +459,15 @@ paths:
         - bartender
       responses:
         '200':
-          description: BarTender print configuration response.
+          description: |-
+            BarTender print configuration response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/bartenderPrintConfiguration'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -427,7 +477,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/bartenderPrintConfiguration'
-        description: BarTender print configuration to add.
+        description: |-
+          BarTender print configuration to add.
         required: true
   '/bartender-print-configuration/{id}':
     get:
@@ -438,20 +489,23 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of BarTender print configuration to fetch.
+          description: |-
+            ID of BarTender print configuration to fetch.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: BarTender print configuration response.
+          description: |-
+            BarTender print configuration response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/bartenderPrintConfiguration'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -464,20 +518,23 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of BarTender print configuration to update.
+          description: |-
+            ID of BarTender print configuration to update.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: BarTender print configuration response.
+          description: |-
+            BarTender print configuration response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/bartenderPrintConfiguration'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -487,7 +544,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/bartenderPrintConfiguration'
-        description: Updated BarTender print configuration parameters (can optionally include 'id').
+        description: |-
+          Updated BarTender print configuration parameters (can optionally include 'id').
         required: true
     delete:
       summary: Delete an existing BarTender print configuration
@@ -497,16 +555,19 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of BarTender print configuration to delete.
+          description: |-
+            ID of BarTender print configuration to delete.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '204':
-          description: Delete successful.
+          description: |-
+            Delete successful.
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -520,16 +581,19 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of BarTender print configuration to test.
+          description: |-
+            ID of BarTender print configuration to test.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '202':
-          description: BarTender print configuration test print request accepted.
+          description: |-
+            BarTender print configuration test print request accepted.
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -543,7 +607,8 @@ paths:
                 stock:
                   type: integer
                   format: int64
-        description: Test data to use in the test print request. The payload must be a JSON object, but the `stock` property is optional.
+        description: |-
+          Test data to use in the test print request. The payload must be a JSON object, but the `stock` property is optional.
         required: true
   /brands:
     get:
@@ -555,13 +620,15 @@ paths:
       parameters:
         - name: name
           in: query
-          description: Only return brands whose name contains this value (case insensitive).
+          description: |-
+            Only return brands whose name contains this value (case insensitive).
           required: false
           schema:
             type: string
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             oneOf:
@@ -572,17 +639,20 @@ paths:
                   - none
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: Brand response.
+          description: |-
+            Brand response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you set `limit` to `none`).
+              description: |-
+                Total number of matching results (how many you'd get if you set `limit` to `none`).
               schema:
                 type: integer
                 format: int32
@@ -594,7 +664,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/brand'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -609,20 +680,23 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of brand to fetch.
+          description: |-
+            ID of brand to fetch.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: Brand response.
+          description: |-
+            Brand response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/brand'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -636,13 +710,15 @@ paths:
       parameters:
         - name: query
           in: query
-          description: Query to perform within the directory. The use of a `*` at the beginning or end of the string is treated as a wildcard. This parameter is case insensitive.
+          description: |-
+            Query to perform within the directory. The use of a `*` at the beginning or end of the string is treated as a wildcard. This parameter is case insensitive.
           required: false
           schema:
             type: string
         - name: query-field
           in: query
-          description: Fields to search. Any property included in a companyDirectoryEntry response may be queried. Defaults to `full-name`, `first-name`, `last-name`, `title`, `department.name`, `phone-number`, `phone-ext`, `mobile`, `email`, and `office`.
+          description: |-
+            Fields to search. Any property included in a companyDirectoryEntry response may be queried. Defaults to `full-name`, `first-name`, `last-name`, `title`, `department.name`, `phone-number`, `phone-ext`, `mobile`, `email`, and `office`.
           required: false
           style: form
           schema:
@@ -651,13 +727,15 @@ paths:
               type: string
         - name: department
           in: query
-          description: Filter by department. If this parameter is used then department will be ignored in the query-field parameter. This parameter is case insensitive.
+          description: |-
+            Filter by department. If this parameter is used then department will be ignored in the query-field parameter. This parameter is case insensitive.
           required: false
           schema:
             type: string
         - name: sort
           in: query
-          description: Order results by this field. Any property included in a companyDirectoryEntry response may be used here. Defaults to `department.name`, `first-name` and `last-name`.
+          description: |-
+            Order results by this field. Any property included in a companyDirectoryEntry response may be used here. Defaults to `department.name`, `first-name` and `last-name`.
           required: false
           style: form
           schema:
@@ -666,24 +744,28 @@ paths:
               type: string
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: CompanyDirectoryEntry response.
+          description: |-
+            CompanyDirectoryEntry response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -695,7 +777,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/companyDirectoryEntry'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -709,24 +792,28 @@ paths:
       parameters:
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: Department response.
+          description: |-
+            Department response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -738,7 +825,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/department'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -752,13 +840,15 @@ paths:
       parameters:
         - name: query
           in: query
-          description: Query terms to filter by (currently searches `name` only).
+          description: |-
+            Query terms to filter by (currently searches `name` only).
           required: false
           schema:
             type: string
         - name: category
           in: query
-          description: Report category IDs to filter by. `null` may be used to return reports that are uncategorized.
+          description: |-
+            Report category IDs to filter by. `null` may be used to return reports that are uncategorized.
           required: false
           style: form
           schema:
@@ -768,24 +858,28 @@ paths:
               format: int64
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: Report response.
+          description: |-
+            Report response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -797,7 +891,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/report'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -811,19 +906,22 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of report to fetch.
+          description: |-
+            ID of report to fetch.
           required: true
           schema:
             type: string
       responses:
         '200':
-          description: Report response.
+          description: |-
+            Report response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/report'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -837,30 +935,35 @@ paths:
       parameters:
         - name: customer-pricing
           in: query
-          description: Filter categories by whether or not they contain customer pricing groups.
+          description: |-
+            Filter categories by whether or not they contain customer pricing groups.
           required: false
           schema:
             type: boolean
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: ReportCategory response.
+          description: |-
+            ReportCategory response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -872,7 +975,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/reportCategory'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -884,13 +988,15 @@ paths:
         - report
       responses:
         '200':
-          description: Report category response.
+          description: |-
+            Report category response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/reportCategory'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -900,7 +1006,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/reportCategory'
-        description: Report category to add.
+        description: |-
+          Report category to add.
         required: true
   '/report-category/{id}':
     get:
@@ -911,19 +1018,22 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of report category to fetch.
+          description: |-
+            ID of report category to fetch.
           required: true
           schema:
             type: string
       responses:
         '200':
-          description: Report category response.
+          description: |-
+            Report category response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/reportCategory'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -936,19 +1046,22 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of report category to update.
+          description: |-
+            ID of report category to update.
           required: true
           schema:
             type: string
       responses:
         '200':
-          description: ReportCategory response.
+          description: |-
+            ReportCategory response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/reportCategory'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -958,7 +1071,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/reportCategory'
-        description: Updated report category parameters.
+        description: |-
+          Updated report category parameters.
         required: true
     delete:
       summary: Delete an existing report category
@@ -968,15 +1082,18 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of report category to delete.
+          description: |-
+            ID of report category to delete.
           required: true
           schema:
             type: string
       responses:
         '204':
-          description: Delete successful.
+          description: |-
+            Delete successful.
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -990,13 +1107,15 @@ paths:
       parameters:
         - name: active
           in: query
-          description: Only return (in)active drops.
+          description: |-
+            Only return (in)active drops.
           required: false
           schema:
             type: boolean
         - name: exclusivity
           in: query
-          description: Types of exclusivity to filter by.
+          description: |-
+            Types of exclusivity to filter by.
           required: false
           style: form
           schema:
@@ -1009,7 +1128,8 @@ paths:
                 - closed
         - name: route
           in: query
-          description: Route names to filter by.
+          description: |-
+            Route names to filter by.
           required: false
           style: form
           schema:
@@ -1018,7 +1138,8 @@ paths:
               type: string
         - name: trip
           in: query
-          description: Trip IDs to filter by.
+          description: |-
+            Trip IDs to filter by.
           required: false
           style: form
           schema:
@@ -1028,7 +1149,8 @@ paths:
               format: int64
         - name: filter-person
           in: query
-          description: Person IDs to filter by.
+          description: |-
+            Person IDs to filter by.
           required: false
           style: form
           schema:
@@ -1038,30 +1160,35 @@ paths:
               format: int64
         - name: sort
           in: query
-          description: Order results by this field. Only one special sort field is supported, distance(lat:45.45|lon:-121.13), which will sort drops by increasing distance from the lat and lon combination.
+          description: |-
+            Order results by this field. Only one special sort field is supported, distance(lat:45.45|lon:-121.13), which will sort drops by increasing distance from the lat and lon combination.
           required: false
           schema:
             type: string
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: Drop response.
+          description: |-
+            Drop response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -1073,7 +1200,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/drop'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -1085,13 +1213,15 @@ paths:
         - drop
       responses:
         '200':
-          description: Drop response.
+          description: |-
+            Drop response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/drop'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -1101,7 +1231,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/newDrop'
-        description: Drop to add.
+        description: |-
+          Drop to add.
         required: true
   '/drop/{id}':
     get:
@@ -1112,20 +1243,23 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of drop to fetch.
+          description: |-
+            ID of drop to fetch.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: Drop response.
+          description: |-
+            Drop response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/drop'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -1138,20 +1272,23 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of drop to update.
+          description: |-
+            ID of drop to update.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: Drop response.
+          description: |-
+            Drop response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/drop'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -1161,7 +1298,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updateDrop'
-        description: Updated drop parameters (can optionally include 'id').
+        description: |-
+          Updated drop parameters (can optionally include 'id').
         required: true
     delete:
       summary: Delete an existing drop
@@ -1171,16 +1309,19 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of drop to delete.
+          description: |-
+            ID of drop to delete.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '204':
-          description: Delete successful.
+          description: |-
+            Delete successful.
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -1188,13 +1329,15 @@ paths:
   /drops/locations:
     get:
       summary: Returns an array of locations for all active drops that the user has access to.
-      description: For example, you can use this to draw markers on map.
+      description: |-
+        For example, you can use this to draw markers on map.
       operationId: findDropLocations
       tags:
         - drop
       responses:
         '200':
-          description: Drop locations response.
+          description: |-
+            Drop locations response.
           content:
             application/json:
               schema:
@@ -1202,7 +1345,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/location'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -1216,13 +1360,15 @@ paths:
       parameters:
         - name: active
           in: query
-          description: Only return (in)active memberships.
+          description: |-
+            Only return (in)active memberships.
           required: false
           schema:
             type: boolean
         - name: drop
           in: query
-          description: Drop IDs to filter by.
+          description: |-
+            Drop IDs to filter by.
           required: false
           style: form
           schema:
@@ -1232,7 +1378,8 @@ paths:
               format: int64
         - name: filter-person
           in: query
-          description: Person IDs to filter by.
+          description: |-
+            Person IDs to filter by.
           required: false
           style: form
           schema:
@@ -1242,13 +1389,15 @@ paths:
               format: int64
         - name: pending
           in: query
-          description: Only return pending (true) or accepted (false) memberships.
+          description: |-
+            Only return pending (true) or accepted (false) memberships.
           required: false
           schema:
             type: boolean
         - name: inline
           in: query
-          description: For convenience, include a full representation of the inlined property. Currently supports "customer", "customer.email", "drop", and "gratitude-total".
+          description: |-
+            For convenience, include a full representation of the inlined property. Currently supports "customer", "customer.email", "drop", and "gratitude-total".
           required: false
           style: form
           schema:
@@ -1264,24 +1413,28 @@ paths:
             type: string
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: Drop membership response.
+          description: |-
+            Drop membership response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -1293,7 +1446,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/dropMembership'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -1305,13 +1459,15 @@ paths:
         - drop-membership
       responses:
         '200':
-          description: Drop membership response.
+          description: |-
+            Drop membership response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/dropMembership'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -1321,7 +1477,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/newDropMembership'
-        description: Drop membership to add.
+        description: |-
+          Drop membership to add.
         required: true
   '/drop-membership/{id}':
     get:
@@ -1332,14 +1489,16 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of drop membership to fetch.
+          description: |-
+            ID of drop membership to fetch.
           required: true
           schema:
             type: integer
             format: int64
         - name: inline
           in: query
-          description: For convenience, include a full representation of the inlined property. Currently supports "customer", "drop", and "gratitude-total".
+          description: |-
+            For convenience, include a full representation of the inlined property. Currently supports "customer", "drop", and "gratitude-total".
           required: false
           style: form
           schema:
@@ -1348,13 +1507,15 @@ paths:
               type: string
       responses:
         '200':
-          description: Drop membership response.
+          description: |-
+            Drop membership response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/dropMembership'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -1367,20 +1528,23 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of drop membership to update.
+          description: |-
+            ID of drop membership to update.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: Drop membership response.
+          description: |-
+            Drop membership response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/dropMembership'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -1390,7 +1554,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updateDropMembership'
-        description: Updated drop membership parameters.
+        description: |-
+          Updated drop membership parameters.
         required: true
     delete:
       summary: Delete an existing drop membership
@@ -1400,16 +1565,19 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of drop membership to delete.
+          description: |-
+            ID of drop membership to delete.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '204':
-          description: Delete successful.
+          description: |-
+            Delete successful.
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -1423,24 +1591,28 @@ paths:
       parameters:
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: File response.
+          description: |-
+            File response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you didn't set `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you didn't set `limit`).
               schema:
                 type: integer
                 format: int32
@@ -1452,7 +1624,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/file'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -1464,13 +1637,15 @@ paths:
         - file
       responses:
         '200':
-          description: File response.
+          description: |-
+            File response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/file'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -1480,7 +1655,8 @@ paths:
           application/json:
             schema:
               type: string
-        description: File to add. The payload is the raw content, not a JSON object.
+        description: |-
+          File to add. The payload is the raw content, not a JSON object.
   '/file/{id}':
     delete:
       summary: Delete an existing file
@@ -1492,15 +1668,18 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of the file to delete.
+          description: |-
+            ID of the file to delete.
           required: true
           schema:
             type: string
       responses:
         '204':
-          description: Delete successful.
+          description: |-
+            Delete successful.
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -1514,13 +1693,15 @@ paths:
       parameters:
         - name: active
           in: query
-          description: Only return (in)active pickups.
+          description: |-
+            Only return (in)active pickups.
           required: false
           schema:
             type: boolean
         - name: route
           in: query
-          description: Route names to filter by.
+          description: |-
+            Route names to filter by.
           required: false
           style: form
           schema:
@@ -1529,7 +1710,8 @@ paths:
               type: string
         - name: trip
           in: query
-          description: Trip IDs to filter by.
+          description: |-
+            Trip IDs to filter by.
           required: false
           style: form
           schema:
@@ -1539,7 +1721,8 @@ paths:
               format: int64
         - name: vendor
           in: query
-          description: Vendor IDs to filter by.
+          description: |-
+            Vendor IDs to filter by.
           required: false
           style: form
           schema:
@@ -1549,24 +1732,28 @@ paths:
               format: int64
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: Pickup response.
+          description: |-
+            Pickup response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you didn't set `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you didn't set `limit`).
               schema:
                 type: integer
                 format: int32
@@ -1578,7 +1765,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/pickup'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -1592,20 +1780,23 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of pickup to fetch.
+          description: |-
+            ID of pickup to fetch.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: Pickup response.
+          description: |-
+            Pickup response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/pickup'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -1619,7 +1810,8 @@ paths:
       parameters:
         - name: drop
           in: query
-          description: Drop IDs to filter by.
+          description: |-
+            Drop IDs to filter by.
           required: false
           style: form
           schema:
@@ -1629,24 +1821,28 @@ paths:
               format: int64
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: Route response.
+          description: |-
+            Route response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -1658,7 +1854,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/route'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -1670,13 +1867,15 @@ paths:
         - route
       responses:
         '200':
-          description: Route response.
+          description: |-
+            Route response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/route'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -1686,7 +1885,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/newRoute'
-        description: Route to add.
+        description: |-
+          Route to add.
         required: true
   '/route/{name}':
     get:
@@ -1697,19 +1897,22 @@ paths:
       parameters:
         - name: name
           in: path
-          description: Name of route to fetch.
+          description: |-
+            Name of route to fetch.
           required: true
           schema:
             type: string
       responses:
         '200':
-          description: Route response.
+          description: |-
+            Route response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/route'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -1722,19 +1925,22 @@ paths:
       parameters:
         - name: name
           in: path
-          description: Name of route to update.
+          description: |-
+            Name of route to update.
           required: true
           schema:
             type: string
       responses:
         '200':
-          description: Route response.
+          description: |-
+            Route response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/route'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -1744,7 +1950,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updateRoute'
-        description: Update route parameters.
+        description: |-
+          Update route parameters.
         required: true
     delete:
       summary: Delete an existing route
@@ -1754,15 +1961,18 @@ paths:
       parameters:
         - name: name
           in: path
-          description: Name of route to delete.
+          description: |-
+            Name of route to delete.
           required: true
           schema:
             type: string
       responses:
         '204':
-          description: Delete successful.
+          description: |-
+            Delete successful.
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -1770,14 +1980,16 @@ paths:
   /trips:
     get:
       summary: Returns all trips from the system that the user has access to
-      description: Trips are ordered for decreasing cutoff time.
+      description: |-
+        Trips are ordered for decreasing cutoff time.
       operationId: findTrips
       tags:
         - trip
       parameters:
         - name: route
           in: query
-          description: Route names to filter by.
+          description: |-
+            Route names to filter by.
           required: false
           style: form
           schema:
@@ -1786,7 +1998,8 @@ paths:
               type: string
         - name: drop
           in: query
-          description: Drop IDs to filter by.
+          description: |-
+            Drop IDs to filter by.
           required: false
           style: form
           schema:
@@ -1796,7 +2009,8 @@ paths:
               format: int64
         - name: stop
           in: query
-          description: Stop IDs to filter by.
+          description: |-
+            Stop IDs to filter by.
           required: false
           style: form
           schema:
@@ -1806,44 +2020,51 @@ paths:
               format: int64
         - name: cutoff-after
           in: query
-          description: Only return trips with cutoffs after or on this date.
+          description: |-
+            Only return trips with cutoffs after or on this date.
           required: false
           schema:
             type: string
             format: date-time
         - name: cutoff-before
           in: query
-          description: Only return trips with cutoffs before this date.
+          description: |-
+            Only return trips with cutoffs before this date.
           required: false
           schema:
             type: string
             format: date-time
         - name: confirmed
           in: query
-          description: Only return (un)confirmed trips.
+          description: |-
+            Only return (un)confirmed trips.
           required: false
           schema:
             type: boolean
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: Trip response.
+          description: |-
+            Trip response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -1855,7 +2076,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/trip'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -1867,13 +2089,15 @@ paths:
         - trip
       responses:
         '200':
-          description: Trip response.
+          description: |-
+            Trip response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/trip'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -1883,7 +2107,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updateTrip'
-        description: Trip to create.
+        description: |-
+          Trip to create.
         required: true
   '/trip/{id}':
     get:
@@ -1894,20 +2119,23 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of trip to fetch.
+          description: |-
+            ID of trip to fetch.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: Trip response.
+          description: |-
+            Trip response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/trip'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -1920,20 +2148,23 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of trip to update.
+          description: |-
+            ID of trip to update.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: Trip response.
+          description: |-
+            Trip response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/trip'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -1943,7 +2174,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updateTrip'
-        description: Trip to update.
+        description: |-
+          Trip to update.
         required: true
     delete:
       summary: Deletes a trip for a route, if the user has permissions
@@ -1953,16 +2185,19 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of trip to delete.
+          description: |-
+            ID of trip to delete.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '204':
-          description: Delete successful.
+          description: |-
+            Delete successful.
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -1970,14 +2205,16 @@ paths:
   /route-stops:
     get:
       summary: Returns all route-stops from the system that the user has access to
-      description: Route-stops are ordered for increasing offset from the route's trip cutoff.
+      description: |-
+        Route-stops are ordered for increasing offset from the route's trip cutoff.
       operationId: findRouteStops
       tags:
         - stop
       parameters:
         - name: route
           in: query
-          description: Route names to filter by.
+          description: |-
+            Route names to filter by.
           required: false
           style: form
           schema:
@@ -1986,7 +2223,8 @@ paths:
               type: string
         - name: drop
           in: query
-          description: Drop IDs to filter by.
+          description: |-
+            Drop IDs to filter by.
           required: false
           style: form
           schema:
@@ -1996,24 +2234,28 @@ paths:
               format: int64
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: Route-stop response.
+          description: |-
+            Route-stop response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -2025,7 +2267,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/routeStop'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -2039,20 +2282,23 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of route-stop to fetch.
+          description: |-
+            ID of route-stop to fetch.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: Route-stop response.
+          description: |-
+            Route-stop response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/routeStop'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -2060,14 +2306,16 @@ paths:
   /stops:
     get:
       summary: Returns all stops from the system that the user has access to
-      description: Stops are ordered for decreasing target time.
+      description: |-
+        Stops are ordered for decreasing target time.
       operationId: findStops
       tags:
         - stop
       parameters:
         - name: route
           in: query
-          description: Route names to filter by.
+          description: |-
+            Route names to filter by.
           required: false
           style: form
           schema:
@@ -2076,7 +2324,8 @@ paths:
               type: string
         - name: trip
           in: query
-          description: Trip IDs names to filter by.
+          description: |-
+            Trip IDs names to filter by.
           required: false
           style: form
           schema:
@@ -2086,7 +2335,8 @@ paths:
               format: int64
         - name: drop
           in: query
-          description: Drop IDs to filter by.
+          description: |-
+            Drop IDs to filter by.
           required: false
           style: form
           schema:
@@ -2096,7 +2346,8 @@ paths:
               format: int64
         - name: pickup
           in: query
-          description: Pickup IDs to filter by.
+          description: |-
+            Pickup IDs to filter by.
           required: false
           style: form
           schema:
@@ -2106,44 +2357,51 @@ paths:
               format: int64
         - name: estimatedDeliveryAfter
           in: query
-          description: Only return stops with an estimated time after or on this date.
+          description: |-
+            Only return stops with an estimated time after or on this date.
           required: false
           schema:
             type: string
             format: date-time
         - name: estimatedDeliveryBefore
           in: query
-          description: Only return stops with an estimated time before this date.
+          description: |-
+            Only return stops with an estimated time before this date.
           required: false
           schema:
             type: string
             format: date-time
         - name: short-drop
           in: query
-          description: Only return stops which have (not) had short-drop warnings sent.
+          description: |-
+            Only return stops which have (not) had short-drop warnings sent.
           required: false
           schema:
             type: boolean
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: Stop response.
+          description: |-
+            Stop response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -2155,7 +2413,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/stop'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -2168,19 +2427,22 @@ paths:
       parameters:
         - name: persist
           in: query
-          description: If true, calculate the offset between the trips's delivery start and this stop's estimated time. For any pre-cutoff trips associated with this stop's trip's route which cutoff later than this stop's trip, create a stop for this location (drop or pickup) if it does not already exist and update that stop's target and estimated times to have the same offset from that stops's trip's delivery start. Also create a route-stop association, if it does not already exist, for this location on this stop's trip's route and update that route-stop with the same delivery offset. API users should always pass  `persist=true` if there are estimated delivery changes. For finalized and/or  actual delivery changes, passing `persist=true` will not actually persist them but will slow down the response.
+          description: |-
+            If true, calculate the offset between the trips's delivery start and this stop's estimated time. For any pre-cutoff trips associated with this stop's trip's route which cutoff later than this stop's trip, create a stop for this location (drop or pickup) if it does not already exist and update that stop's target and estimated times to have the same offset from that stops's trip's delivery start. Also create a route-stop association, if it does not already exist, for this location on this stop's trip's route and update that route-stop with the same delivery offset. API users should always pass  `persist=true` if there are estimated delivery changes. For finalized and/or  actual delivery changes, passing `persist=true` will not actually persist them but will slow down the response.
           required: false
           schema:
             type: boolean
       responses:
         '200':
-          description: Stop response.
+          description: |-
+            Stop response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/stop'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -2190,7 +2452,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updateStop'
-        description: Stop to add.
+        description: |-
+          Stop to add.
         required: true
   '/stop/{id}':
     get:
@@ -2201,20 +2464,23 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of stop to fetch.
+          description: |-
+            ID of stop to fetch.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: Stop response.
+          description: |-
+            Stop response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/stop'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -2227,32 +2493,37 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of stop to update.
+          description: |-
+            ID of stop to update.
           required: true
           schema:
             type: integer
             format: int64
         - name: persist
           in: query
-          description: If true, calculate the offset between the trips's delivery start and this stop's estimated time. For any pre-cutoff trips associated with this stop's trip's route which cutoff later than this stop's trip, create a stop for this location (drop or pickup) if it does not already exist and update that stop's target and estimated times to have the same offset from that stops's trip's delivery start. Also create a route-stop association, if it does not already exist, for this location on this stop's trip's route and update that route-stop with the same delivery offset. If propagate is set, apply the persistance logic to the later stops on the trip as well. API users  should always pass `persist=true` if there are estimated delivery changes. For  finalized and/or actual delivery changes, passing `persist=true` will not actually  persist them but will slow down the response.
+          description: |-
+            If true, calculate the offset between the trips's delivery start and this stop's estimated time. For any pre-cutoff trips associated with this stop's trip's route which cutoff later than this stop's trip, create a stop for this location (drop or pickup) if it does not already exist and update that stop's target and estimated times to have the same offset from that stops's trip's delivery start. Also create a route-stop association, if it does not already exist, for this location on this stop's trip's route and update that route-stop with the same delivery offset. If propagate is set, apply the persistance logic to the later stops on the trip as well. API users  should always pass `persist=true` if there are estimated delivery changes. For  finalized and/or actual delivery changes, passing `persist=true` will not actually  persist them but will slow down the response.
           required: false
           schema:
             type: boolean
         - name: propagate
           in: query
-          description: If true, calculate the change from the existing estimated time. Shift the estimated time of all later stops on the trip by the same amount. For pre-cutoff trips, also shift the target times.
+          description: |-
+            If true, calculate the change from the existing estimated time. Shift the estimated time of all later stops on the trip by the same amount. For pre-cutoff trips, also shift the target times.
           required: false
           schema:
             type: boolean
       responses:
         '200':
-          description: Stop response.
+          description: |-
+            Stop response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/stop'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -2262,7 +2533,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updateStop'
-        description: Stop to update.
+        description: |-
+          Stop to update.
         required: true
     delete:
       summary: Delete an existing stop
@@ -2272,22 +2544,26 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of stop to delete.
+          description: |-
+            ID of stop to delete.
           required: true
           schema:
             type: integer
             format: int64
         - name: persist
           in: query
-          description: If true, for any pre-cutoff trips associated with this stop's trip's route which cutoff later than this stop's trip, delete any stops for this location (drop or pickup). Also delete any route-stop associations for this location on this stop's trip's route.
+          description: |-
+            If true, for any pre-cutoff trips associated with this stop's trip's route which cutoff later than this stop's trip, delete any stops for this location (drop or pickup). Also delete any route-stop associations for this location on this stop's trip's route.
           required: false
           schema:
             type: boolean
       responses:
         '204':
-          description: Delete successful.
+          description: |-
+            Delete successful.
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -2302,42 +2578,49 @@ paths:
       parameters:
         - name: audited
           in: query
-          description: Filter for products that have or haven't been audited. When set, only products that contain (un)audited packaging are returned, and their packaging array only contains (un)audited packaging.
+          description: |-
+            Filter for products that have or haven't been audited. When set, only products that contain (un)audited packaging are returned, and their packaging array only contains (un)audited packaging.
           required: false
           schema:
             type: string
         - name: search
           in: query
-          description: Search string for filtering products. The logic behind this is left up to the implementation, but it should at least match words in the product name, and may optionally match the product description or other characteristics.
+          description: |-
+            Search string for filtering products. The logic behind this is left up to the implementation, but it should at least match words in the product name, and may optionally match the product description or other characteristics.
           required: false
           schema:
             type: string
         - name: packaged-product
           in: query
-          description: Packaged-product codes to filter by.
+          description: |-
+            Packaged-product codes to filter by.
           required: false
           schema:
             type: string
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: Product audit response.
+          description: |-
+            Product audit response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -2349,7 +2632,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/productAudit'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -2364,25 +2648,29 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of product to fetch.
+          description: |-
+            ID of product to fetch.
           required: true
           schema:
             type: string
         - name: audited
           in: query
-          description: When set, the packaging array only contains (un)audited packaging.
+          description: |-
+            When set, the packaging array only contains (un)audited packaging.
           required: false
           schema:
             type: string
       responses:
         '200':
-          description: Product audit response.
+          description: |-
+            Product audit response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/productAudit'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -2397,20 +2685,23 @@ paths:
       parameters:
         - name: id
           in: path
-          description: Id of packaged product being audited.
+          description: |-
+            Id of packaged product being audited.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: Packaged-product audit response.
+          description: |-
+            Packaged-product audit response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/packagedProductAudit'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -2420,7 +2711,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updatePackagedProductAudit'
-        description: Packaged product to update.
+        description: |-
+          Packaged product to update.
         required: true
   /products:
     get:
@@ -2431,13 +2723,15 @@ paths:
       parameters:
         - name: search
           in: query
-          description: Search string for filtering products. The logic behind this is left up to the implementation, but it should at least match words in the product name, and may optionally match the product description or other characteristics.
+          description: |-
+            Search string for filtering products. The logic behind this is left up to the implementation, but it should at least match words in the product name, and may optionally match the product description or other characteristics.
           required: false
           schema:
             type: string
         - name: gtin13
           in: query
-          description: Packaged-product 13-digit Global Trade Item Numbers to filter by.
+          description: |-
+            Packaged-product 13-digit Global Trade Item Numbers to filter by.
           required: false
           style: form
           schema:
@@ -2447,7 +2741,8 @@ paths:
               format: int64
         - name: brand
           in: query
-          description: Brand IDs to filter by.
+          description: |-
+            Brand IDs to filter by.
           required: false
           style: form
           schema:
@@ -2457,7 +2752,8 @@ paths:
               format: int64
         - name: category
           in: query
-          description: Category IDs to filter by (for products directly associated with the categories).
+          description: |-
+            Category IDs to filter by (for products directly associated with the categories).
           required: false
           style: form
           schema:
@@ -2467,7 +2763,8 @@ paths:
               format: int64
         - name: primary-category
           in: query
-          description: Primary-category IDs to filter by (for products directly associated with the categories).
+          description: |-
+            Primary-category IDs to filter by (for products directly associated with the categories).
           required: false
           style: form
           schema:
@@ -2477,7 +2774,8 @@ paths:
               format: int64
         - name: ancestor-category
           in: query
-          description: Category IDs to filter by (for products associated with the categories or their descendants).
+          description: |-
+            Category IDs to filter by (for products associated with the categories or their descendants).
           required: false
           style: form
           schema:
@@ -2487,7 +2785,8 @@ paths:
               format: int64
         - name: packaged-product
           in: query
-          description: Packaged product codes to filter by.
+          description: |-
+            Packaged product codes to filter by.
           required: false
           style: form
           schema:
@@ -2496,7 +2795,8 @@ paths:
               type: string
         - name: tag
           in: query
-          description: Tags to filter by.
+          description: |-
+            Tags to filter by.
           required: false
           style: form
           schema:
@@ -2505,7 +2805,8 @@ paths:
               type: string
         - name: filter-person
           in: query
-          description: Person IDs to filter by (selects their favorite products).
+          description: |-
+            Person IDs to filter by (selects their favorite products).
           required: false
           style: form
           schema:
@@ -2515,14 +2816,16 @@ paths:
               format: int64
         - name: annotate-person
           in: query
-          description: Person ID for associating additional metadata with results (e.g. whether this person has favorited a given packaged-product). If unset and you're authenticated, defaults to your authenticated ID.
+          description: |-
+            Person ID for associating additional metadata with results (e.g. whether this person has favorited a given packaged-product). If unset and you're authenticated, defaults to your authenticated ID.
           required: false
           schema:
             type: integer
             format: int64
         - name: inline
           in: query
-          description: For convenience, include a full representation of the inlined property. Currently supports the local "description", "favorites", and "substitutions" as well as "brand", "packaging", "vendors", and descendants.
+          description: |-
+            For convenience, include a full representation of the inlined property. Currently supports the local "description", "favorites", and "substitutions" as well as "brand", "packaging", "vendors", and descendants.
           required: false
           style: form
           schema:
@@ -2531,24 +2834,28 @@ paths:
               type: string
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: Product response.
+          description: |-
+            Product response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -2560,7 +2867,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/product'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -2574,13 +2882,15 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of product to fetch.
+          description: |-
+            ID of product to fetch.
           required: true
           schema:
             type: string
         - name: inline
           in: query
-          description: For convenience, include a full representation of the inlined property. Currently supports the local "description", "favorites", and "substitutions" as well as "brand", "packaging", "vendors", and descendants.
+          description: |-
+            For convenience, include a full representation of the inlined property. Currently supports the local "description", "favorites", and "substitutions" as well as "brand", "packaging", "vendors", and descendants.
           required: false
           style: form
           schema:
@@ -2589,13 +2899,15 @@ paths:
               type: string
       responses:
         '200':
-          description: Product response.
+          description: |-
+            Product response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/product'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -2609,7 +2921,8 @@ paths:
       parameters:
         - name: product
           in: query
-          description: Product IDs to filter by.
+          description: |-
+            Product IDs to filter by.
           required: false
           style: form
           schema:
@@ -2619,7 +2932,8 @@ paths:
               format: int64
         - name: code
           in: query
-          description: Packaged product codes to filter by.
+          description: |-
+            Packaged product codes to filter by.
           required: false
           style: form
           schema:
@@ -2628,7 +2942,8 @@ paths:
               type: string
         - name: gtin13
           in: query
-          description: 13-digit Global Trade Item Numbers to filter by.
+          description: |-
+            13-digit Global Trade Item Numbers to filter by.
           required: false
           style: form
           schema:
@@ -2638,7 +2953,8 @@ paths:
               format: int64
         - name: brand
           in: query
-          description: Brand IDs to filter by.
+          description: |-
+            Brand IDs to filter by.
           required: false
           style: form
           schema:
@@ -2648,7 +2964,8 @@ paths:
               format: int64
         - name: category
           in: query
-          description: Category IDs to filter by (for products directly associated with the categories).
+          description: |-
+            Category IDs to filter by (for products directly associated with the categories).
           required: false
           style: form
           schema:
@@ -2658,7 +2975,8 @@ paths:
               format: int64
         - name: primary-category
           in: query
-          description: Primary-category IDs to filter by (for products directly associated with the categories).
+          description: |-
+            Primary-category IDs to filter by (for products directly associated with the categories).
           required: false
           style: form
           schema:
@@ -2668,7 +2986,8 @@ paths:
               format: int64
         - name: ancestor-category
           in: query
-          description: Category IDs to filter by (for packaged products associated with the categories or their descendants).
+          description: |-
+            Category IDs to filter by (for packaged products associated with the categories or their descendants).
           required: false
           style: form
           schema:
@@ -2678,7 +2997,8 @@ paths:
               format: int64
         - name: tag
           in: query
-          description: Tags to filter by.
+          description: |-
+            Tags to filter by.
           required: false
           style: form
           schema:
@@ -2687,7 +3007,8 @@ paths:
               type: string
         - name: filter-person
           in: query
-          description: Person IDs to filter by (selects their favorite packaged products).
+          description: |-
+            Person IDs to filter by (selects their favorite packaged products).
           required: false
           style: form
           schema:
@@ -2697,14 +3018,16 @@ paths:
               format: int64
         - name: annotate-person
           in: query
-          description: Person ID for associating additional metadata with results (e.g. whether this person has favorited a given packaged-product). If unset and you're authenticated, defaults to your authenticated ID.
+          description: |-
+            Person ID for associating additional metadata with results (e.g. whether this person has favorited a given packaged-product). If unset and you're authenticated, defaults to your authenticated ID.
           required: false
           schema:
             type: integer
             format: int64
         - name: inline
           in: query
-          description: For convenience, include a full representation of the inlined property. Currently supports the local "favorites", "next-purchase-arrival", and "quantity-on-next-purchase" as well as "image", "product", "vendors", and descendants.
+          description: |-
+            For convenience, include a full representation of the inlined property. Currently supports the local "favorites", "next-purchase-arrival", and "quantity-on-next-purchase" as well as "image", "product", "vendors", and descendants.
           required: false
           style: form
           schema:
@@ -2713,24 +3036,28 @@ paths:
               type: string
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: Packaged product response.
+          description: |-
+            Packaged product response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -2742,7 +3069,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/packagedProduct'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -2756,13 +3084,15 @@ paths:
       parameters:
         - name: code
           in: path
-          description: Code of the packaged product to fetch.
+          description: |-
+            Code of the packaged product to fetch.
           required: true
           schema:
             type: string
         - name: inline
           in: query
-          description: For convenience, include a full representation of the inlined property. Currently supports the local "favorites", "next-purchase-arrival", and "quantity-on-next-purchase" as well as "image", "product", "vendors", and descendants.
+          description: |-
+            For convenience, include a full representation of the inlined property. Currently supports the local "favorites", "next-purchase-arrival", and "quantity-on-next-purchase" as well as "image", "product", "vendors", and descendants.
           required: false
           style: form
           schema:
@@ -2771,13 +3101,15 @@ paths:
               type: string
       responses:
         '200':
-          description: Product response.
+          description: |-
+            Product response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/packagedProduct'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -2792,7 +3124,8 @@ paths:
       parameters:
         - name: packaged-product
           in: query
-          description: Packaged product codes to filter by.
+          description: |-
+            Packaged product codes to filter by.
           required: false
           style: form
           schema:
@@ -2801,24 +3134,28 @@ paths:
               type: string
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: Packaged product image response.
+          description: |-
+            Packaged product image response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -2830,7 +3167,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/packagedProductImage'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -2843,13 +3181,15 @@ paths:
         - product
       responses:
         '200':
-          description: Packaged product tag association response.
+          description: |-
+            Packaged product tag association response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/packagedProductImage'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -2859,7 +3199,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/packagedProductImage'
-        description: Packaged product image to add.
+        description: |-
+          Packaged product image to add.
         required: true
   '/packaged-product-image/{id}':
     get:
@@ -2871,19 +3212,22 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of packaged product image to fetch.
+          description: |-
+            ID of packaged product image to fetch.
           required: true
           schema:
             type: string
       responses:
         '200':
-          description: Packaged product image response.
+          description: |-
+            Packaged product image response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/packagedProductImage'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -2897,20 +3241,23 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of packaged product image to update.
+          description: |-
+            ID of packaged product image to update.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: Packaged product image response.
+          description: |-
+            Packaged product image response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/packagedProductImage'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -2920,7 +3267,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/packagedProductImage'
-        description: Packaged product image to update.
+        description: |-
+          Packaged product image to update.
         required: true
     delete:
       summary: Delete a packaged product image
@@ -2931,16 +3279,19 @@ paths:
       parameters:
         - name: id
           in: path
-          description: Packaged product image to delete.
+          description: |-
+            Packaged product image to delete.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '204':
-          description: Delete successful.
+          description: |-
+            Delete successful.
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -2954,13 +3305,15 @@ paths:
       parameters:
         - name: internal
           in: query
-          description: If true, only return internal tags (that the user has access to). If false, only return public tags (regardless of the user's access to internal tags). If unset, don't filter based on the tag visibility.
+          description: |-
+            If true, only return internal tags (that the user has access to). If false, only return public tags (regardless of the user's access to internal tags). If unset, don't filter based on the tag visibility.
           required: false
           schema:
             type: boolean
         - name: category
           in: query
-          description: Categories to filter by.
+          description: |-
+            Categories to filter by.
           required: false
           style: form
           schema:
@@ -2969,24 +3322,28 @@ paths:
               type: string
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: Packaged product tag response.
+          description: |-
+            Packaged product tag response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -2998,7 +3355,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/packagedProductTag'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -3012,31 +3370,36 @@ paths:
       parameters:
         - name: filter-person
           in: query
-          description: Person ID to filter by.
+          description: |-
+            Person ID to filter by.
           required: true
           schema:
             type: integer
             format: int64
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: Packaged product tag association response.
+          description: |-
+            Packaged product tag association response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -3048,7 +3411,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/packagedProductTagAssociation'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -3060,13 +3424,15 @@ paths:
         - packaged-product-tag
       responses:
         '200':
-          description: Packaged product tag association response.
+          description: |-
+            Packaged product tag association response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/packagedProductTagAssociation'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -3076,7 +3442,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/packagedProductTagAssociation'
-        description: Packaged-product tag association to add.
+        description: |-
+          Packaged-product tag association to add.
         required: true
   '/packaged-product-tag-association/{id}':
     delete:
@@ -3087,16 +3454,19 @@ paths:
       parameters:
         - name: id
           in: path
-          description: Packaged product tag association ID to delete.
+          description: |-
+            Packaged product tag association ID to delete.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '204':
-          description: Delete successful.
+          description: |-
+            Delete successful.
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -3111,7 +3481,8 @@ paths:
       parameters:
         - name: parent
           in: query
-          description: Category IDs to filter by.
+          description: |-
+            Category IDs to filter by.
           required: false
           style: form
           schema:
@@ -3121,13 +3492,15 @@ paths:
               format: int64
         - name: active
           in: query
-          description: Only return (in)active categories.
+          description: |-
+            Only return (in)active categories.
           required: false
           schema:
             type: boolean
         - name: product
           in: query
-          description: Product IDs to filter by.
+          description: |-
+            Product IDs to filter by.
           required: false
           style: form
           schema:
@@ -3137,7 +3510,8 @@ paths:
               format: int64
         - name: packaged-product
           in: query
-          description: Packaged product codes to filter by.
+          description: |-
+            Packaged product codes to filter by.
           required: false
           style: form
           schema:
@@ -3146,7 +3520,8 @@ paths:
               type: string
         - name: inline
           in: query
-          description: For convenience, include a full representation of the inlined property. Currently supports `ancestors` and `depth`.
+          description: |-
+            For convenience, include a full representation of the inlined property. Currently supports `ancestors` and `depth`.
           required: false
           style: form
           schema:
@@ -3155,24 +3530,28 @@ paths:
               type: string
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: Category response.
+          description: |-
+            Category response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -3184,7 +3563,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/category'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -3196,13 +3576,15 @@ paths:
         - category
       responses:
         '200':
-          description: Category response.
+          description: |-
+            Category response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/category'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -3212,7 +3594,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updateCategory'
-        description: Category to create.
+        description: |-
+          Category to create.
         required: true
   '/category/{id}':
     get:
@@ -3224,14 +3607,16 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of category to fetch.
+          description: |-
+            ID of category to fetch.
           required: true
           schema:
             type: integer
             format: int64
         - name: inline
           in: query
-          description: For convenience, include a full representation of the inlined property. Currently supports "ancestors" and "depth".
+          description: |-
+            For convenience, include a full representation of the inlined property. Currently supports "ancestors" and "depth".
           required: false
           style: form
           schema:
@@ -3240,13 +3625,15 @@ paths:
               type: string
       responses:
         '200':
-          description: Category response.
+          description: |-
+            Category response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/category'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -3259,20 +3646,23 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of category to update.
+          description: |-
+            ID of category to update.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: Category response.
+          description: |-
+            Category response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/category'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -3282,19 +3672,22 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updateCategory'
-        description: Category to update.
+        description: |-
+          Category to update.
         required: true
   /purchases:
     get:
       summary: Returns all purchases from the system that the user has access to
-      description: Purchases are ordered for increasing ID (creation time).
+      description: |-
+        Purchases are ordered for increasing ID (creation time).
       operationId: findPurchases
       tags:
         - purchase
       parameters:
         - name: vendor
           in: query
-          description: Vendor IDs to filter by.
+          description: |-
+            Vendor IDs to filter by.
           required: false
           style: form
           schema:
@@ -3304,7 +3697,8 @@ paths:
               format: int64
         - name: pickup
           in: query
-          description: Pickup IDs to filter by.
+          description: |-
+            Pickup IDs to filter by.
           required: false
           style: form
           schema:
@@ -3314,7 +3708,8 @@ paths:
               format: int64
         - name: trip
           in: query
-          description: Trip IDs to filter by.
+          description: |-
+            Trip IDs to filter by.
           required: false
           style: form
           schema:
@@ -3324,7 +3719,8 @@ paths:
               format: int64
         - name: status
           in: query
-          description: Purchase-status string to filter by.
+          description: |-
+            Purchase-status string to filter by.
           required: false
           style: form
           schema:
@@ -3341,24 +3737,28 @@ paths:
                 - paid
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: Purchase response.
+          description: |-
+            Purchase response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you didn't set `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you didn't set `limit`).
               schema:
                 type: integer
                 format: int32
@@ -3370,7 +3770,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/purchase'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -3384,20 +3785,23 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of purchase to fetch.
+          description: |-
+            ID of purchase to fetch.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: Purchase response.
+          description: |-
+            Purchase response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/purchase'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -3411,7 +3815,8 @@ paths:
       parameters:
         - name: username
           in: query
-          description: Usernames to filter by.
+          description: |-
+            Usernames to filter by.
           required: false
           style: form
           schema:
@@ -3420,7 +3825,8 @@ paths:
               type: string
         - name: email
           in: query
-          description: Email addresses to filter by.
+          description: |-
+            Email addresses to filter by.
           required: false
           style: form
           schema:
@@ -3430,7 +3836,8 @@ paths:
               format: email
         - name: drop
           in: query
-          description: Drop IDs to filter by.
+          description: |-
+            Drop IDs to filter by.
           required: false
           style: form
           schema:
@@ -3440,7 +3847,8 @@ paths:
               format: int64
         - name: trip
           in: query
-          description: Trip IDs to filter by.
+          description: |-
+            Trip IDs to filter by.
           required: false
           style: form
           schema:
@@ -3450,7 +3858,8 @@ paths:
               format: int64
         - name: product
           in: query
-          description: Product IDs to filter by.
+          description: |-
+            Product IDs to filter by.
           required: false
           style: form
           schema:
@@ -3460,7 +3869,8 @@ paths:
               format: int64
         - name: packaged-product
           in: query
-          description: Packaged product codes to filter by.
+          description: |-
+            Packaged product codes to filter by.
           required: false
           style: form
           schema:
@@ -3469,7 +3879,8 @@ paths:
               type: string
         - name: filter-person
           in: query
-          description: Person IDs to filter by.
+          description: |-
+            Person IDs to filter by.
           required: false
           style: form
           schema:
@@ -3479,7 +3890,8 @@ paths:
               format: int64
         - name: status
           in: query
-          description: Order-status string to filter by.
+          description: |-
+            Order-status string to filter by.
           required: false
           style: form
           schema:
@@ -3494,21 +3906,24 @@ paths:
                 - lost
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
         - name: inline
           in: query
-          description: For convenience, include a full representation of the inlined property. Currently supports "dropMembershipId".
+          description: |-
+            For convenience, include a full representation of the inlined property. Currently supports "dropMembershipId".
           required: false
           style: form
           schema:
@@ -3517,10 +3932,12 @@ paths:
               type: string
       responses:
         '200':
-          description: Order response.
+          description: |-
+            Order response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -3532,7 +3949,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/order'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -3544,13 +3962,15 @@ paths:
         - order
       responses:
         '200':
-          description: Order response.
+          description: |-
+            Order response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/order'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -3560,7 +3980,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updateOrder'
-        description: Order to add.
+        description: |-
+          Order to add.
         required: true
   '/order/{id}':
     get:
@@ -3571,20 +3992,23 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of order to fetch.
+          description: |-
+            ID of order to fetch.
           required: true
           schema:
             type: integer
             format: int64
         - name: accept
           in: query
-          description: Override the HTTP Accept header to chose the response type. Empty and unrecognized values will result in application/json.
+          description: |-
+            Override the HTTP Accept header to chose the response type. Empty and unrecognized values will result in application/json.
           required: false
           schema:
             type: string
         - name: inline
           in: query
-          description: For convenience, include a full representation of the inlined property. Currently supports "dropMembershipId".
+          description: |-
+            For convenience, include a full representation of the inlined property. Currently supports "dropMembershipId".
           required: false
           style: form
           schema:
@@ -3593,7 +4017,8 @@ paths:
               type: string
       responses:
         '200':
-          description: Order response.
+          description: |-
+            Order response.
           content:
             application/json:
               schema:
@@ -3605,7 +4030,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/order'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -3624,26 +4050,30 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of order to update.
+          description: |-
+            ID of order to update.
           required: true
           schema:
             type: integer
             format: int64
         - name: save
           in: query
-          description: Whether to save the result of the PUT or not (defaults to true). Set to false if you want to preview the side-effects of a change before going through with an update.
+          description: |-
+            Whether to save the result of the PUT or not (defaults to true). Set to false if you want to preview the side-effects of a change before going through with an update.
           required: false
           schema:
             type: boolean
       responses:
         '200':
-          description: Order response.
+          description: |-
+            Order response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/changedOrder'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -3653,7 +4083,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updateOrder'
-        description: Updated order parameters (can optionally include 'id').
+        description: |-
+          Updated order parameters (can optionally include 'id').
         required: true
     delete:
       summary: Delete an existing order
@@ -3663,16 +4094,19 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of order to delete.
+          description: |-
+            ID of order to delete.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '204':
-          description: Delete successful.
+          description: |-
+            Delete successful.
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -3686,7 +4120,8 @@ paths:
       parameters:
         - name: order
           in: query
-          description: Order IDs to filter by.
+          description: |-
+            Order IDs to filter by.
           required: false
           style: form
           schema:
@@ -3696,7 +4131,8 @@ paths:
               format: int64
         - name: product
           in: query
-          description: Product IDs to filter by.
+          description: |-
+            Product IDs to filter by.
           required: false
           style: form
           schema:
@@ -3706,7 +4142,8 @@ paths:
               format: int64
         - name: packaged-product
           in: query
-          description: Packaged product codes to filter by.
+          description: |-
+            Packaged product codes to filter by.
           required: false
           style: form
           schema:
@@ -3715,24 +4152,28 @@ paths:
               type: string
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: Order-line response.
+          description: |-
+            Order-line response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -3744,7 +4185,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/orderLine'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -3756,13 +4198,15 @@ paths:
         - order
       responses:
         '200':
-          description: Order-line response.
+          description: |-
+            Order-line response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/orderLine'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -3772,7 +4216,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updateOrderLine'
-        description: Order-line to add.
+        description: |-
+          Order-line to add.
         required: true
   '/order-line/{id}':
     get:
@@ -3783,20 +4228,23 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of order-line to fetch.
+          description: |-
+            ID of order-line to fetch.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: Order-line response.
+          description: |-
+            Order-line response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/orderLine'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -3809,20 +4257,23 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of order-line to update.
+          description: |-
+            ID of order-line to update.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: Order-line response.
+          description: |-
+            Order-line response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/orderLine'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -3832,7 +4283,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updateOrderLine'
-        description: Updated order-line parameters (can optionally include 'id').
+        description: |-
+          Updated order-line parameters (can optionally include 'id').
         required: true
     delete:
       summary: Delete an existing order-line
@@ -3842,16 +4294,19 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of order-line to delete.
+          description: |-
+            ID of order-line to delete.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '204':
-          description: Delete successful.
+          description: |-
+            Delete successful.
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -3865,7 +4320,8 @@ paths:
       parameters:
         - name: order
           in: query
-          description: Order IDs to filter by.
+          description: |-
+            Order IDs to filter by.
           required: false
           style: form
           schema:
@@ -3875,24 +4331,28 @@ paths:
               format: int64
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: Order fee response.
+          description: |-
+            Order fee response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -3904,7 +4364,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/orderFee'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -3918,20 +4379,23 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of order fee to fetch.
+          description: |-
+            ID of order fee to fetch.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: Order fee response.
+          description: |-
+            Order fee response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/orderFee'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -3946,14 +4410,16 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of order to retrieve parcel carrier options for.
+          description: |-
+            ID of order to retrieve parcel carrier options for.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: Order parcel carrier estimate response.
+          description: |-
+            Order parcel carrier estimate response.
           content:
             application/json:
               schema:
@@ -3961,7 +4427,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/orderParcelCarrierEstimate'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -3969,20 +4436,23 @@ paths:
   /vendors:
     get:
       summary: Returns all vendors from the system that the user has access to
-      description: Vendors are ordered for increasing ID (creation time).
+      description: |-
+        Vendors are ordered for increasing ID (creation time).
       operationId: findVendors
       tags:
         - vendor
       parameters:
         - name: active
           in: query
-          description: Only return (in)active vendors.
+          description: |-
+            Only return (in)active vendors.
           required: false
           schema:
             type: boolean
         - name: manager
           in: query
-          description: Person IDs to filter by, selecting vendors that these vendor employees manage.
+          description: |-
+            Person IDs to filter by, selecting vendors that these vendor employees manage.
           required: false
           style: form
           schema:
@@ -3992,7 +4462,8 @@ paths:
               format: int64
         - name: buyer
           in: query
-          description: Person IDs to filter by, selecting vendors that these Azure employees buy from.
+          description: |-
+            Person IDs to filter by, selecting vendors that these Azure employees buy from.
           required: false
           style: form
           schema:
@@ -4002,24 +4473,28 @@ paths:
               format: int64
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: Vendor response.
+          description: |-
+            Vendor response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you didn't set `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you didn't set `limit`).
               schema:
                 type: integer
                 format: int32
@@ -4031,7 +4506,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/vendor'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -4045,20 +4521,23 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of vendor to fetch.
+          description: |-
+            ID of vendor to fetch.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: Vendor response.
+          description: |-
+            Vendor response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/vendor'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -4066,14 +4545,16 @@ paths:
   /account-entries:
     get:
       summary: Returns all dollar credits and debits from the system that the user has access to. 
-      description: Results are ordered by increasing settled dates, falling back to IDs when multiple entries settled on the same day.
+      description: |-
+        Results are ordered by increasing settled dates, falling back to IDs when multiple entries settled on the same day.
       operationId: findAccountEntries
       tags:
         - account
       parameters:
         - name: filter-person
           in: query
-          description: Person IDs to filter by.
+          description: |-
+            Person IDs to filter by.
           required: false
           style: form
           schema:
@@ -4083,27 +4564,31 @@ paths:
               format: int64
         - name: date-after
           in: query
-          description: Only return entries with dates after this date (inclusive).
+          description: |-
+            Only return entries with dates after this date (inclusive).
           required: false
           schema:
             type: string
             format: date
         - name: date-before
           in: query
-          description: Only return entries with dates before this date (exclusive).
+          description: |-
+            Only return entries with dates before this date (exclusive).
           required: false
           schema:
             type: string
             format: date
         - name: balance
           in: query
-          description: Add the `balance` property to returned entries.
+          description: |-
+            Add the `balance` property to returned entries.
           required: false
           schema:
             type: boolean
         - name: reason
           in: query
-          description: The reason slugs to filter by.
+          description: |-
+            The reason slugs to filter by.
           required: false
           style: form
           schema:
@@ -4114,24 +4599,28 @@ paths:
                 - affiliate-referral
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: Account entry response.
+          description: |-
+            Account entry response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -4143,7 +4632,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/accountEntry'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -4157,20 +4647,23 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of account entry to fetch.
+          description: |-
+            ID of account entry to fetch.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: Account entry response.
+          description: |-
+            Account entry response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/accountEntry'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -4183,13 +4676,15 @@ paths:
         - payment
       responses:
         '200':
-          description: Account entry response.
+          description: |-
+            Account entry response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/accountEntry'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -4199,25 +4694,29 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/payment'
-        description: Payment to create. Amount and payment-method are both required.
+        description: |-
+          Payment to create. Amount and payment-method are both required.
         required: true
   /payment-methods:
     get:
       summary: Returns all payment methods from the system that the user has access to
-      description: Methods associated with a person are ordered by decreasing preference. The ordering between methods associated with different people is undefined.
+      description: |-
+        Methods associated with a person are ordered by decreasing preference. The ordering between methods associated with different people is undefined.
       operationId: findPayments
       tags:
         - payment
       parameters:
         - name: active
           in: query
-          description: Only return (in)active payment methods.
+          description: |-
+            Only return (in)active payment methods.
           required: false
           schema:
             type: boolean
         - name: filter-person
           in: query
-          description: Person IDs to filter by.
+          description: |-
+            Person IDs to filter by.
           required: false
           style: form
           schema:
@@ -4227,24 +4726,28 @@ paths:
               format: int64
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: Payment method response.
+          description: |-
+            Payment method response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -4256,7 +4759,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/paymentMethod'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -4268,13 +4772,15 @@ paths:
         - payment
       responses:
         '200':
-          description: Payment method response.
+          description: |-
+            Payment method response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/paymentMethod'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -4284,7 +4790,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/newPaymentMethod'
-        description: Payment method to add.
+        description: |-
+          Payment method to add.
         required: true
   '/payment-method/{id}':
     get:
@@ -4295,20 +4802,23 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of payment method to fetch.
+          description: |-
+            ID of payment method to fetch.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: Payment method response.
+          description: |-
+            Payment method response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/paymentMethod'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -4321,16 +4831,19 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of payment method to deactivate.
+          description: |-
+            ID of payment method to deactivate.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '204':
-          description: Deactivate successful.
+          description: |-
+            Deactivate successful.
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -4338,14 +4851,16 @@ paths:
   /rewards:
     get:
       summary: Returns all reward credits and debits from the system that the user has access to. 
-      description: Results are ordered by increasing settled times, falling back to ID for pending debits.
+      description: |-
+        Results are ordered by increasing settled times, falling back to ID for pending debits.
       operationId: findRewards
       tags:
         - account
       parameters:
         - name: filter-person
           in: query
-          description: Person IDs to filter by.
+          description: |-
+            Person IDs to filter by.
           required: false
           style: form
           schema:
@@ -4355,21 +4870,24 @@ paths:
               format: int64
         - name: date-after
           in: query
-          description: Only return entries with dates after this date (inclusive).
+          description: |-
+            Only return entries with dates after this date (inclusive).
           required: false
           schema:
             type: string
             format: date-time
         - name: date-before
           in: query
-          description: Only return entries with dates before this date (exclusive).
+          description: |-
+            Only return entries with dates before this date (exclusive).
           required: false
           schema:
             type: string
             format: date-time
         - name: status
           in: query
-          description: Reward status to filter by.
+          description: |-
+            Reward status to filter by.
           required: false
           style: form
           schema:
@@ -4381,7 +4899,8 @@ paths:
                 - settled
         - name: order
           in: query
-          description: Order IDs to filter by.
+          description: |-
+            Order IDs to filter by.
           required: false
           style: form
           schema:
@@ -4391,30 +4910,35 @@ paths:
               format: int64
         - name: totals
           in: query
-          description: Add the `total-credit`, `total-debit`, and `total-pending` properties to returned entries.
+          description: |-
+            Add the `total-credit`, `total-debit`, and `total-pending` properties to returned entries.
           required: false
           schema:
             type: boolean
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: Reward response.
+          description: |-
+            Reward response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -4426,7 +4950,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/reward'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -4440,20 +4965,23 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of reward to fetch.
+          description: |-
+            ID of reward to fetch.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: Reward response.
+          description: |-
+            Reward response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/reward'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -4461,14 +4989,16 @@ paths:
   /addresses:
     get:
       summary: Returns all addresses from the system that the user has access to
-      description: Addresses associated with a person are ordered by decreasing preference. The ordering between addresses associated with different people or (for the same person) with the same preference value is undefined.
+      description: |-
+        Addresses associated with a person are ordered by decreasing preference. The ordering between addresses associated with different people or (for the same person) with the same preference value is undefined.
       operationId: findAddresses
       tags:
         - address
       parameters:
         - name: filter-person
           in: query
-          description: Person IDs to filter by.
+          description: |-
+            Person IDs to filter by.
           required: false
           style: form
           schema:
@@ -4478,7 +5008,8 @@ paths:
               format: int64
         - name: inline
           in: query
-          description: For convenience, include a full representation of the inlined property. Currently supports "country", "person", and descendants.
+          description: |-
+            For convenience, include a full representation of the inlined property. Currently supports "country", "person", and descendants.
           required: false
           style: form
           schema:
@@ -4487,24 +5018,28 @@ paths:
               type: string
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: Address response.
+          description: |-
+            Address response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -4516,7 +5051,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/address'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -4529,7 +5065,8 @@ paths:
       parameters:
         - name: inline
           in: query
-          description: For convenience, include a full representation of the inlined property. Currently supports "country", "person", and descendants.
+          description: |-
+            For convenience, include a full representation of the inlined property. Currently supports "country", "person", and descendants.
           required: false
           style: form
           schema:
@@ -4538,13 +5075,15 @@ paths:
               type: string
       responses:
         '200':
-          description: Address response.
+          description: |-
+            Address response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/address'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -4554,7 +5093,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/address'
-        description: Address to add.
+        description: |-
+          Address to add.
         required: true
   '/address/{id}':
     get:
@@ -4565,14 +5105,16 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of address to fetch.
+          description: |-
+            ID of address to fetch.
           required: true
           schema:
             type: integer
             format: int64
         - name: inline
           in: query
-          description: For convenience, include a full representation of the inlined property. Currently supports "country", "person", and descendants.
+          description: |-
+            For convenience, include a full representation of the inlined property. Currently supports "country", "person", and descendants.
           required: false
           style: form
           schema:
@@ -4581,13 +5123,15 @@ paths:
               type: string
       responses:
         '200':
-          description: Address response.
+          description: |-
+            Address response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/address'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -4600,14 +5144,16 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of address to update.
+          description: |-
+            ID of address to update.
           required: true
           schema:
             type: integer
             format: int64
         - name: inline
           in: query
-          description: For convenience, include a full representation of the inlined property. Currently supports "country", "person", and descendants.
+          description: |-
+            For convenience, include a full representation of the inlined property. Currently supports "country", "person", and descendants.
           required: false
           style: form
           schema:
@@ -4616,13 +5162,15 @@ paths:
               type: string
       responses:
         '200':
-          description: Address response.
+          description: |-
+            Address response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/address'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -4632,7 +5180,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/address'
-        description: Address to update.
+        description: |-
+          Address to update.
         required: true
     delete:
       summary: Delete an existing address
@@ -4642,16 +5191,19 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of address to delete.
+          description: |-
+            ID of address to delete.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '204':
-          description: Delete successful.
+          description: |-
+            Delete successful.
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -4659,31 +5211,36 @@ paths:
   /countries:
     get:
       summary: Returns all countries from the system
-      description: Countries that are allowed to be used with addresses, ordered by name.
+      description: |-
+        Countries that are allowed to be used with addresses, ordered by name.
       operationId: findCountries
       tags:
         - country
       parameters:
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: Country response.
+          description: |-
+            Country response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -4695,7 +5252,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/country'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -4703,37 +5261,43 @@ paths:
   /regions:
     get:
       summary: Returns all country regions from the system
-      description: Regions that are allowed to be used with addresses in the United States and Canada, ordered alphabetically. Other countries may use any string values for their regions.
+      description: |-
+        Regions that are allowed to be used with addresses in the United States and Canada, ordered alphabetically. Other countries may use any string values for their regions.
       operationId: findRegions
       tags:
         - region
       parameters:
         - name: country
           in: query
-          description: Country to filter by.
+          description: |-
+            Country to filter by.
           required: false
           schema:
             type: string
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: Country region response.
+          description: |-
+            Country region response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -4745,7 +5309,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/region'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -4753,14 +5318,16 @@ paths:
   /emails:
     get:
       summary: Returns all emails from the system that the user has access to.
-      description: Emails associated with a person are ordered by decreasing preference. The ordering between emails associated with different people or (for the same person) with the same preference value is undefined.
+      description: |-
+        Emails associated with a person are ordered by decreasing preference. The ordering between emails associated with different people or (for the same person) with the same preference value is undefined.
       operationId: findEmails
       tags:
         - email
       parameters:
         - name: filter-person
           in: query
-          description: Person IDs to filter by.
+          description: |-
+            Person IDs to filter by.
           required: false
           style: form
           schema:
@@ -4770,24 +5337,28 @@ paths:
               format: int64
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: Email response.
+          description: |-
+            Email response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -4799,7 +5370,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/email'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -4811,13 +5383,15 @@ paths:
         - email
       responses:
         '200':
-          description: Email response.
+          description: |-
+            Email response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/email'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -4827,7 +5401,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updateEmailUserPassword'
-        description: Email to add.
+        description: |-
+          Email to add.
         required: true
   '/email/{id}':
     get:
@@ -4838,20 +5413,23 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of email to fetch.
+          description: |-
+            ID of email to fetch.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: Email response.
+          description: |-
+            Email response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/email'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -4864,20 +5442,23 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of email to update.
+          description: |-
+            ID of email to update.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: Email response.
+          description: |-
+            Email response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/email'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -4887,7 +5468,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updateEmailUserPassword'
-        description: Email to update.
+        description: |-
+          Email to update.
         required: true
     delete:
       summary: Delete an existing email
@@ -4897,16 +5479,19 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of email to delete.
+          description: |-
+            ID of email to delete.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '204':
-          description: Delete successful.
+          description: |-
+            Delete successful.
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -4920,7 +5505,8 @@ paths:
       parameters:
         - name: drop
           in: query
-          description: Drop IDs to filter by.
+          description: |-
+            Drop IDs to filter by.
           required: false
           style: form
           schema:
@@ -4930,7 +5516,8 @@ paths:
               format: int64
         - name: inline
           in: query
-          description: For convenience, include additional information. Currently supports "email" as described in the email model, "order-place-issue", and "is-drop-coordinator".
+          description: |-
+            For convenience, include additional information. Currently supports "email" as described in the email model, "order-place-issue", and "is-drop-coordinator".
           required: false
           style: form
           schema:
@@ -4939,24 +5526,28 @@ paths:
               type: string
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: Person response.
+          description: |-
+            Person response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -4968,7 +5559,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/person'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -4982,19 +5574,22 @@ paths:
       parameters:
         - name: marketing-slug
           in: path
-          description: Marketing slug of affiliate code to fetch.
+          description: |-
+            Marketing slug of affiliate code to fetch.
           required: true
           schema:
             type: string
       responses:
         '200':
-          description: Affiliate code response.
+          description: |-
+            Affiliate code response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/affiliateCode'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -5008,14 +5603,16 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of person to fetch.
+          description: |-
+            ID of person to fetch.
           required: true
           schema:
             type: integer
             format: int64
         - name: inline
           in: query
-          description: For convenience, include additional information. Currently supports "email" as described in the email model, "order-place-issue", and "is-drop-coordinator".
+          description: |-
+            For convenience, include additional information. Currently supports "email" as described in the email model, "order-place-issue", and "is-drop-coordinator".
           required: false
           style: form
           schema:
@@ -5024,13 +5621,15 @@ paths:
               type: string
       responses:
         '200':
-          description: Person response.
+          description: |-
+            Person response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/person'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -5043,20 +5642,23 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of person to update.
+          description: |-
+            ID of person to update.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: Person response.
+          description: |-
+            Person response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/person'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -5072,7 +5674,8 @@ paths:
       parameters:
         - name: inline
           in: query
-          description: For convenience, include additional information. Currently supports "email" as described in the email model and "order-place-issue".
+          description: |-
+            For convenience, include additional information. Currently supports "email" as described in the email model and "order-place-issue".
           required: false
           style: form
           schema:
@@ -5081,13 +5684,15 @@ paths:
               type: string
       responses:
         '200':
-          description: Person response.
+          description: |-
+            Person response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/person'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -5099,13 +5704,15 @@ paths:
         - person
       responses:
         '200':
-          description: Person response.
+          description: |-
+            Person response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/person'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -5122,13 +5729,15 @@ paths:
         - sessionCookie: []
       responses:
         '200':
-          description: Session response.
+          description: |-
+            Session response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/session'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -5141,13 +5750,15 @@ paths:
         - session
       responses:
         '200':
-          description: Session response.
+          description: |-
+            Session response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/session'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -5169,13 +5780,15 @@ paths:
         - sessionCookie: []
       responses:
         '200':
-          description: Session response.
+          description: |-
+            Session response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/session'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -5197,7 +5810,8 @@ paths:
       parameters:
         - name: inline
           in: query
-          description: For convenience, include a full representation of the inlined property. Currently supports "session.person" and descendants.
+          description: |-
+            For convenience, include a full representation of the inlined property. Currently supports "session.person" and descendants.
           required: false
           style: form
           schema:
@@ -5206,13 +5820,15 @@ paths:
               type: string
       responses:
         '200':
-          description: Registration request response.
+          description: |-
+            Registration request response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/registrationResponse'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -5231,12 +5847,14 @@ paths:
         - registration
       responses:
         '204':
-          description: Registration email re-sent.
+          description: |-
+            Registration email re-sent.
           content:
             application/json:
               schema: {}
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -5255,9 +5873,11 @@ paths:
         - password
       responses:
         '204':
-          description: Password-reset email sent (if the registration email corresponded to an existing person. Otherwise, you'll still get a 204 to avoid leaking information about member email addresses).
+          description: |-
+            Password-reset email sent (if the registration email corresponded to an existing person. Otherwise, you'll still get a 204 to avoid leaking information about member email addresses).
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -5276,13 +5896,15 @@ paths:
         - password
       responses:
         '200':
-          description: Person response.
+          description: |-
+            Person response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/person'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -5292,7 +5914,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/passwordResetConfirmation'
-        description: The registrant's confirmation token.
+        description: |-
+          The registrant's confirmation token.
         required: true
   /notifications:
     get:
@@ -5303,13 +5926,15 @@ paths:
       parameters:
         - name: active
           in: query
-          description: Only return (in)active notifications.
+          description: |-
+            Only return (in)active notifications.
           required: false
           schema:
             type: boolean
         - name: filter-person
           in: query
-          description: Person IDs to filter by.
+          description: |-
+            Person IDs to filter by.
           required: false
           style: form
           schema:
@@ -5319,23 +5944,27 @@ paths:
               format: int64
         - name: annotate-person
           in: query
-          description: Add a boolean dismissed field to the results with whether or not the annotate-person has dismissed this notification, required with dismissed.
+          description: |-
+            Add a boolean dismissed field to the results with whether or not the annotate-person has dismissed this notification, required with dismissed.
           required: false
           schema:
             type: integer
             format: int64
         - name: dismissed
           in: query
-          description: Only return notifications that are (not) dismissed by the annotate-person.
+          description: |-
+            Only return notifications that are (not) dismissed by the annotate-person.
           required: false
           schema:
             type: boolean
       responses:
         '200':
-          description: Notification response.
+          description: |-
+            Notification response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -5347,7 +5976,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/notification'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -5360,13 +5990,15 @@ paths:
         - notification
       responses:
         '200':
-          description: Notification dismissal response.
+          description: |-
+            Notification dismissal response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/notificationDismissal'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -5376,7 +6008,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/notificationDismissal'
-        description: Notification dismissal to add.
+        description: |-
+          Notification dismissal to add.
         required: true
   /favorites:
     get:
@@ -5387,7 +6020,8 @@ paths:
       parameters:
         - name: filter-person
           in: query
-          description: Person IDs to filter by.
+          description: |-
+            Person IDs to filter by.
           required: false
           style: form
           schema:
@@ -5397,13 +6031,15 @@ paths:
               format: int64
         - name: active
           in: query
-          description: Only return favorites associated with (in)active packaged products. For example, we sometimes discontinue products and then pick them back up later. In this context, "active" means "for sale to at least some customers".
+          description: |-
+            Only return favorites associated with (in)active packaged products. For example, we sometimes discontinue products and then pick them back up later. In this context, "active" means "for sale to at least some customers".
           required: false
           schema:
             type: boolean
         - name: inline
           in: query
-          description: For convenience, include a full representation of the inlined property. Currently supports "packaged-product" and descendants.
+          description: |-
+            For convenience, include a full representation of the inlined property. Currently supports "packaged-product" and descendants.
           required: false
           style: form
           schema:
@@ -5412,24 +6048,28 @@ paths:
               type: string
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: Array of favorites response.
+          description: |-
+            Array of favorites response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -5441,7 +6081,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/favorite'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -5453,13 +6094,15 @@ paths:
         - favorite
       responses:
         '200':
-          description: Favorite response.
+          description: |-
+            Favorite response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/favorite'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -5469,7 +6112,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updateFavorite'
-        description: Favorite to create.
+        description: |-
+          Favorite to create.
         required: true
   '/favorite/{id}':
     get:
@@ -5480,14 +6124,16 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of favorite to fetch.
+          description: |-
+            ID of favorite to fetch.
           required: true
           schema:
             type: integer
             format: int64
         - name: inline
           in: query
-          description: For convenience, include a full representation of the inlined property. Currently supports "packaged-product" and descendants.
+          description: |-
+            For convenience, include a full representation of the inlined property. Currently supports "packaged-product" and descendants.
           required: false
           style: form
           schema:
@@ -5496,13 +6142,15 @@ paths:
               type: string
       responses:
         '200':
-          description: Favorite response.
+          description: |-
+            Favorite response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/favorite'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -5515,20 +6163,23 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of favorite to update.
+          description: |-
+            ID of favorite to update.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: Favorite response.
+          description: |-
+            Favorite response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/favorite'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -5538,7 +6189,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updateFavorite'
-        description: Favorite to update.
+        description: |-
+          Favorite to update.
         required: true
     delete:
       summary: Deletes a customer favorite
@@ -5548,16 +6200,19 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of favorite to update.
+          description: |-
+            ID of favorite to update.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '204':
-          description: Delete successful.
+          description: |-
+            Delete successful.
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -5571,21 +6226,24 @@ paths:
       parameters:
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: Array of faq response.
+          description: |-
+            Array of faq response.
           content:
             application/json:
               schema:
@@ -5593,7 +6251,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/faq'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -5605,13 +6264,15 @@ paths:
         - faq
       responses:
         '200':
-          description: Faq response.
+          description: |-
+            Faq response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/faq'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -5621,7 +6282,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updateFaq'
-        description: Faq to create.
+        description: |-
+          Faq to create.
         required: true
   '/faq/{id}':
     get:
@@ -5632,20 +6294,23 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of faq to fetch.
+          description: |-
+            ID of faq to fetch.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: Faq response.
+          description: |-
+            Faq response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/faq'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -5658,20 +6323,23 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of faq to update.
+          description: |-
+            ID of faq to update.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: Faq response.
+          description: |-
+            Faq response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/faq'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -5681,7 +6349,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updateFaq'
-        description: Faq to update.
+        description: |-
+          Faq to update.
         required: true
     delete:
       summary: Deletes a faq
@@ -5691,16 +6360,19 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of faq to delete.
+          description: |-
+            ID of faq to delete.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '204':
-          description: Delete successful.
+          description: |-
+            Delete successful.
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -5714,7 +6386,8 @@ paths:
       parameters:
         - name: delivery
           in: query
-          description: Printer delivery method.
+          description: |-
+            Printer delivery method.
           required: false
           style: form
           schema:
@@ -5727,7 +6400,8 @@ paths:
                 - bartender
         - name: format
           in: query
-          description: Printer format.
+          description: |-
+            Printer format.
           required: false
           style: form
           schema:
@@ -5740,24 +6414,28 @@ paths:
                 - bartender
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: Printer response.
+          description: |-
+            Printer response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -5769,7 +6447,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/printer'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -5783,20 +6462,23 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of printer to fetch.
+          description: |-
+            ID of printer to fetch.
           required: true
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: Printer response.
+          description: |-
+            Printer response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/printer'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -5810,24 +6492,28 @@ paths:
       parameters:
         - name: limit
           in: query
-          description: Maximum number of results to return.
+          description: |-
+            Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: |-
+            Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: Warehouse response.
+          description: |-
+            Warehouse response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
+              description: |-
+                Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -5839,7 +6525,8 @@ paths:
                 items:
                   $ref: '#/components/schemas/warehouse'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -5853,19 +6540,22 @@ paths:
       parameters:
         - name: code
           in: path
-          description: Code of warehouse to fetch.
+          description: |-
+            Code of warehouse to fetch.
           required: true
           schema:
             type: string
       responses:
         '200':
-          description: Warehouse response.
+          description: |-
+            Warehouse response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/warehouse'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -5877,7 +6567,8 @@ paths:
       parameters:
         - name: inline
           in: query
-          description: For convenience, include a full representation of the inlined property. Currently supports "address.country".
+          description: |-
+            For convenience, include a full representation of the inlined property. Currently supports "address.country".
           required: false
           style: form
           schema:
@@ -5886,13 +6577,15 @@ paths:
               type: string
       responses:
         '200':
-          description: Ip2location response.
+          description: |-
+            Ip2location response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ip2location'
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -5900,25 +6593,29 @@ paths:
   /order-frequency-segment:
     get:
       summary: Get a customer order frequency
-      description: Returns 'active' if the customer has ordered within the last 120 days, 'activeag' (for "active aging") if they've ordered before but not within 120 days, `activereg` if they've never ordered. If no customer exists, returns `new`.
+      description: |-
+        Returns 'active' if the customer has ordered within the last 120 days, 'activeag' (for "active aging") if they've ordered before but not within 120 days, `activereg` if they've never ordered. If no customer exists, returns `new`.
       operationId: orderFrequencySegment
       parameters:
         - name: email
           in: query
-          description: Email of the person to look up.
+          description: |-
+            Email of the person to look up.
           required: true
           schema:
             type: string
       responses:
         '200':
-          description: Returns 'active' if the customer has ordered within the last 120 days, 'activeag' (for "active aging") if they've ordered before but not within 120 days, `activereg` if they've never ordered. If no customer exists, returns `new`.
+          description: |-
+            Returns 'active' if the customer has ordered within the last 120 days, 'activeag' (for "active aging") if they've ordered before but not within 120 days, `activereg` if they've never ordered. If no customer exists, returns `new`.
           content:
             application/json:
               schema:
                 type: object
                 properties:
                   email:
-                    description: Email address sent for the lookup.
+                    description: |-
+                      Email address sent for the lookup.
                     type: string
                   orderFrequencySegment:
                     type: string
@@ -5928,7 +6625,8 @@ paths:
                       - activeag
                       - activereg
         default:
-          description: Unexpected error.
+          description: |-
+            Unexpected error.
           content:
             application/json:
               schema:
@@ -5942,45 +6640,55 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/updatePersonUserPassword'
-      description: Person to update.
+      description: |-
+        Person to update.
       required: true
   securitySchemes:
     basic:
       type: http
-      description: Basic authentication (http://tools.ietf.org/html/rfc2617#section-2).
+      description: |-
+        Basic authentication (http://tools.ietf.org/html/rfc2617#section-2).
       scheme: basic
     sessionCookie:
       type: apiKey
       in: header
       name: cookie
-      description: Session cookie (http://tools.ietf.org/html/rfc6265).
+      description: |-
+        Session cookie (http://tools.ietf.org/html/rfc6265).
   schemas:
     affiliateCode:
-      description: An affiliate code and associated marketing slug of a person.
+      description: |-
+        An affiliate code and associated marketing slug of a person.
       type: object
       properties:
         marketing-slug:
-          description: Unique marketing slug of a person.
+          description: |-
+            Unique marketing slug of a person.
           type: string
         affiliate-code:
-          description: Unique affiliate code of the same person.
+          description: |-
+            Unique affiliate code of the same person.
           type: string
       required:
         - marketing-slug
         - affiliate-code
     affiliateReferral:
-      description: An affiliate referral.
+      description: |-
+        An affiliate referral.
       type: object
       properties:
         referred:
-          description: Date-time the referred person's account was referred.
+          description: |-
+            Date-time the referred person's account was referred.
           type: string
           format: date-time
         name:
-          description: Name of the person referred.
+          description: |-
+            Name of the person referred.
           type: string
         amount-earned:
-          description: Dollar value for the sum of account credits to the referrer that were caused by this referral.
+          description: |-
+            Dollar value for the sum of account credits to the referrer that were caused by this referral.
           type: number
           format: float
       required:
@@ -5988,47 +6696,56 @@ components:
         - name
         - amount-earned
     bartenderHost:
-      description: A BarTender host/instance.
+      description: |-
+        A BarTender host/instance.
       type: object
       properties:
         code:
-          description: Slug for stable reference (e.g. "bt1").
+          description: |-
+            Slug for stable reference (e.g. "bt1").
           type: string
         name:
-          description: Human readable name (e.g. "Bar Tender 1").
+          description: |-
+            Human readable name (e.g. "Bar Tender 1").
           type: string
       required:
         - code
         - name
     bartenderTemplate:
-      description: A BarTender template/document.
+      description: |-
+        A BarTender template/document.
       type: object
       properties:
         id:
           type: integer
           format: int64
         path:
-          description: Path to the BarTender template on the BarTender host filesystem.
+          description: |-
+            Path to the BarTender template on the BarTender host filesystem.
           type: string
       required:
         - id
         - path
     bartenderPrintConfiguration:
-      description: A BarTender print configuration for BarTender print requests. These configurations are added to warehouse pieces (which are related to individual stock) in Beehive and are used to route print requests and to tell BarTender which template should be used. A print request will be created for each print configuration associated with a stock location's warehouse.
+      description: |-
+        A BarTender print configuration for BarTender print requests. These configurations are added to warehouse pieces (which are related to individual stock) in Beehive and are used to route print requests and to tell BarTender which template should be used. A print request will be created for each print configuration associated with a stock location's warehouse.
       type: object
       properties:
         id:
           type: integer
           format: int64
         host:
-          description: The BarTender host's code.
+          description: |-
+            The BarTender host's code.
           type: string
         printer:
-          description: The printer ID. The referenced printer must support the `bartender` format and delivery methods.
+          description: |-
+            The printer ID. The referenced printer must support the `bartender` format and delivery methods.
           type: integer
           format: int64
         template:
-          description: The BarTender template ID.
+          description: |-
+            The BarTender template ID.
           type: integer
           format: int64
       required:
@@ -6037,7 +6754,8 @@ components:
         - printer
         - template
     companyDirectoryEntry:
-      description: A company directory entry.
+      description: |-
+        A company directory entry.
       type: object
       properties:
         full-name:
@@ -6071,49 +6789,58 @@ components:
         street:
           type: string
     department:
-      description: An Azure department.
+      description: |-
+        An Azure department.
       type: object
       properties:
         name:
-          description: Name of the department.
+          description: |-
+            Name of the department.
           type: string
       required:
         - name
     report:
-      description: A report.
+      description: |-
+        A report.
       type: object
       properties:
         id:
           type: integer
           format: int64
         name:
-          description: The name of the report.
+          description: |-
+            The name of the report.
           type: string
         category:
-          description: The ID of the report category the report is in.
+          description: |-
+            The ID of the report category the report is in.
           type: string
       required:
         - id
         - name
     reportCategory:
-      description: A report category.
+      description: |-
+        A report category.
       type: object
       properties:
         id:
           type: integer
           format: int64
         name:
-          description: The category name.
+          description: |-
+            The category name.
           type: string
         customer-pricing:
-          description: Whether or not reports in this category are customer pricing groups (for use in the pricing module).
+          description: |-
+            Whether or not reports in this category are customer pricing groups (for use in the pricing module).
           type: boolean
       required:
         - id
         - name
         - customer-pricing
     drop:
-      description: An order-delivery location.
+      description: |-
+        An order-delivery location.
       type: object
       properties:
         id:
@@ -6122,10 +6849,12 @@ components:
         name:
           type: string
         coordinators:
-          description: Coordinators for this drop. The first entry is the primary contact.
+          description: |-
+            Coordinators for this drop. The first entry is the primary contact.
           type: array
           items:
-            description: Person ID for this coordinator.
+            description: |-
+              Person ID for this coordinator.
             type: integer
             format: int32
         address:
@@ -6133,19 +6862,24 @@ components:
         geo:
           $ref: '#/components/schemas/geo'
         active:
-          description: Whether or not this drop is actively ordering.
+          description: |-
+            Whether or not this drop is actively ordering.
           type: boolean
         accounts-payable-contact:
-          description: Name of the drop employee Azure's accounts-payable should contact, if different from the primary contact.
+          description: |-
+            Name of the drop employee Azure's accounts-payable should contact, if different from the primary contact.
           type: string
         after-hours-phone:
-          description: E.123 telephone number Azure should call if we need to contact the drop after business hours.
+          description: |-
+            E.123 telephone number Azure should call if we need to contact the drop after business hours.
           type: string
         business-hours:
-          description: Regular business hours for the drop (e.g. "8:30-6 Mon-Fri, 9-5 Sat, closed Sun").
+          description: |-
+            Regular business hours for the drop (e.g. "8:30-6 Mon-Fri, 9-5 Sat, closed Sun").
           type: string
         business-type:
-          description: What type of business do you run?.
+          description: |-
+            What type of business do you run?.
           type: array
           items:
             type: string
@@ -6158,10 +6892,12 @@ components:
               - seasonal
               - wholesale-distributor
         buyer:
-          description: Name of the drop employee who usually places orders for this drop, if different from the primary contact.
+          description: |-
+            Name of the drop employee who usually places orders for this drop, if different from the primary contact.
           type: string
         pickup-contact:
-          description: Do customers need to contact you to pick up their orders?  Retail preference. Only available when how-members-receive is "can-hold-sometimes" or "can-hold".
+          description: |-
+            Do customers need to contact you to pick up their orders?  Retail preference. Only available when how-members-receive is "can-hold-sometimes" or "can-hold".
           type: string
           enum:
             - 'yes'
@@ -6170,7 +6906,8 @@ components:
         contact-person:
           type: string
         contact-type:
-          description: How can customers contact you?.
+          description: |-
+            How can customers contact you?.
           type: array
           items:
             type: string
@@ -6179,16 +6916,20 @@ components:
               - email
               - other
         contact-type-other-notes:
-          description: Description of the alternative contact method. Available when contact-type includes "other".
+          description: |-
+            Description of the alternative contact method. Available when contact-type includes "other".
           type: string
         contact-type-phone:
-          description: E.123 telephone number customers should call to contact this drop. Available when contact-type includes "phone".
+          description: |-
+            E.123 telephone number customers should call to contact this drop. Available when contact-type includes "phone".
           type: string
         directions:
-          description: Driving directions for a truck approaching this drop (e.g. avoiding low bridges, tight turns, etc. on more obvious routes).
+          description: |-
+            Driving directions for a truck approaching this drop (e.g. avoiding low bridges, tight turns, etc. on more obvious routes).
           type: string
         driver-callable-phone:
-          description: E.123 telephone number for a driver approaching this drop.
+          description: |-
+            E.123 telephone number for a driver approaching this drop.
           type: string
         exclusivity:
           type: string
@@ -6197,33 +6938,40 @@ components:
             - semi-open
             - closed
         food-stamps:
-          description: Does your drop accept food stamps?  Business preference.
+          description: |-
+            Does your drop accept food stamps?  Business preference.
           type: string
           enum:
             - 'yes'
             - 'no'
             - limited
         food-stamps-limited-notes:
-          description: Description of limited food-stamp acceptance. Business preference. Only available when food-stamps is "limited".
+          description: |-
+            Description of limited food-stamp acceptance. Business preference. Only available when food-stamps is "limited".
           type: string
         hold-time:
-          description: How long will you hold a customer's order?  For example, "24 hours", "three days for dry, frozen by arrangement", etc. Retail preference. Only available when how-members-receive is "can-hold-sometimes" or "can-hold".
+          description: |-
+            How long will you hold a customer's order?  For example, "24 hours", "three days for dry, frozen by arrangement", etc. Retail preference. Only available when how-members-receive is "can-hold-sometimes" or "can-hold".
           type: string
         how-members-receive:
-          description: How do your members receive their items?  Retail preference.
+          description: |-
+            How do your members receive their items?  Retail preference.
           type: string
           enum:
             - must-show
             - can-hold-sometimes
             - can-hold
         invoice-always:
-          description: Always print paper invoices, regardless of the customer's invoice-delivery preference.
+          description: |-
+            Always print paper invoices, regardless of the customer's invoice-delivery preference.
           type: boolean
         okay-to-text-phone:
-          description: Can the driver send text messages to the driver-callable phone?.
+          description: |-
+            Can the driver send text messages to the driver-callable phone?.
           type: boolean
         parking:
-          description: Parking location ownership for this drop.
+          description: |-
+            Parking location ownership for this drop.
           type: string
           enum:
             - home
@@ -6232,43 +6980,53 @@ components:
             - public
             - other-building
         special-orders:
-          description: Do you take special orders for Azure products from customers? Wholesale preference.
+          description: |-
+            Do you take special orders for Azure products from customers? Wholesale preference.
           type: boolean
         storage:
-          description: Storage environments available at this drop.
+          description: |-
+            Storage environments available at this drop.
           type: array
           items:
             $ref: '#/components/schemas/storage'
         fees:
           $ref: '#/components/schemas/dropFees'
         order-minimum:
-          description: The minimum total order value (in dollars) required to ship a particular trip to this drop. For example, if the minimum is $400 and there are three $100 orders placed for a stop, that stop will be under-minimum, and the orders will not be shipped. If, on the other hand, there were four $100 orders placed for a stop, that stop would be (just) over-minimum, and the orders would be shipped.
+          description: |-
+            The minimum total order value (in dollars) required to ship a particular trip to this drop. For example, if the minimum is $400 and there are three $100 orders placed for a stop, that stop will be under-minimum, and the orders will not be shipped. If, on the other hand, there were four $100 orders placed for a stop, that stop would be (just) over-minimum, and the orders would be shipped.
           type: number
           format: float
         members:
-          description: Number of customers on this drop.
+          description: |-
+            Number of customers on this drop.
           type: integer
           format: int32
         order-frequency:
-          description: Order counts for this drop over the past year.
+          description: |-
+            Order counts for this drop over the past year.
           type: object
           properties:
             orders:
-              description: Count of orders for this route-trip-drop.
+              description: |-
+                Count of orders for this route-trip-drop.
               type: integer
               format: int32
             cutoff:
-              description: Cutoff date for this route-trip.
+              description: |-
+                Cutoff date for this route-trip.
               type: string
               format: date
         notes:
-          description: Free-form Markdown notes for any member-oriented drop information that doesn't fit into an existing field. This information is public for open and semi-open drops, and visible to all members for closed drops.
+          description: |-
+            Free-form Markdown notes for any member-oriented drop information that doesn't fit into an existing field. This information is public for open and semi-open drops, and visible to all members for closed drops.
           type: string
         sells-finished-goods-to-azure:
-          description: Do you also sell your finished good to Azure?  Only available if business-type includes "manufacturing-business".
+          description: |-
+            Do you also sell your finished good to Azure?  Only available if business-type includes "manufacturing-business".
           type: boolean
         uses-azure-to-drop-ship:
-          description: Do you drop ship Azure orders (have Azure ship directly to your customers)?  Only available if business-type includes "online-store".
+          description: |-
+            Do you drop ship Azure orders (have Azure ship directly to your customers)?  Only available if business-type includes "online-store".
           type: boolean
       required:
         - id
@@ -6280,7 +7038,8 @@ components:
     newDrop:
       $ref: '#/components/schemas/drop'
     updateDrop:
-      description: An order-delivery location.
+      description: |-
+        An order-delivery location.
       type: object
       properties:
         id:
@@ -6293,10 +7052,12 @@ components:
         geo:
           $ref: '#/components/schemas/geo'
         active:
-          description: Whether or not this drop is actively ordering.
+          description: |-
+            Whether or not this drop is actively ordering.
           type: boolean
         parking:
-          description: Parking location ownership for this drop.
+          description: |-
+            Parking location ownership for this drop.
           type: string
           enum:
             - home
@@ -6304,78 +7065,94 @@ components:
             - non-profit
             - public
         storage:
-          description: Storage environments available at this drop.
+          description: |-
+            Storage environments available at this drop.
           type: array
           items:
             $ref: '#/components/schemas/storage'
         fees:
           $ref: '#/components/schemas/dropFees'
         notes:
-          description: Free-form Markdown notes for any member-oriented drop information that doesn't fit into an existing field. This information is public for open and semi-open drops, and visible to all members for closed drops.
+          description: |-
+            Free-form Markdown notes for any member-oriented drop information that doesn't fit into an existing field. This information is public for open and semi-open drops, and visible to all members for closed drops.
           type: string
       required:
         - name
         - active
     dropFees:
-      description: Additional costs for members receiving at a drop.
+      description: |-
+        Additional costs for members receiving at a drop.
       type: object
       properties:
         medium:
-          description: Payment medium (nothing, volunteer time, or a monetary payment).
+          description: |-
+            Payment medium (nothing, volunteer time, or a monetary payment).
           type: string
           enum:
             - volunteer
             - payment
         condition:
-          description: Fee trigger (never, only when orders are held, or for every order).
+          description: |-
+            Fee trigger (never, only when orders are held, or for every order).
           type: string
           enum:
             - held
             - order
         notes:
-          description: Fee amount and structure.
+          description: |-
+            Fee amount and structure.
           type: string
     dropMembership:
-      description: A drop membership.
+      description: |-
+        A drop membership.
       type: object
       properties:
         id:
           type: integer
           format: int64
         customer:
-          description: Customer that has the drop membership.
+          description: |-
+            Customer that has the drop membership.
           type: integer
           format: int64
         drop:
-          description: The drop this membership is for.
+          description: |-
+            The drop this membership is for.
           type: integer
           format: int64
         active:
-          description: Whether or not this membership is active. Pending memberships are active, and the usual flow for semi-open drops is (active true, pending true) -> (active true, pending false) -> (active false, pending false).
+          description: |-
+            Whether or not this membership is active. Pending memberships are active, and the usual flow for semi-open drops is (active true, pending true) -> (active true, pending false) -> (active false, pending false).
           type: boolean
         pending:
-          description: Whether the membership is pending (true) or accepted (false).
+          description: |-
+            Whether the membership is pending (true) or accepted (false).
           type: boolean
         created:
-          description: Date-time the drop-membership was created.
+          description: |-
+            Date-time the drop-membership was created.
           type: string
           format: date-time
         heavy:
-          description: Whether the member can get pallets, totes, barrels, and other heavy objects off a truck (defaults to false).
+          description: |-
+            Whether the member can get pallets, totes, barrels, and other heavy objects off a truck (defaults to false).
           type: boolean
         notifications:
           $ref: '#/components/schemas/dropMembershipNotifications'
         gratitude-total:
-          description: Total "Azure Gratitude" (monetary incentive for hosting a drop) received from being this drop's coordinator. Only set if the "inline" query parameter contains "gratitude-total".
+          description: |-
+            Total "Azure Gratitude" (monetary incentive for hosting a drop) received from being this drop's coordinator. Only set if the "inline" query parameter contains "gratitude-total".
           type: number
           format: float
           minimum: 0
         computed:
-          description: Optional computed properties included via the "computed" parameter.
+          description: |-
+            Optional computed properties included via the "computed" parameter.
           type: object
           properties:
             lastOrderPlaced:
-              description: Date-time the member last placed an order on this drop.
+              description: |-
+                Date-time the member last placed an order on this drop.
               type: string
               format: date-time
       required:
@@ -6387,25 +7164,31 @@ components:
         - created
         - notifications
     updateDropMembership:
-      description: A drop membership to update.
+      description: |-
+        A drop membership to update.
       type: object
       properties:
         customer:
-          description: Customer that has the drop membership.
+          description: |-
+            Customer that has the drop membership.
           type: integer
           format: int64
         drop:
-          description: The drop this membership is for.
+          description: |-
+            The drop this membership is for.
           type: integer
           format: int64
         active:
-          description: Whether or not this membership is active.
+          description: |-
+            Whether or not this membership is active.
           type: boolean
         pending:
-          description: Whether the membership is pending (true) or accepted (false).
+          description: |-
+            Whether the membership is pending (true) or accepted (false).
           type: boolean
         heavy:
-          description: Whether the member can get pallets, totes, barrels, and other heavy objects off a truck (defaults to false).
+          description: |-
+            Whether the member can get pallets, totes, barrels, and other heavy objects off a truck (defaults to false).
           type: boolean
         notifications:
           $ref: '#/components/schemas/dropMembershipNotifications'
@@ -6416,25 +7199,30 @@ components:
     newDropMembership:
       $ref: '#/components/schemas/updateDropMembership'
     dropMembershipNotifications:
-      description: Configure if and how a user receives per-drop notifications.
+      description: |-
+        Configure if and how a user receives per-drop notifications.
       type: object
       properties:
         cutoff:
-          description: Receive notifications from Azure before cutoffs for this drop.
+          description: |-
+            Receive notifications from Azure before cutoffs for this drop.
           format: array
           items:
             $ref: '#/components/schemas/notificationChannel'
     file:
-      description: An opaque file. This is usually used for product and category images, but could also be used for other content.
+      description: |-
+        An opaque file. This is usually used for product and category images, but could also be used for other content.
       type: object
       properties:
         id:
-          description: The identifier for this file. This is generated by the server, but will be a UUID as defined by RFC 4122.
+          description: |-
+            The identifier for this file. This is generated by the server, but will be a UUID as defined by RFC 4122.
           type: string
       required:
         - id
     pickup:
-      description: A purchase-pickup location.
+      description: |-
+        A purchase-pickup location.
       type: object
       properties:
         id:
@@ -6443,10 +7231,12 @@ components:
         name:
           type: string
         vendors:
-          description: Vendors supplying this pickup.
+          description: |-
+            Vendors supplying this pickup.
           type: array
           items:
-            description: Vendor ID.
+            description: |-
+              Vendor ID.
             type: integer
             format: int32
         address:
@@ -6454,10 +7244,12 @@ components:
         geo:
           $ref: '#/components/schemas/geo'
         active:
-          description: Whether or not this pickup is actively supplying purchases.
+          description: |-
+            Whether or not this pickup is actively supplying purchases.
           type: boolean
         notes:
-          description: Free-form Markdown notes for any pickup information that doesn't fit into an existing field.
+          description: |-
+            Free-form Markdown notes for any pickup information that doesn't fit into an existing field.
           type: string
       required:
         - id
@@ -6467,7 +7259,8 @@ components:
         - geo
         - active
     route:
-      description: An order-delivery truck route.
+      description: |-
+        An order-delivery truck route.
       type: object
       properties:
         id:
@@ -6476,37 +7269,47 @@ components:
         name:
           type: string
         description:
-          type: string
+|-
+            type: string
         cutoff-frequency:
-          description: Number of days between cutoffs.
+          description: |-
+            Number of days between cutoffs.
           type: integer
           format: int32
         delivery-offset:
-          description: Number of days after cutoff before the first stop.
+          description: |-
+            Number of days after cutoff before the first stop.
           type: integer
           format: int32
         internal:
-          description: Is the route for internal use? This controls whether customers can access the route via the API (they can't if internal is true).
+          description: |-
+            Is the route for internal use? This controls whether customers can access the route via the API (they can't if internal is true).
           type: boolean
         backhaul-cost-per-pound:
-          description: Route backhaul cost per pound.
+          description: |-
+            Route backhaul cost per pound.
           type: number
           format: float
         backhaul-cost-per-pickup:
-          description: Route backhaul cost per pickup.
+          description: |-
+            Route backhaul cost per pickup.
           type: number
           format: float
         hub:
-          description: A hub route is a delivery route that occurs after we ship an entire route to a distribution hub (such as a big loading dock in Kansas City). The route is unloaded at the hub and reloaded onto another carrier's truck for actual delivery. In terms of Customer Care, It is a one-way route; the truck, trailer, and any shipped goods refused by a customer never return to the warehouse.
+          description: |-
+            A hub route is a delivery route that occurs after we ship an entire route to a distribution hub (such as a big loading dock in Kansas City). The route is unloaded at the hub and reloaded onto another carrier's truck for actual delivery. In terms of Customer Care, It is a one-way route; the truck, trailer, and any shipped goods refused by a customer never return to the warehouse.
           type: boolean
         driverName:
-          description: Truck drivers name.
+          description: |-
+            Truck drivers name.
           type: string
         driverPhone:
-          description: Truck drivers phone.
+          description: |-
+            Truck drivers phone.
           type: string
         notes:
-          description: General notes about the route.
+          description: |-
+            General notes about the route.
           type: string
       required:
         - name
@@ -6518,41 +7321,52 @@ components:
         - driverPhone
         - notes
     updateRoute:
-      description: An order-delivery truck route's updated values.
+      description: |-
+        An order-delivery truck route's updated values.
       type: object
       properties:
         description:
-          type: string
+|-
+            type: string
         cutoff-frequency:
-          description: Number of days between cutoffs.
+          description: |-
+            Number of days between cutoffs.
           type: integer
           format: int32
         delivery-offset:
-          description: Number of days after cutoff before the first stop.
+          description: |-
+            Number of days after cutoff before the first stop.
           type: integer
           format: int32
         internal:
-          description: Is the route for internal use? This controls whether customers can access the route via the API (they can't if internal is true).
+          description: |-
+            Is the route for internal use? This controls whether customers can access the route via the API (they can't if internal is true).
           type: boolean
         backhaul-cost-per-pound:
-          description: Route backhaul cost per pound.
+          description: |-
+            Route backhaul cost per pound.
           type: number
           format: float
         backhaul-cost-per-pickup:
-          description: Route backhaul cost per pickup.
+          description: |-
+            Route backhaul cost per pickup.
           type: number
           format: float
         hub:
-          description: A hub route is a delivery route that occurs after we ship an entire route to a distribution hub (such as a big loading dock in Kansas City). The route is unloaded at the hub and reloaded onto another carrier's truck for actual delivery. In terms of Customer Care, It is a one-way route; the truck, trailer, and any shipped goods refused by a customer never return to the warehouse.
+          description: |-
+            A hub route is a delivery route that occurs after we ship an entire route to a distribution hub (such as a big loading dock in Kansas City). The route is unloaded at the hub and reloaded onto another carrier's truck for actual delivery. In terms of Customer Care, It is a one-way route; the truck, trailer, and any shipped goods refused by a customer never return to the warehouse.
           type: boolean
         driverName:
-          description: Truck drivers name.
+          description: |-
+            Truck drivers name.
           type: string
         driverPhone:
-          description: Truck drivers phone.
+          description: |-
+            Truck drivers phone.
           type: string
         notes:
-          description: General notes about the route.
+          description: |-
+            General notes about the route.
           type: string
       required:
         - cutoff-frequency
@@ -6561,56 +7375,69 @@ components:
     newRoute:
       $ref: '#/components/schemas/route'
     trip:
-      description: A truck delivering orders along a route.
+      description: |-
+        A truck delivering orders along a route.
       type: object
       properties:
         id:
           type: integer
           format: int64
         route:
-          description: Name of the followed route.
+          description: |-
+            Name of the followed route.
           type: string
         cutoff:
-          description: Cutoff for placing orders on this trip.
+          description: |-
+            Cutoff for placing orders on this trip.
           type: string
           format: date-time
         confirmed:
-          description: When the trip was reviewed and orders were either accepted or (for short drops) bumped to the next trip. This will always be set before the trip is confirmed, and will be unset until then. Customer service and customers who have received a short-drop notification can continue to manipulate placed orders in the window between cutoff and confirmation.
+          description: |-
+            When the trip was reviewed and orders were either accepted or (for short drops) bumped to the next trip. This will always be set before the trip is confirmed, and will be unset until then. Customer service and customers who have received a short-drop notification can continue to manipulate placed orders in the window between cutoff and confirmation.
           type: string
           format: date-time
         pick-date:
-          description: Date-time that orders for this trip should be picked.
+          description: |-
+            Date-time that orders for this trip should be picked.
           type: string
           format: date-time
         shipped:
-          description: Approximately when the truck left the warehouse. This will always be set after the truck has left, and will be unset until then.
+          description: |-
+            Approximately when the truck left the warehouse. This will always be set after the truck has left, and will be unset until then.
           type: string
           format: date-time
         delivery-start:
-          description: Estimated stop-time for the first stop.
+          description: |-
+            Estimated stop-time for the first stop.
           type: string
           format: date-time
         delivery-end:
-          description: Estimated stop-time for the last stop.
+          description: |-
+            Estimated stop-time for the last stop.
           type: string
           format: date-time
         backhaul-start:
-          description: Estimated date-time for the first backhaul.
+          description: |-
+            Estimated date-time for the first backhaul.
           type: string
           format: date-time
         backhaul-end:
-          description: Estimated date-time for the last backhaul.
+          description: |-
+            Estimated date-time for the last backhaul.
           type: string
           format: date-time
         warehouse-arrival:
-          description: Estimated date-time for warehouse arrival.
+          description: |-
+            Estimated date-time for warehouse arrival.
           type: string
           format: date-time
         notes:
-          description: Free-form Markdown notes for additional trip information. We expect this will mostly be for delay causes (e.g. "High winds in Laramie" or "The truck broke down").
+          description: |-
+            Free-form Markdown notes for additional trip information. We expect this will mostly be for delay causes (e.g. "High winds in Laramie" or "The truck broke down").
           type: string
         status:
-          description: Current stage of a trip's lifecycle.
+          description: |-
+            Current stage of a trip's lifecycle.
           type: string
           enum:
             - new
@@ -6623,38 +7450,47 @@ components:
         - cutoff
         - delivery-start
     updateTrip:
-      description: A truck delivering orders along a route to be updated.
+      description: |-
+        A truck delivering orders along a route to be updated.
       type: object
       properties:
         route:
-          description: Name of the followed route.
+          description: |-
+            Name of the followed route.
           type: string
         cutoff:
-          description: Cutoff for placing orders on this trip.
+          description: |-
+            Cutoff for placing orders on this trip.
           type: string
           format: date-time
         pick-date:
-          description: Date-time that orders for this trip should be picked.
+          description: |-
+            Date-time that orders for this trip should be picked.
           type: string
           format: date-time
         delivery-start:
-          description: Estimated stop-time for the first stop.
+          description: |-
+            Estimated stop-time for the first stop.
           type: string
           format: date-time
         delivery-end:
-          description: Estimated stop-time for the last stop.
+          description: |-
+            Estimated stop-time for the last stop.
           type: string
           format: date-time
         backhaul-start:
-          description: Estimated date-time for the first backhaul.
+          description: |-
+            Estimated date-time for the first backhaul.
           type: string
           format: date-time
         backhaul-end:
-          description: Estimated date-time for the last backhaul.
+          description: |-
+            Estimated date-time for the last backhaul.
           type: string
           format: date-time
         warehouse-arrival:
-          description: Estimated date-time for warehouse arrival.
+          description: |-
+            Estimated date-time for warehouse arrival.
           type: string
           format: date-time
       required:
@@ -6662,21 +7498,25 @@ components:
         - cutoff
         - delivery-start
     routeStop:
-      description: A template used to create stops when a trip is created.
+      description: |-
+        A template used to create stops when a trip is created.
       type: object
       properties:
         id:
           type: integer
           format: int64
         route:
-          description: Route name for the route-stop.
+          description: |-
+            Route name for the route-stop.
           type: string
         drop:
-          description: Drop ID for the route-stop.
+          description: |-
+            Drop ID for the route-stop.
           type: integer
           format: int64
         delivery-offset:
-          description: Offset from midnight on the morning of the trips's delivery start until the usual delivery time for this drop.
+          description: |-
+            Offset from midnight on the morning of the trips's delivery start until the usual delivery time for this drop.
           type: string
           format: duration
         drop-shipping-fee:
@@ -6687,40 +7527,49 @@ components:
         - drop
         - delivery-offset
     stop:
-      description: A trip stop or waypoint. Stops are created for all route-stops when a trip is created for that route. At confirmation time, stops that will not be visited (e.g. because they missed their order-minimum) are deleted.
+      description: |-
+        A trip stop or waypoint. Stops are created for all route-stops when a trip is created for that route. At confirmation time, stops that will not be visited (e.g. because they missed their order-minimum) are deleted.
       type: object
       properties:
         id:
           type: integer
           format: int64
         trip:
-          description: Trip ID for the stop.
+          description: |-
+            Trip ID for the stop.
           type: integer
           format: int64
         drop:
-          description: Drop ID for the stop.
+          description: |-
+            Drop ID for the stop.
           type: integer
           format: int64
         short-drop:
-          description: Whether short-drop warnings were sent out for this stop. If they were, customers can manipulate placed orders after cutoff time, although nobody can edit orders after the trip is confirmed.
+          description: |-
+            Whether short-drop warnings were sent out for this stop. If they were, customers can manipulate placed orders after cutoff time, although nobody can edit orders after the trip is confirmed.
           type: boolean
         pickup:
-          description: Pickup ID for the stop.
+          description: |-
+            Pickup ID for the stop.
           type: integer
           format: int64
         timezone:
-          description: IANA time zone location (https://www.iana.org/time-zones, e.g. America/Los_Angeles).
+          description: |-
+            IANA time zone location (https://www.iana.org/time-zones, e.g. America/Los_Angeles).
           type: string
         estimatedDelivery:
-          description: Editable until verification.
+          description: |-
+            Editable until verification.
           type: string
           format: date-time
         finalizedDelivery:
-          description: Editable between verification and delivery.
+          description: |-
+            Editable between verification and delivery.
           type: string
           format: date-time
         actualDelivery:
-          description: When the stop is actually reached.
+          description: |-
+            When the stop is actually reached.
           type: string
           format: date-time
         drop-shipping-fee:
@@ -6731,31 +7580,38 @@ components:
         - estimatedDelivery
         - finalizedDelivery
     updateStop:
-      description: An update to a trip stop or waypoint.
+      description: |-
+        An update to a trip stop or waypoint.
       type: object
       properties:
         trip:
-          description: Trip ID for the stop.
+          description: |-
+            Trip ID for the stop.
           type: integer
           format: int64
         drop:
-          description: Drop ID for the stop.
+          description: |-
+            Drop ID for the stop.
           type: integer
           format: int64
         pickup:
-          description: Pickup ID for the stop.
+          description: |-
+            Pickup ID for the stop.
           type: integer
           format: int64
         estimatedDelivery:
-          description: Editable until verification.
+          description: |-
+            Editable until verification.
           type: string
           format: date-time
         finalizedDelivery:
-          description: Editable between verification and delivery.
+          description: |-
+            Editable between verification and delivery.
           type: string
           format: date-time
         actualDelivery:
-          description: When the stop is actually reached.
+          description: |-
+            When the stop is actually reached.
           type: string
           format: date-time
       required:
@@ -6763,7 +7619,8 @@ components:
         - estimatedDelivery
         - finalizedDelivery
     shippingService:
-      description: A parcel-carrier service. The listing below is ordered by carrier and then by increasing duration.
+      description: |-
+        A parcel-carrier service. The listing below is ordered by carrier and then by increasing duration.
       type: string
       enum:
         - UPS 2nd Day Air
@@ -6771,14 +7628,16 @@ components:
         - USPS Priority Mail Express
         - USPS Priority Mail
     shippingClimate:
-      description: An environment for shipping products. 'all' is a shipping climate for products of all types. 'dry' includes both 'dry' and 'greenhouse' storage environments. 'chilled/frozen' includes both 'chilled' and 'frozen' storage environments.
+      description: |-
+        An environment for shipping products. 'all' is a shipping climate for products of all types. 'dry' includes both 'dry' and 'greenhouse' storage environments. 'chilled/frozen' includes both 'chilled' and 'frozen' storage environments.
       type: string
       enum:
         - all
         - dry
         - chilled/frozen
     storage:
-      description: An environment for storing products. The related to shippingClimate is less detailed, because stock is generally in transit for less time than it is in storage.
+      description: |-
+        An environment for storing products. The related to shippingClimate is less detailed, because stock is generally in transit for less time than it is in storage.
       type: string
       enum:
         - dry
@@ -6786,62 +7645,77 @@ components:
         - frozen
         - greenhouse
     packagedProduct:
-      description: A particular packaged form of a product.
+      description: |-
+        A particular packaged form of a product.
       type: object
       properties:
         code:
           type: string
         gtin13:
-          description: 13-digit Global Trade Item Number (https://schema.org/gtin13).
+          description: |-
+            13-digit Global Trade Item Number (https://schema.org/gtin13).
           type: string
         size:
-          description: Size of the product (e.g. 12 oz., or 6x12 oz.).
+          description: |-
+            Size of the product (e.g. 12 oz., or 6x12 oz.).
           type: string
         packs:
-          description: Package organization (e.g. "4", "4x32.5", or "2x4x32.5").
+          description: |-
+            Package organization (e.g. "4", "4x32.5", or "2x4x32.5").
           type: string
         unit:
-          description: Unit of measurement ("ounce", "liter", etc.).
+          description: |-
+            Unit of measurement ("ounce", "liter", etc.).
           type: string
         weight:
           $ref: '#/components/schemas/weight'
         volume:
-          description: Volume of this packaged product in cubic feet.
+          description: |-
+            Volume of this packaged product in cubic feet.
           type: number
           format: float
         price:
           $ref: '#/components/schemas/price'
         stock:
-          description: Amount of stock available for purchase. This includes breakdown ancestors. For example, if we have a single 4 x 6 x 14 oz case in the warehouse, the 4 x 6 x 14 oz packaging will have 1 stock, the 6 x 14 oz packagaging will have 4 stock, and the 14 oz packaging will have 24 stock.
+          description: |-
+            Amount of stock available for purchase. This includes breakdown ancestors. For example, if we have a single 4 x 6 x 14 oz case in the warehouse, the 4 x 6 x 14 oz packaging will have 1 stock, the 6 x 14 oz packagaging will have 4 stock, and the 14 oz packaging will have 24 stock.
           type: integer
           format: int32
         favorite:
-          description: If the annotate-person you associated with the request has favorited this packaged product.
+          description: |-
+            If the annotate-person you associated with the request has favorited this packaged product.
           type: boolean
         favorites:
-          description: Number of people who've marked this packaged product as a favorite.
+          description: |-
+            Number of people who've marked this packaged product as a favorite.
           type: integer
           format: int32
         tags:
-          description: Mark types for this packaged product.
+          description: |-
+            Mark types for this packaged product.
           type: array
           items:
             type: string
         bargain-bin-notes:
-          description: Bargain-bin notes for this packaged product.
+          description: |-
+            Bargain-bin notes for this packaged product.
           type: string
         statusReason:
-          description: Reason this packaged product is in its current status.
+          description: |-
+            Reason this packaged product is in its current status.
           type: string
         servings-per-container:
-          description: Servings per container. The rest of the nutrition information is in product.nutrition-facts, but the number of servings per container depends on the packaging size. For composite packaging (e.g. a 12 x 6 x 2 oz case), the value applies to the smallest component with a nutrition label (e.g. the 2 oz items, if they're labeled, or the 6 x 2 oz boxes, if they're labeled and the 2 oz items are not).
+          description: |-
+            Servings per container. The rest of the nutrition information is in product.nutrition-facts, but the number of servings per container depends on the packaging size. For composite packaging (e.g. a 12 x 6 x 2 oz case), the value applies to the smallest component with a nutrition label (e.g. the 2 oz items, if they're labeled, or the 6 x 2 oz boxes, if they're labeled and the 2 oz items are not).
           type: string
         product:
-          description: The product that this packaging packages.
+          description: |-
+            The product that this packaging packages.
           type: integer
           format: int64
         primary-category:
-          description: The id of the primary category for this packaged product.
+          description: |-
+            The id of the primary category for this packaged product.
           type: integer
           format: int64
       required:
@@ -6851,20 +7725,24 @@ components:
         - price
         - tags
     packagedProductImage:
-      description: An association between a packaged product and an image.
+      description: |-
+        An association between a packaged product and an image.
       type: object
       properties:
         id:
           type: integer
           format: int64
         packaged-product:
-          description: Code for the associated packaged product.
+          description: |-
+            Code for the associated packaged product.
           type: string
         image:
-          description: File ID for the associated image.
+          description: |-
+            File ID for the associated image.
           type: string
         order:
-          description: Ordering precedence among other entries associated with this packaged product. Defaults to zero.
+          description: |-
+            Ordering precedence among other entries associated with this packaged product. Defaults to zero.
           type: integer
           format: int32
       required:
@@ -6872,24 +7750,29 @@ components:
         - packaged-product
         - image
     packagedProductTag:
-      description: A type of packaged product or other boolean marker.
+      description: |-
+        A type of packaged product or other boolean marker.
       type: object
       properties:
         slug:
-          description: Code used as the primary key for tags.
+          description: |-
+            Code used as the primary key for tags.
           type: string
         name:
-          description: Human-readable tag name.
+          description: |-
+            Human-readable tag name.
           type: string
         category:
-          description: Category code describing the type of tag.
+          description: |-
+            Category code describing the type of tag.
           type: string
           enum:
             - status
             - price-level
             - characteristic
     packagedProductTagAssociation:
-      description: A packaged product tag representing a saved filter for a person.
+      description: |-
+        A packaged product tag representing a saved filter for a person.
       type: object
       properties:
         id:
@@ -6905,112 +7788,139 @@ components:
         - person
         - tag
     product:
-      description: A product available for sale (independent of packaging).
+      description: |-
+        A product available for sale (independent of packaging).
       type: object
       properties:
         id:
           type: integer
           format: int64
         name:
-          description: Sentence-length product name.
+          description: |-
+            Sentence-length product name.
           type: string
         seo-name:
-          description: An SEO-optimized name. A lengthened version of the full name that includes additional keywords or rephrasing, suitable for use in a title tag. When this is unset, the name is a reasonable fallback.
+          description: |-
+            An SEO-optimized name. A lengthened version of the full name that includes additional keywords or rephrasing, suitable for use in a title tag. When this is unset, the name is a reasonable fallback.
           type: string
         treatAsActive:
-          description: If true, this product will be published to search engines even when it is inactive (out for season, out long term, or discontinued).
+          description: |-
+            If true, this product will be published to search engines even when it is inactive (out for season, out long term, or discontinued).
           type: boolean
         inactiveDescription:
-          description: HTML description applicable only when the product is inactive (out for season, out long term, or discontinued). It should contain specific information pertinent to the inactive status of the product (e.g. details about why it is inactive and what similar products are available instead). It should not duplicate information in short-description or description.
+          description: |-
+            HTML description applicable only when the product is inactive (out for season, out long term, or discontinued). It should contain specific information pertinent to the inactive status of the product (e.g. details about why it is inactive and what similar products are available instead). It should not duplicate information in short-description or description.
           type: string
         short-description:
-          description: Paragraph-length, stand-alone, plain-text product description.
+|-
+            description: |-
+  Paragraph-length, stand-alone, plain-text product description.
           type: string
         description:
-          description: Long-form, HTML product description. When short-description is set, this value is for additional information which did not fit into short-description. Displaying both short-description and description is not redundant. Displaying only description may be confusing when short-description is available.
+|-
+            description: |-
+  Long-form, HTML product description. When short-description is set, this value is for additional information which did not fit into short-description. Displaying both short-description and description is not redundant. Displaying only description may be confusing when short-description is available.
           type: string
         brand:
-          description: The brand associated with this product.
+          description: |-
+            The brand associated with this product.
           type: integer
           format: int64
         directions:
-          description: Product use directions (e.g., cooking suggestions).
+          description: |-
+            Product use directions (e.g., cooking suggestions).
           type: string
         favorites:
-          description: Number of people who've marked this product as a favorite.
+          description: |-
+            Number of people who've marked this product as a favorite.
           type: integer
           format: int32
         ingredients:
-          description: Ingredients used in this product (e.g., "dried cranberries (organic cranberries, organic cane sugar, organic sunflower oil)").
+          description: |-
+            Ingredients used in this product (e.g., "dried cranberries (organic cranberries, organic cane sugar, organic sunflower oil)").
           type: string
         nutrition-facts:
           $ref: '#/components/schemas/nutritionFacts'
         packaging:
-          description: Packaged versions of this product.
+          description: |-
+            Packaged versions of this product.
           type: array
           items:
             type: integer
             format: int64
         substitutions:
-          description: Suggested in-stock substitutions.
+          description: |-
+            Suggested in-stock substitutions.
           type: object
           properties:
             by-category:
-              description: Suggested substitute product IDs which belong to related categories.
+              description: |-
+                Suggested substitute product IDs which belong to related categories.
               type: array
               items:
                 type: integer
                 format: int64
             staff-picks:
-              description: Suggested substitute product IDs which were chosen by staff members.
+              description: |-
+                Suggested substitute product IDs which were chosen by staff members.
               type: array
               items:
                 type: integer
                 format: int64
         country-of-origin:
-          description: Country of origin for this product.
+          description: |-
+            Country of origin for this product.
           type: string
         storage:
           $ref: '#/components/schemas/storage'
         slug:
-          description: A slug generated from the product name.
+          description: |-
+            A slug generated from the product name.
           type: string
       required:
         - id
         - name
     nutritionFacts:
-      description: Nutrition facts.
+      description: |-
+        Nutrition facts.
       type: object
       properties:
         headers:
-          description: Nutrition-fact headers (e.g. "Serving Size 1 cake (19g)" or "Calories 60").
+          description: |-
+            Nutrition-fact headers (e.g. "Serving Size 1 cake (19g)" or "Calories 60").
           type: array
           items:
             type: string
         daily-values:
-          description: Nutrition facts daily values.
+          description: |-
+            Nutrition facts daily values.
           type: array
           items:
             $ref: '#/components/schemas/nutritionFactsDailyValue'
     nutritionFactsDailyValue:
-      description: A nutrition facts daily value.
+      description: |-
+        A nutrition facts daily value.
       type: object
       properties:
         indent:
-          description: If true, this label should be indented (e.g. an indented "Dietary Fiber" entry might follow a non-indented "Total Carbohydrate" entry).
+          description: |-
+            If true, this label should be indented (e.g. an indented "Dietary Fiber" entry might follow a non-indented "Total Carbohydrate" entry).
           type: boolean
         label:
-          description: Daily value label (e.g. "Total Carbohydrate 14g", "Calcium").
+          description: |-
+            Daily value label (e.g. "Total Carbohydrate 14g", "Calcium").
           type: string
         percentage:
-          description: Daily value percentage (e.g., "10" or "<1").
+          description: |-
+            Daily value percentage (e.g., "10" or "<1").
           type: string
       required:
         - indent
         - label
         - percentage
     brand:
-      description: A brand which may be associated with several products.
+      description: |-
+        A brand which may be associated with several products.
       type: object
       properties:
         id:
@@ -7019,66 +7929,79 @@ components:
         name:
           type: string
         url:
-          description: Homepage for the brand.
+          description: |-
+            Homepage for the brand.
           type: string
           format: url
         slug:
-          description: A slug generated from the brand name.
+          description: |-
+            A slug generated from the brand name.
           type: string
       required:
         - id
         - name
     _price:
-      description: A helper object for `price`.
+      description: |-
+        A helper object for `price`.
       type: object
       properties:
         dollars:
-          description: Price of the packaging in dollars.
+          description: |-
+            Price of the packaging in dollars.
           type: number
           format: float
           minimum: 0
         per-pound:
-          description: Whether the `dollars` value is per-pound or per-package.
+          description: |-
+            Whether the `dollars` value is per-pound or per-package.
           type: boolean
         discount:
-          description: Text for the discount (e.g. "12%", or "$3.50").
+          description: |-
+            Text for the discount (e.g. "12%", or "$3.50").
           type: string
         dollars-per-unit:
-          description: The per-unit price.
+          description: |-
+            The per-unit price.
           type: number
           format: float
           minimum: 0
         rewards-rate:
-          description: Rewards rate (as a percentage) earned for this packaging. This will only be set for packaging with a fixed rewards rate. The rewards earned for this product will be the price (after sales) * min(max(`person.rewards-rate`, `product.rewards-rate`), `product.maxRewardsRate`) / 100, rounded to the nearest cent, rounding half to even.
+          description: |-
+            Rewards rate (as a percentage) earned for this packaging. This will only be set for packaging with a fixed rewards rate. The rewards earned for this product will be the price (after sales) * min(max(`person.rewards-rate`, `product.rewards-rate`), `product.maxRewardsRate`) / 100, rounded to the nearest cent, rounding half to even.
           type: integer
           format: int32
           minimum: 0
         maxRewardsRate:
-          description: The maximum rewards rate that could be earned for this product. A value of 0 means that no rewards will be earned.
+          description: |-
+            The maximum rewards rate that could be earned for this product. A value of 0 means that no rewards will be earned.
           type: integer
           format: int32
           minimum: 0
         unit:
-          description: The unit for `dollars-per-unit`.
+          description: |-
+            The unit for `dollars-per-unit`.
           type: string
       required:
         - maxRewardsRate
         - dollars
     priceLevel:
-      description: A customer property to pick the right price from 'price'.
+      description: |-
+        A customer property to pick the right price from 'price'.
       type: string
       enum:
         - retail
         - wholesale
         - member
     permission:
-      description: An API authorization or authorization category.
+      description: |-
+        An API authorization or authorization category.
       type: string
       enum:
         - staff
         - superuser
     price:
-      description: Product price information.
+      description: |-
+        Product price information.
       type: object
       properties:
         retail:
@@ -7088,117 +8011,148 @@ components:
         member:
           $ref: '#/components/schemas/_price'
     category:
-      description: A category available for sale.
+      description: |-
+        A category available for sale.
       type: object
       properties:
         id:
           type: integer
           format: int64
         name:
-          description: A phrase naming the category. This should be understandable (but not necessarily unique) without any further context. It must be unique for categories sharing a given parent.
+          description: |-
+            A phrase naming the category. This should be understandable (but not necessarily unique) without any further context. It must be unique for categories sharing a given parent.
           type: string
         short-name:
-          description: A word or two naming the category. A shortened version of the full name that drops any words already contained in the category's ancestors' short names. This will be used in places where the ancestor short names are in close proximity (e.g. URL slugs) to avoid having the same word many times. When this is unset, the name is a reasonable fallback.
+          description: |-
+            A word or two naming the category. A shortened version of the full name that drops any words already contained in the category's ancestors' short names. This will be used in places where the ancestor short names are in close proximity (e.g. URL slugs) to avoid having the same word many times. When this is unset, the name is a reasonable fallback.
           type: string
         seo-name:
-          description: An SEO-optimized name for the category. A lengthened version of the full name that includes additional keywords or rephrasing, suitable for use in a title tag. When this is unset, the name is a reasonable fallback.
+          description: |-
+            An SEO-optimized name for the category. A lengthened version of the full name that includes additional keywords or rephrasing, suitable for use in a title tag. When this is unset, the name is a reasonable fallback.
           type: string
         description:
-          description: A sentence or two with a stand-alone category description. When this is unset, the nearest ancestor description is a reasonable fallback.
+|-
+            description: |-
+  A sentence or two with a stand-alone category description. When this is unset, the nearest ancestor description is a reasonable fallback.
           type: string
         image:
-          description: A picture of this category. When set for a fetched category, the value will be a URL. When set for an uploaded category, file IDs and media URLs can be used interchangeably.
+          description: |-
+            A picture of this category. When set for a fetched category, the value will be a URL. When set for an uploaded category, file IDs and media URLs can be used interchangeably.
           type: string
         parent:
-          description: Category ID for the parent category.
+          description: |-
+            Category ID for the parent category.
           type: integer
           format: int64
         ancestors:
-          description: Ancestor categories. If set, `ancestors[0]` is the parent category and the final `ancestors` entry is the root category. Include "ancestors" in the `inline` query parameter if you need this.
+          description: |-
+            Ancestor categories. If set, `ancestors[0]` is the parent category and the final `ancestors` entry is the root category. Include "ancestors" in the `inline` query parameter if you need this.
           type: array
           items:
             $ref: '#/components/schemas/category'
         depth:
-          description: The number of ancestor categories. Include "depth" in the `inline` query parameter if you need this.
+          description: |-
+            The number of ancestor categories. Include "depth" in the `inline` query parameter if you need this.
           type: integer
           format: int32
         primary:
-          description: Is this a primary category?.
+          description: |-
+            Is this a primary category?.
           type: boolean
         active:
-          description: Is this category active?.
+          description: |-
+            Is this category active?.
           type: boolean
         keywords:
           type: array
           items:
-            description: A keyword for this category.
+            description: |-
+              A keyword for this category.
             type: string
         featured:
-          description: Ordering precedence for likely customer interest. Defaults to zero.
+          description: |-
+            Ordering precedence for likely customer interest. Defaults to zero.
           type: integer
           format: int32
         slug:
-          description: A slug generated from the category short-name (or name if short-name is not defined).
+          description: |-
+            A slug generated from the category short-name (or name if short-name is not defined).
           type: string
       required:
         - id
         - name
     updateCategory:
-      description: A category to update.
+      description: |-
+        A category to update.
       type: object
       properties:
         name:
-          description: A phrase naming the category. This should be understandable (but not necessarily unique) without any further context. It must be unique for categories sharing a given parent.
+          description: |-
+            A phrase naming the category. This should be understandable (but not necessarily unique) without any further context. It must be unique for categories sharing a given parent.
           type: string
         short-name:
-          description: A word or two naming the category. A shortened version of the full name that drops any words already contained in the category's ancestors' short names. This will be used in places where the ancestor short names are in close proximity (e.g. URL slugs) to avoid having the same word many times. When this is unset, the name is a reasonable fallback.
+          description: |-
+            A word or two naming the category. A shortened version of the full name that drops any words already contained in the category's ancestors' short names. This will be used in places where the ancestor short names are in close proximity (e.g. URL slugs) to avoid having the same word many times. When this is unset, the name is a reasonable fallback.
           type: string
         seo-name:
-          description: An SEO-optimized name for the category. A lengthened version of the full name that includes additional keywords or rephrasing, suitable for use in a title tag. When this is unset, the name is a reasonable fallback.
+          description: |-
+            An SEO-optimized name for the category. A lengthened version of the full name that includes additional keywords or rephrasing, suitable for use in a title tag. When this is unset, the name is a reasonable fallback.
           type: string
         description:
-          description: A sentence or two with a stand-alone category description. When this is unset, the nearest ancestor description is a reasonable fallback.
+|-
+            description: |-
+  A sentence or two with a stand-alone category description. When this is unset, the nearest ancestor description is a reasonable fallback.
           type: string
         image:
-          description: A picture of this category. When set for a fetched category, the value will be a URL. When set for an uploaded category, file IDs and media URLs can be used interchangeably.
+          description: |-
+            A picture of this category. When set for a fetched category, the value will be a URL. When set for an uploaded category, file IDs and media URLs can be used interchangeably.
           type: string
         parent:
-          description: Category ID for the parent category.
+          description: |-
+            Category ID for the parent category.
           type: integer
           format: int64
         primary:
-          description: Is this a primary category?.
+          description: |-
+            Is this a primary category?.
           type: boolean
         active:
-          description: Is this category active?.
+          description: |-
+            Is this category active?.
           type: boolean
         keywords:
           type: array
           items:
-            description: A keyword for this category.
+            description: |-
+              A keyword for this category.
             type: string
         featured:
-          description: Ordering precedence for likely customer interest. Defaults to zero.
+          description: |-
+            Ordering precedence for likely customer interest. Defaults to zero.
           type: integer
           format: int32
         slug:
-          description: A slug generated from the category short-name (or name if short-name is not defined).
+          description: |-
+            A slug generated from the category short-name (or name if short-name is not defined).
           type: string
       required:
         - name
     purchase:
-      description: A purchase order placed by Azure.
+      description: |-
+        A purchase order placed by Azure.
       type: object
       properties:
         id:
           type: integer
           format: int64
         vendor:
-          description: Vendor supplying the order.
+          description: |-
+            Vendor supplying the order.
           type: integer
           format: int64
         status:
-          description: Purchase's lifecycle stage.
+          description: |-
+            Purchase's lifecycle stage.
           type: string
           enum:
             - open
@@ -7210,57 +8164,69 @@ components:
             - reconciled
             - paid
         submitted:
-          description: When the purchase was submitted.
+          description: |-
+            When the purchase was submitted.
           type: string
           format: date-time
         confirmed:
-          description: When the purchase was confirmed.
+          description: |-
+            When the purchase was confirmed.
           type: string
           format: date-time
         delivered:
-          description: When the purchase was delivered.
+          description: |-
+            When the purchase was delivered.
           type: string
           format: date-time
         reconciled:
-          description: When the purchase was reconciled.
+          description: |-
+            When the purchase was reconciled.
           type: string
           format: date-time
         pickup:
-          description: Drop the purchase is destined for (only set for backhaul purchases).
+          description: |-
+            Drop the purchase is destined for (only set for backhaul purchases).
           type: integer
           format: int64
         trip:
-          description: Trip delivering the purchase (only set for backhaul purchases).
+          description: |-
+            Trip delivering the purchase (only set for backhaul purchases).
           type: integer
           format: int64
         notes:
-          description: Free-form Markdown notes for any purchase information that doesn't fit into an existing field.
+          description: |-
+            Free-form Markdown notes for any purchase information that doesn't fit into an existing field.
           type: string
       required:
         - id
         - vendor
         - status
     order:
-      description: An order placed by a customer.
+      description: |-
+        An order placed by a customer.
       type: object
       properties:
         id:
           type: integer
           format: int64
         customer:
-          description: Customer making the order.
+          description: |-
+            Customer making the order.
           type: integer
           format: int64
         inline:
-          description: Optional inlined properties included via the "inline" parameter.
+          description: |-
+            Optional inlined properties included via the "inline" parameter.
           type: object
           properties:
             dropMembershipId:
-              description: The membership ID of the customer making the order. Only included if the request includes the inlined "dropMembershipId".
+              description: |-
+                The membership ID of the customer making the order. Only included if the request includes the inlined "dropMembershipId".
               type: integer
               format: int64
         status:
-          description: Order's lifecycle stage.
+          description: |-
+            Order's lifecycle stage.
           type: string
           enum:
             - open
@@ -7269,37 +8235,45 @@ components:
             - shipped
             - lost
         placed:
-          description: When the order was placed.
+          description: |-
+            When the order was placed.
           type: string
           format: date-time
         shipped:
-          description: When the order was shipped.
+          description: |-
+            When the order was shipped.
           type: string
           format: date-time
         target-delivery:
-          description: Planned delivery time (fixed before the trip starts, and unset for parcel-carrier orders).
+          description: |-
+            Planned delivery time (fixed before the trip starts, and unset for parcel-carrier orders).
           type: string
           format: date-time
         estimated-delivery:
-          description: Estimated delivery time (updated after the trip starts until the order is delivered, and unset for parcel-carrier orders).
+          description: |-
+            Estimated delivery time (updated after the trip starts until the order is delivered, and unset for parcel-carrier orders).
           type: string
           format: date-time
         delivered:
-          description: When the order was delivered.
+          description: |-
+            When the order was delivered.
           type: string
           format: date-time
         checkout-payment:
           $ref: '#/components/schemas/payment'
         rewards-allocation:
-          description: Rewards allocated for this order. For open orders, this value has no side-effects. For placed orders that are not yet shipped, this value will match the associated pending rewards debit amount. When the order ships, this value does not change, but the associated rewards debit will have its amount reduced if the allocated rewards exceed the dollar balance. If, instead of shipping, the placed order returns to open status, the associated pending rewards debit is deleted, releasing those rewards to be allocated towards other orders.
+          description: |-
+            Rewards allocated for this order. For open orders, this value has no side-effects. For placed orders that are not yet shipped, this value will match the associated pending rewards debit amount. When the order ships, this value does not change, but the associated rewards debit will have its amount reduced if the allocated rewards exceed the dollar balance. If, instead of shipping, the placed order returns to open status, the associated pending rewards debit is deleted, releasing those rewards to be allocated towards other orders.
           type: number
           format: float
         drop:
-          description: Drop the order is destined for (unset for parcel-carrier orders).
+          description: |-
+            Drop the order is destined for (unset for parcel-carrier orders).
           type: integer
           format: int64
         trip:
-          description: Trip delivering the order (automatically populated for parcel-carrier orders).
+          description: |-
+            Trip delivering the order (automatically populated for parcel-carrier orders).
           type: integer
           format: int64
         address:
@@ -7307,194 +8281,237 @@ components:
         parcel-carrier-services:
           $ref: '#/components/schemas/orderParcelCarrierServices'
         perishable-shipping-warning-accepted:
-          description: If true, the customer has accepted the warning regarding shipping perishable product.
+          description: |-
+            If true, the customer has accepted the warning regarding shipping perishable product.
           type: boolean
         cases-shipped:
-          description: Total quantity of shipped boxes and bulk stock.
+          description: |-
+            Total quantity of shipped boxes and bulk stock.
           type: integer
           format: int64
         casesShippedBreakdown:
           $ref: '#/components/schemas/orderCaseQuantitiesByTemperature'
         notes:
-          description: Warehouse packing instructions.
+          description: |-
+            Warehouse packing instructions.
           type: string
         lastApiUpdate:
-          description: A datetime denoting when the order or its order-lines were last updated via the API.
+          description: |-
+            A datetime denoting when the order or its order-lines were last updated via the API.
           type: string
         holdShipmentUntilStockAvailable:
-          description: If true, the customer has requested to hold shipment of the order until all requested stock is available.
+          description: |-
+            If true, the customer has requested to hold shipment of the order until all requested stock is available.
           type: boolean
         computed:
-          description: Optional computed properties included via the "computed" parameter.
+          description: |-
+            Optional computed properties included via the "computed" parameter.
           type: object
           properties:
             totalPriceOrdered:
-              description: Dollar value for the sum of all ordered products (does not include potential fees).
+              description: |-
+                Dollar value for the sum of all ordered products (does not include potential fees).
               type: number
               format: float
             totalPriceShipped:
-              description: Dollar value for the sum of all shipped products (does not include potential fees).
+              description: |-
+                Dollar value for the sum of all shipped products (does not include potential fees).
               type: number
               format: float
             totalFees:
-              description: Dollar value for the sum of all order fees (pre or post shipment, dependent on order status).
+              description: |-
+                Dollar value for the sum of all order fees (pre or post shipment, dependent on order status).
               type: number
               format: float
             cases:
               type: object
               properties:
                 frozen:
-                  description: Count of cases shipped with frozen products.
+                  description: |-
+                    Count of cases shipped with frozen products.
                   type: integer
                   format: int64
                 refrigeratedAndRoomTemp:
-                  description: Count of cases shipped with refrigerated/room-temperature products.
+                  description: |-
+                    Count of cases shipped with refrigerated/room-temperature products.
                   type: integer
                   format: int64
                 greenhouse:
-                  description: Count of cases shipped with greenhouse products.
+                  description: |-
+                    Count of cases shipped with greenhouse products.
                   type: integer
                   format: int64
                 total:
-                  description: Total count of cases shipped.
+                  description: |-
+                    Total count of cases shipped.
                   type: integer
                   format: int64
             quantityOrdered:
               type: object
               properties:
                 frozen:
-                  description: Total count of frozen products ordered.
+                  description: |-
+                    Total count of frozen products ordered.
                   type: number
                   format: float
                 refrigerated:
-                  description: Total count of refrigerated products ordered.
+                  description: |-
+                    Total count of refrigerated products ordered.
                   type: number
                   format: float
                 roomTemp:
-                  description: Total count of room temperature products ordered.
+                  description: |-
+                    Total count of room temperature products ordered.
                   type: number
                   format: float
                 greenhouse:
-                  description: Total count of greenhouse products ordered.
+                  description: |-
+                    Total count of greenhouse products ordered.
                   type: number
                   format: float
                 total:
-                  description: Total count of all products ordered.
+                  description: |-
+                    Total count of all products ordered.
                   type: number
                   format: float
             quantityShipped:
               type: object
               properties:
                 frozen:
-                  description: Total count of frozen products shipped.
+                  description: |-
+                    Total count of frozen products shipped.
                   type: number
                   format: float
                 refrigerated:
-                  description: Total count of refrigerated products shipped.
+                  description: |-
+                    Total count of refrigerated products shipped.
                   type: number
                   format: float
                 roomTemp:
-                  description: Total count of room temperature products shipped.
+                  description: |-
+                    Total count of room temperature products shipped.
                   type: number
                   format: float
                 greenhouse:
-                  description: Total count of greenhouse products shipped.
+                  description: |-
+                    Total count of greenhouse products shipped.
                   type: number
                   format: float
                 total:
-                  description: Total count of all products shipped.
+                  description: |-
+                    Total count of all products shipped.
                   type: number
                   format: float
             weightOrdered:
               type: object
               properties:
                 frozen:
-                  description: Total weight (in pounds) of frozen products ordered.
+                  description: |-
+                    Total weight (in pounds) of frozen products ordered.
                   type: number
                   format: float
                 refrigerated:
-                  description: Total weight (in pounds) of refrigerated products ordered.
+                  description: |-
+                    Total weight (in pounds) of refrigerated products ordered.
                   type: number
                   format: float
                 roomTemp:
-                  description: Total weight (in pounds) of room temperature products ordered.
+                  description: |-
+                    Total weight (in pounds) of room temperature products ordered.
                   type: number
                   format: float
                 greenhouse:
-                  description: Total weight (in pounds) of greenhouse products ordered.
+                  description: |-
+                    Total weight (in pounds) of greenhouse products ordered.
                   type: number
                   format: float
                 total:
-                  description: Total weight (in pounds) of all products ordered.
+                  description: |-
+                    Total weight (in pounds) of all products ordered.
                   type: number
                   format: float
             weightShipped:
               type: object
               properties:
                 frozen:
-                  description: Total weight (in pounds) of frozen products shipped.
+                  description: |-
+                    Total weight (in pounds) of frozen products shipped.
                   type: number
                   format: float
                 refrigerated:
-                  description: Total weight (in pounds) of refrigerated products shipped.
+                  description: |-
+                    Total weight (in pounds) of refrigerated products shipped.
                   type: number
                   format: float
                 roomTemp:
-                  description: Total weight (in pounds) of room temperature products shipped.
+                  description: |-
+                    Total weight (in pounds) of room temperature products shipped.
                   type: number
                   format: float
                 greenhouse:
-                  description: Total weight (in pounds) of greenhouse products shipped.
+                  description: |-
+                    Total weight (in pounds) of greenhouse products shipped.
                   type: number
                   format: float
                 total:
-                  description: Total weight (in pounds) of all products shipped.
+                  description: |-
+                    Total weight (in pounds) of all products shipped.
                   type: number
                   format: float
             volumeOrdered:
               type: object
               properties:
                 frozen:
-                  description: Total volume (in cubic feet) of frozen products ordered.
+                  description: |-
+                    Total volume (in cubic feet) of frozen products ordered.
                   type: number
                   format: float
                 refrigerated:
-                  description: Total volume (in cubic feet) of refrigerated products ordered.
+                  description: |-
+                    Total volume (in cubic feet) of refrigerated products ordered.
                   type: number
                   format: float
                 roomTemp:
-                  description: Total volume (in cubic feet) of room temperature products ordered.
+                  description: |-
+                    Total volume (in cubic feet) of room temperature products ordered.
                   type: number
                   format: float
                 greenhouse:
-                  description: Total volume (in cubic feet) of greenhouse products ordered.
+                  description: |-
+                    Total volume (in cubic feet) of greenhouse products ordered.
                   type: number
                   format: float
                 total:
-                  description: Total volume (in cubic feet) of all products ordered.
+                  description: |-
+                    Total volume (in cubic feet) of all products ordered.
                   type: number
                   format: float
             volumeShipped:
               type: object
               properties:
                 frozen:
-                  description: Total volume (in cubic feet) of frozen products shipped.
+                  description: |-
+                    Total volume (in cubic feet) of frozen products shipped.
                   type: number
                   format: float
                 refrigerated:
-                  description: Total volume (in cubic feet) of refrigerated products shipped.
+                  description: |-
+                    Total volume (in cubic feet) of refrigerated products shipped.
                   type: number
                   format: float
                 roomTemp:
-                  description: Total volume (in cubic feet) of room temperature products shipped.
+                  description: |-
+                    Total volume (in cubic feet) of room temperature products shipped.
                   type: number
                   format: float
                 greenhouse:
-                  description: Total volume (in cubic feet) of greenhouse products shipped.
+                  description: |-
+                    Total volume (in cubic feet) of greenhouse products shipped.
                   type: number
                   format: float
                 total:
-                  description: Total volume (in cubic feet) of all products shipped.
+                  description: |-
+                    Total volume (in cubic feet) of all products shipped.
                   type: number
                   format: float
       required:
@@ -7502,15 +8519,18 @@ components:
         - customer
         - status
     updateOrder:
-      description: An order placed by a customer.
+      description: |-
+        An order placed by a customer.
       type: object
       properties:
         customer:
-          description: Customer making the order.
+          description: |-
+            Customer making the order.
           type: integer
           format: int64
         status:
-          description: Order's lifecycle stage.
+          description: |-
+            Order's lifecycle stage.
           type: string
           enum:
             - open
@@ -7520,11 +8540,13 @@ components:
         checkout-payment:
           $ref: '#/components/schemas/payment'
         drop:
-          description: Drop the order is destined for (unset for parcel-carrier orders).
+          description: |-
+            Drop the order is destined for (unset for parcel-carrier orders).
           type: integer
           format: int64
         trip:
-          description: Trip delivering the order (automatically populated for parcel-carrier orders).
+          description: |-
+            Trip delivering the order (automatically populated for parcel-carrier orders).
           type: integer
           format: int64
         address:
@@ -7532,41 +8554,49 @@ components:
         parcel-carrier-services:
           $ref: '#/components/schemas/orderParcelCarrierServices'
         perishable-shipping-warning-accepted:
-          description: If true, the customer has accepted the warning regarding shipping perishable product.
+          description: |-
+            If true, the customer has accepted the warning regarding shipping perishable product.
           type: boolean
         notes:
-          description: Additional information about the order, including special instructions for Azure's pickers.
+          description: |-
+            Additional information about the order, including special instructions for Azure's pickers.
           type: string
         holdShipmentUntilStockAvailable:
-          description: If true, the customer has requested to hold shipment of the order until all requested stock is available.
+          description: |-
+            If true, the customer has requested to hold shipment of the order until all requested stock is available.
           type: boolean
       required:
         - customer
         - status
     changedOrder:
-      description: An updated order and a list of any side-effects from the update.
+      description: |-
+        An updated order and a list of any side-effects from the update.
       type: object
       properties:
         order:
           $ref: '#/components/schemas/order'
         changes:
-          description: An array of side-effects. Will be set if there were side-effects and unset if there were none.
+          description: |-
+            An array of side-effects. Will be set if there were side-effects and unset if there were none.
           type: array
           items:
             $ref: '#/components/schemas/orderChange'
       required:
         - order
     orderChange:
-      description: A side-effect from an order update.
+      description: |-
+        A side-effect from an order update.
       type: object
       properties:
         type:
-          description: A slug identifying the type of change.
+          description: |-
+            A slug identifying the type of change.
           type: string
           enum:
             - remove-order-line
         reason:
-          description: A human-readable description of the change.
+          description: |-
+            A human-readable description of the change.
           type: string
         order-line:
           $ref: '#/components/schemas/orderLine'
@@ -7574,71 +8604,88 @@ components:
         - change
         - reason
     orderCaseQuantitiesByTemperature:
-      description: Quantity of shipped boxes and bulk stock by temperature type.
+      description: |-
+        Quantity of shipped boxes and bulk stock by temperature type.
       type: object
       properties:
         frozen:
-          description: Quantity of shipped boxes and bulk stock with the frozen climate.
+          description: |-
+            Quantity of shipped boxes and bulk stock with the frozen climate.
           type: integer
           format: int32
         refrigerated:
-          description: Quantity of shipped boxes and bulk stock with the refrigerated climate.
+          description: |-
+            Quantity of shipped boxes and bulk stock with the refrigerated climate.
           type: integer
           format: int32
         roomTemp:
-          description: Quantity of shipped boxes and bulk stock with the room temperature climate.
+          description: |-
+            Quantity of shipped boxes and bulk stock with the room temperature climate.
           type: integer
           format: int32
     orderLine:
-      description: A per-product entry in an order.
+      description: |-
+        A per-product entry in an order.
       type: object
       properties:
         id:
           type: integer
           format: int64
         order:
-          description: Order that the order-line belongs to.
+          description: |-
+            Order that the order-line belongs to.
           type: integer
           format: int64
         packaged-product:
-          description: Packaged product code that is being ordered.
+          description: |-
+            Packaged product code that is being ordered.
           type: string
         product:
-          description: Product ID of the packaged product that is being ordered.
+          description: |-
+            Product ID of the packaged product that is being ordered.
           type: integer
           format: int64
         name:
-          description: Most order lines are for packaged products, but Azure sometimes bills for less concrete items like catalog ads. This field holds a brief description of the line, and should be used for invoices instead of following packaged-product (which may not be set).
+          description: |-
+            Most order lines are for packaged products, but Azure sometimes bills for less concrete items like catalog ads. This field holds a brief description of the line, and should be used for invoices instead of following packaged-product (which may not be set).
           type: string
         quantity-ordered:
-          description: Number of product instances requested.
+          description: |-
+            Number of product instances requested.
           type: integer
           format: int32
         quantity-shipped:
-          description: Number of product instances delivered.
+          description: |-
+            Number of product instances delivered.
           type: number
           format: float
         weight:
-          description: Weight of the shipped products in pounds (estimated until picking time).
+          description: |-
+            Weight of the shipped products in pounds (estimated until picking time).
           type: number
           format: float
         volume:
-          description: Volume of the shipped products in cubic feet (estimated until picking time).
+          description: |-
+            Volume of the shipped products in cubic feet (estimated until picking time).
           type: number
           format: float
         price:
-          description: The total price for this line in dollars (estimated until picking time). The per-unit price used to calculate this total is currently locked in when you place the order.
+          description: |-
+            The total price for this line in dollars (estimated until picking time). The per-unit price used to calculate this total is currently locked in when you place the order.
           type: number
           format: float
         rewards:
-          description: The total rewards earned by this line (estimated until picking time). The per-unit rewards used to calculate this total are currently locked in when you place the order.
+          description: |-
+            The total rewards earned by this line (estimated until picking time). The per-unit rewards used to calculate this total are currently locked in when you place the order.
           type: number
           format: float
         warnings:
-          description: An array of warnings about this product.
+          description: |-
+            An array of warnings about this product.
           type: array
           items:
-            description: Warnings about products that a customer can associate with this order, but maybe should not (e.g. that is is likely to expire before reaching the customer).
+            description: |-
+              Warnings about products that a customer can associate with this order, but maybe should not (e.g. that is is likely to expire before reaching the customer).
             type: string
       required:
         - id
@@ -7648,41 +8695,49 @@ components:
         - weight
         - volume
     updateOrderLine:
-      description: A per-product entry in an order.
+      description: |-
+        A per-product entry in an order.
       type: object
       properties:
         order:
-          description: Order that the order-line belongs to.
+          description: |-
+            Order that the order-line belongs to.
           type: integer
           format: int64
         packaged-product:
-          description: Packaged product code that is being ordered.
+          description: |-
+            Packaged product code that is being ordered.
           type: string
         name:
-          description: Most order lines are for packaged products, but Azure sometimes bills for less concrete items like catalog ads. This field holds a brief description of the line, and should be used for invoices instead of following packaged-product (which may not be set).
+          description: |-
+            Most order lines are for packaged products, but Azure sometimes bills for less concrete items like catalog ads. This field holds a brief description of the line, and should be used for invoices instead of following packaged-product (which may not be set).
           type: string
         quantity-ordered:
-          description: Number of product instances requested.
+          description: |-
+            Number of product instances requested.
           type: integer
           format: int32
       required:
         - order
         - quantity-ordered
     orderFee:
-      description: An additional charge associated with an order (estimated until picking time).
+      description: |-
+        An additional charge associated with an order (estimated until picking time).
       type: object
       properties:
         id:
           type: integer
           format: int64
         order:
-          description: Order that the fee belongs to.
+          description: |-
+            Order that the fee belongs to.
           type: integer
           format: int64
         type:
           $ref: '#/components/schemas/orderFeeType'
         amount:
-          description: Dollar value for the fee.
+          description: |-
+            Dollar value for the fee.
           type: number
           format: float
         climate:
@@ -7690,77 +8745,93 @@ components:
         shipping-service:
           $ref: '#/components/schemas/shippingService'
         notes:
-          description: Additional information about the reason or amount for the fee.
+          description: |-
+            Additional information about the reason or amount for the fee.
           type: string
       required:
         - order
         - type
         - amount
     orderFeeType:
-      description: A property for an order fee.
+      description: |-
+        A property for an order fee.
       type: string
       enum:
         - shipping
         - small-order
     dropShippingFee:
-      description: Information for calculating shipping costs for orders delivered to a stop.
+      description: |-
+        Information for calculating shipping costs for orders delivered to a stop.
       type: object
       properties:
         percent:
-          description: The `shipping` order fee is the total order-line price over all lines on the order, multiplied by this percentage, and then rounded to the nearest cent.
+          description: |-
+            The `shipping` order fee is the total order-line price over all lines on the order, multiplied by this percentage, and then rounded to the nearest cent.
           type: number
           format: float
     orderParcelCarrierEstimate:
-      description: A parcel carrier shipping estimate for a given order or portion of order.
+      description: |-
+        A parcel carrier shipping estimate for a given order or portion of order.
       type: object
       properties:
         cost:
-          description: The cost of the shipping service.
+          description: |-
+            The cost of the shipping service.
           type: number
           format: float
         climate:
           $ref: '#/components/schemas/shippingClimate'
         service:
-          description: The parcel carrier service used for this estimate.
+          description: |-
+            The parcel carrier service used for this estimate.
           type: array
           items:
             $ref: '#/components/schemas/shippingService'
         expires:
-          description: The date-time when this estimate expires. Orders placed for this climate/service after that expiration may have a different fee or delivery estimates.
+          description: |-
+            The date-time when this estimate expires. Orders placed for this climate/service after that expiration may have a different fee or delivery estimates.
           type: string
           format: date-time
         shipping-date:
-          description: The estimated date when the covered order-lines will ship.
+          description: |-
+            The estimated date when the covered order-lines will ship.
           type: string
           format: date
         earliest-delivery:
-          description: The estimated earliest delivery date (inclusive) for the covered order-lines.
+          description: |-
+            The estimated earliest delivery date (inclusive) for the covered order-lines.
           type: string
           format: date
         latest-delivery:
-          description: The estimated latest delivery date (inclusive) for the covered order-lines.
+          description: |-
+            The estimated latest delivery date (inclusive) for the covered order-lines.
           type: string
           format: date
         contact-for-quote:
-          description: The customer should contact this person or team for a personalized shipping quote for this service.
+          description: |-
+            The customer should contact this person or team for a personalized shipping quote for this service.
           type: object
           properties:
             name:
-              description: Name of the person or team.
+              description: |-
+                Name of the person or team.
               type: string
             email:
-              description: Email for the person or team.
+              description: |-
+                Email for the person or team.
               type: string
               format: email
             telephone:
-              description: E.123 telephone number for the person or team.
+              description: |-
+                E.123 telephone number for the person or team.
               type: string
               format: telephone
       required:
         - climate
         - service
     orderParcelCarrierServices:
-      description: Parcel carrier services selected for an order.
+      description: |-
+        Parcel carrier services selected for an order.
       type: object
       properties:
         all:
@@ -7770,7 +8841,8 @@ components:
         chilled/frozen:
           $ref: '#/components/schemas/shippingService'
     vendor:
-      description: A company that sells products to Azure.
+      description: |-
+        A company that sells products to Azure.
       type: object
       properties:
         id:
@@ -7779,46 +8851,56 @@ components:
         name:
           type: string
         active:
-          description: Whether or not this vendor is actively supplying purchases.
+          description: |-
+            Whether or not this vendor is actively supplying purchases.
           type: boolean
         url:
-          description: Homepage for the vendor.
+          description: |-
+            Homepage for the vendor.
           type: string
           format: url
         indie:
-          description: Whether or not this vendor is a privately held company.
+          description: |-
+            Whether or not this vendor is a privately held company.
           type: boolean
         account:
-          description: Vendor's identifier for Azure.
+          description: |-
+            Vendor's identifier for Azure.
           type: string
       required:
         - id
         - name
         - active
     accountEntry:
-      description: A dollar entry in a person's account.
+      description: |-
+        A dollar entry in a person's account.
       type: object
       properties:
         id:
           type: integer
           format: int64
         person:
-          description: Person associated with the account.
+          description: |-
+            Person associated with the account.
           type: integer
           format: int64
         amount:
-          description: Dollar value for the entry (positive for credits like customer payments, negative for debits like order charges).
+          description: |-
+            Dollar value for the entry (positive for credits like customer payments, negative for debits like order charges).
           type: number
           format: float
         date:
-          description: When the entry was added.
+          description: |-
+            When the entry was added.
           type: string
           format: date
         notes:
-          description: A line of Markdown identifying the entry (e.g. "charge for order 123" or "payed with card ending in 0123").
+          description: |-
+            A line of Markdown identifying the entry (e.g. "charge for order 123" or "payed with card ending in 0123").
           type: string
         balance:
-          description: Account balance after this account entry.
+          description: |-
+            Account balance after this account entry.
           type: number
           format: float
       required:
@@ -7827,37 +8909,45 @@ components:
         - amount
         - date
     creditCard:
-      description: A credit card (one of our supported payment methods).
+      description: |-
+        A credit card (one of our supported payment methods).
       type: object
       properties:
         id:
           type: integer
           format: int64
         type:
-          description: String identifying this payment method.
+          description: |-
+            String identifying this payment method.
           type: string
           enum:
             - credit-card
         active:
-          description: Whether or not this payment method is available for further activity.
+          description: |-
+            Whether or not this payment method is available for further activity.
           type: boolean
         person:
-          description: Person associated with this payment method.
+          description: |-
+            Person associated with this payment method.
           type: integer
           format: int64
         name:
-          description: Billing name (which may differ from the associated person's name).
+          description: |-
+            Billing name (which may differ from the associated person's name).
           type: string
         address:
           $ref: '#/components/schemas/address'
         issuer:
-          description: Provider network. You can determine this from the leading digits of the card number, but we don't store those digits.
+          description: |-
+            Provider network. You can determine this from the leading digits of the card number, but we don't store those digits.
           type: string
         last-four:
-          description: Last four digits of the card number for identification.
+          description: |-
+            Last four digits of the card number for identification.
           type: string
         expiration:
-          description: Expiration date. We only use the month and year; the day will always be '01'.
+          description: |-
+            Expiration date. We only use the month and year; the day will always be '01'.
           type: string
           format: date
       required:
@@ -7870,36 +8960,45 @@ components:
         - last-four
         - expiration
     newCreditCard:
-      description: Azure does not store much credit card information internally (we use an external card processor), but we do need all of the information for the initial upload so we can pass it along to the external processor.
+      description: |-
+        Azure does not store much credit card information internally (we use an external card processor), but we do need all of the information for the initial upload so we can pass it along to the external processor.
       type: object
       properties:
         type:
-          description: String identifying this payment method.
+          description: |-
+            String identifying this payment method.
           type: string
           enum:
             - credit-card
         active:
-          description: Whether or not this payment method is available for further activity. Defaults to true.
+          description: |-
+            Whether or not this payment method is available for further activity. Defaults to true.
           type: boolean
         person:
-          description: Person associated with this payment method.
+          description: |-
+            Person associated with this payment method.
           type: integer
           format: int64
         name:
-          description: Billing name (which may differ from the associated person's name).
+          description: |-
+            Billing name (which may differ from the associated person's name).
           type: string
         address:
-          description: Billing address associated with this credit card.
+          description: |-
+            Billing address associated with this credit card.
           type: integer
           format: int64
         number:
-          description: Card number.
+          description: |-
+            Card number.
           type: string
         security-code:
-          description: Security code (also known as the verification value).
+          description: |-
+            Security code (also known as the verification value).
           type: string
         expiration:
-          description: Expiration date. We only use the month and year and ignore the day (which you should set to '01').
+          description: |-
+            Expiration date. We only use the month and year and ignore the day (which you should set to '01').
           type: string
           format: date
       required:
@@ -7911,14 +9010,16 @@ components:
         - security-code
         - expiration
     genericPaymentMethod:
-      description: One of our supported payment methods that does not have properties beyond the generic payment-method properties.
+      description: |-
+        One of our supported payment methods that does not have properties beyond the generic payment-method properties.
       type: object
       properties:
         id:
           type: integer
           format: int64
         type:
-          description: String identifying this payment method. cash-on-delivery means customers must pay for their order in cash to pick up the order. hold-for-payment means customers must pay for the order before Azure will ship it. net-N means the order must be paid for within N days. payroll-deduction means the invoiced price will be deducted from the customer's (an Azure employee) next paycheck.
+          description: |-
+            String identifying this payment method. cash-on-delivery means customers must pay for their order in cash to pick up the order. hold-for-payment means customers must pay for the order before Azure will ship it. net-N means the order must be paid for within N days. payroll-deduction means the invoiced price will be deducted from the customer's (an Azure employee) next paycheck.
           type: string
           enum:
             - cash-on-delivery
@@ -7927,10 +9028,12 @@ components:
             - net-30-days
             - payroll-deduction
         active:
-          description: Whether or not this payment method is available for further activity.
+          description: |-
+            Whether or not this payment method is available for further activity.
           type: boolean
         person:
-          description: Person associated with this payment method.
+          description: |-
+            Person associated with this payment method.
           type: integer
           format: int64
       required:
@@ -7946,56 +9049,68 @@ components:
       anyOf:
         - $ref: '#/components/schemas/newCreditCard'
     payment:
-      description: A payment instance where an amount will be (or has been) charged via a payment-method.
+      description: |-
+        A payment instance where an amount will be (or has been) charged via a payment-method.
       type: object
       properties:
         payment-method:
-          description: Payment-method ID to use (or which was used).
+          description: |-
+            Payment-method ID to use (or which was used).
           type: integer
           format: int64
         type:
-          description: The type of payment used.
+          description: |-
+            The type of payment used.
           type: string
         last-four:
-          description: The last four digits of the credit card used. Only included if the payment type is Credit Card.
+          description: |-
+            The last four digits of the credit card used. Only included if the payment type is Credit Card.
           type: string
         amount:
-          description: Amount to charge (or which was charged) in dollars.
+          description: |-
+            Amount to charge (or which was charged) in dollars.
           type: number
           format: float
         paid:
-          description: Has the payment been charged?.
+          description: |-
+            Has the payment been charged?.
           type: boolean
       required:
         - payment-method
     registrationRequest:
-      description: A request for registering a new person.
+      description: |-
+        A request for registering a new person.
       type: object
       properties:
         person:
           $ref: '#/components/schemas/updatePerson'
         catalog:
-          description: Set to true to receive the catalog after registration.
+          description: |-
+            Set to true to receive the catalog after registration.
           type: boolean
         address:
           $ref: '#/components/schemas/address'
         email:
-          description: The registrant's primary email address. Will have a preference level of 100.
+          description: |-
+            The registrant's primary email address. Will have a preference level of 100.
           type: string
           format: email
         telephone:
-          description: The registrant's telephone numbers (currently only supports 'voice' and 'text' types).
+          description: |-
+            The registrant's telephone numbers (currently only supports 'voice' and 'text' types).
           type: array
           items:
             $ref: '#/components/schemas/telephone'
         drop:
-          description: The registrant's chosen drop.
+          description: |-
+            The registrant's chosen drop.
           type: integer
           format: int64
         context:
           $ref: '#/components/schemas/registrationContext'
         authentication-base-url:
-          description: Redirect URL for the authentication UI. The authentication notification points customers at {authentication-base-url}{authentication-token} to authenticate a new session.
+          description: |-
+            Redirect URL for the authentication UI. The authentication notification points customers at {authentication-base-url}{authentication-token} to authenticate a new session.
           type: string
           format: url
         post-affiliate-pro:
@@ -8005,29 +9120,34 @@ components:
         - email
         - authentication-base-url
     registrationContext:
-      description: The context in which the registration request is being made (to select between available notification templates). Defaults to "registration".
+      description: |-
+        The context in which the registration request is being made (to select between available notification templates). Defaults to "registration".
       type: string
       enum:
         - registration
         - checkout
         - catalog-request
     reward:
-      description: A reward entry.
+      description: |-
+        A reward entry.
       type: object
       properties:
         id:
           type: integer
           format: int64
         person:
-          description: Person associated with the reward.
+          description: |-
+            Person associated with the reward.
           type: integer
           format: int64
         amount:
-          description: Reward value for the entry (positive for credits, negative for debits).
+          description: |-
+            Reward value for the entry (positive for credits, negative for debits).
           type: number
           format: float
         type:
-          description: This entry's reward type.
+          description: |-
+            This entry's reward type.
           type: string
           enum:
             - earned
@@ -8035,29 +9155,35 @@ components:
             - expired
             - promotion
         settled:
-          description: When the entry was settled. This will be unset for pending debits, and will be set for all settled debits.
+          description: |-
+            When the entry was settled. This will be unset for pending debits, and will be set for all settled debits.
           type: string
           format: date-time
         order:
-          description: The order which produced (for credits) or consumed (for debits) this entry.
+          description: |-
+            The order which produced (for credits) or consumed (for debits) this entry.
           type: integer
           format: int64
         account-entry:
-          description: The account-entry credit created by this entry. This will be set for rewards debits where the referenced account-entry credit shows the dollar increase associated with this rewards decrease.
+          description: |-
+            The account-entry credit created by this entry. This will be set for rewards debits where the referenced account-entry credit shows the dollar increase associated with this rewards decrease.
           type: integer
           format: int64
         total-credit:
-          description: Settled credit total through this reward entry.
+          description: |-
+            Settled credit total through this reward entry.
           type: number
           format: float
           minimum: 0
         total-debit:
-          description: Settled debit total through this reward entry.
+          description: |-
+            Settled debit total through this reward entry.
           type: number
           format: float
           minimum: 0
         total-pending:
-          description: Pending debit total through this reward entry.
+          description: |-
+            Pending debit total through this reward entry.
           type: number
           format: float
           minimum: 0
@@ -8067,134 +9193,162 @@ components:
         - amount
         - order
     postAffiliatePro:
-      description: Business logic around the affiliate program is handled by Beehive. If Beehive determines the referrer is due credit then this information is passed on to Post Affiliate Pro as a sale.
+      description: |-
+        Business logic around the affiliate program is handled by Beehive. If Beehive determines the referrer is due credit then this information is passed on to Post Affiliate Pro as a sale.
       type: object
       properties:
         referrer:
-          description: Post Affiliate Pro referring affiliate code.
+          description: |-
+            Post Affiliate Pro referring affiliate code.
           type: string
         visitor:
-          description: Post Affiliate Pro visitor id. This information is opaque to Azure.
+          description: |-
+            Post Affiliate Pro visitor id. This information is opaque to Azure.
           type: string
         banner:
-          description: Post Affiliate Pro banner ad id. This information is opaque to Azure.
+          description: |-
+            Post Affiliate Pro banner ad id. This information is opaque to Azure.
           type: string
       required:
         - referrer
         - visitor
     registrationResponse:
-      description: The registration response.
+      description: |-
+        The registration response.
       type: object
       properties:
         session:
           $ref: '#/components/schemas/session'
         auth-token:
-          description: Auth token. Can be sent to login to authenticate a new session.
+          description: |-
+            Auth token. Can be sent to login to authenticate a new session.
           type: string
         resend-token:
-          description: Resend token. Can be sent to resendRegistrationNotification to trigger a new registration notification.
+          description: |-
+            Resend token. Can be sent to resendRegistrationNotification to trigger a new registration notification.
           type: string
       required:
         - session
         - resend-token
     resendRegistrationNotification:
-      description: A request for another registration notification.
+      description: |-
+        A request for another registration notification.
       type: object
       properties:
         context:
           $ref: '#/components/schemas/registrationContext'
         authentication-base-url:
-          description: Redirect URL for the authentication UI. The authentication notification points customers at {authentication-base-url}{authentication-token} to authenticate a new session.
+          description: |-
+            Redirect URL for the authentication UI. The authentication notification points customers at {authentication-base-url}{authentication-token} to authenticate a new session.
           type: string
           format: url
         token:
-          description: The registrant's resend token.
+          description: |-
+            The registrant's resend token.
           type: string
       required:
         - authentication-base-url
         - token
     token:
-      description: Authentication credentials.
+      description: |-
+        Authentication credentials.
       type: object
       properties:
         token:
-          description: Token for authentication.
+          description: |-
+            Token for authentication.
           type: string
       required:
         - token
     usernamePassword:
-      description: Authentication credentials.
+      description: |-
+        Authentication credentials.
       type: object
       properties:
         username:
-          description: Username for authentication. Instead of your username, you could also use your primary email address or your person ID here.
+          description: |-
+            Username for authentication. Instead of your username, you could also use your primary email address or your person ID here.
           type: string
         password:
-          description: Password for authentication.
+          description: |-
+            Password for authentication.
           type: string
       required:
         - username
         - password
     passwordResetRequest:
-      description: A request for a password-reset token.
+      description: |-
+        A request for a password-reset token.
       type: object
       properties:
         base-url:
-          description: Redirect URL for the password reset UI. The password reset email points customers at {base-url}{confirmation-token} to confirm their password reset.
+          description: |-
+            Redirect URL for the password reset UI. The password reset email points customers at {base-url}{confirmation-token} to confirm their password reset.
           type: string
           format: url
         email:
-          description: The email address for the person whose password will be reset. Instead of the email address, you may also use your username or person ID here.
+          description: |-
+            The email address for the person whose password will be reset. Instead of the email address, you may also use your username or person ID here.
           type: string
       required:
         - base-url
         - email
     passwordResetConfirmation:
-      description: A request to reset a password using a password-reset token.
+      description: |-
+        A request to reset a password using a password-reset token.
       type: object
       properties:
         token:
-          description: The password-reset confirmation token.
+          description: |-
+            The password-reset confirmation token.
           type: string
         password:
-          description: The new password.
+          description: |-
+            The new password.
           type: string
       required:
         - token
         - password
     notificationChannel:
-      description: Channel technology for pushing user notifications.
+      description: |-
+        Channel technology for pushing user notifications.
       type: string
       enum:
         - email
         - text
     telephone:
-      description: A telephone number.
+      description: |-
+        A telephone number.
       type: object
       properties:
         pref:
-          description: Mark a preferred-use telephone number (assumed false).
+          description: |-
+            Mark a preferred-use telephone number (assumed false).
           type: boolean
         type:
-          description: An array of properties for this number.
+          description: |-
+            An array of properties for this number.
           type: array
           items:
             $ref: '#/components/schemas/telephoneType'
         number:
-          description: E.123 telephone number.
+          description: |-
+            E.123 telephone number.
           type: string
           format: telephone
       required:
         - type
         - number
     telephoneType:
-      description: A property of a telephone number.
+      description: |-
+        A property of a telephone number.
       type: string
       enum:
         - text
         - voice
     person:
-      description: A person (customer, vendor, employee, ..).
+      description: |-
+        A person (customer, vendor, employee, ..).
       type: object
       properties:
         id:
@@ -8203,184 +9357,227 @@ components:
         name:
           type: string
         active:
-          description: Whether or not this account is active. Inactive users cannot log in.
+          description: |-
+            Whether or not this account is active. Inactive users cannot log in.
           type: boolean
         password-usable:
-          description: Whether or not this account has a usable password.
+          description: |-
+            Whether or not this account has a usable password.
           type: boolean
         email:
-          description: The person's preferred, error-less email address (set if the "inline" query parameter contains "email").
+          description: |-
+            The person's preferred, error-less email address (set if the "inline" query parameter contains "email").
           type: string
           format: email
         can-email:
-          description: Can Azure contact this person for reasons other than registration.
+          description: |-
+            Can Azure contact this person for reasons other than registration.
           type: boolean
         sale-magazine:
-          description: Set to true to receive the sale magazine.
+          description: |-
+            Set to true to receive the sale magazine.
           type: boolean
         company:
-          description: Employer name.
+          description: |-
+            Employer name.
           type: string
         allow-social-media:
-          description: Does this person want social media links to display.
+          description: |-
+            Does this person want social media links to display.
           type: boolean
         price-level:
           $ref: '#/components/schemas/priceLevel'
         rewards-rate:
-          description: Rewards rate (as a percentage) for this customer. The rewards earned for a product will be the price (after sales) * min(max(`person.rewards-rate`, `product.rewards-rate`), `product.maxRewardsRate`) / 100, rounded to the nearest cent, rounding half to even.
+          description: |-
+            Rewards rate (as a percentage) for this customer. The rewards earned for a product will be the price (after sales) * min(max(`person.rewards-rate`, `product.rewards-rate`), `product.maxRewardsRate`) / 100, rounded to the nearest cent, rounding half to even.
           type: integer
           format: int32
           minimum: 0
         notifications:
           $ref: '#/components/schemas/personNotifications'
         permissions:
-          description: API permissions for this person.
+          description: |-
+            API permissions for this person.
           type: array
           items:
             $ref: '#/components/schemas/permission'
         order-place-issue:
-          description: If the person should be warned or blocked from placing orders, this property will be set with a slugged reason and recommended action. Only set if the "inline" query parameter contains "order-place-issue".
+          description: |-
+            If the person should be warned or blocked from placing orders, this property will be set with a slugged reason and recommended action. Only set if the "inline" query parameter contains "order-place-issue".
           type: string
           enum:
             - outstanding-balance-contact
             - outstanding-balance-pay
             - outstanding-balance-warn
         internal-notes:
-          description: Free-form Markdown notes for any internal information that doesn't fit into an existing field. Only Azure employees can view or edit this information, although it may be passed into the registerPerson endpoint when registering new people.
+          description: |-
+            Free-form Markdown notes for any internal information that doesn't fit into an existing field. Only Azure employees can view or edit this information, although it may be passed into the registerPerson endpoint when registering new people.
           type: string
         affiliate-code:
-          description: Affiliate code to be used with URL shares.
+          description: |-
+            Affiliate code to be used with URL shares.
           type: string
         affiliate-username:
-          description: Affiliate username (email).
+          description: |-
+            Affiliate username (email).
           type: string
           format: email
         is-allowed-to-be-affiliate:
-          description: Is allowed to be an affiliate.
+          description: |-
+            Is allowed to be an affiliate.
           type: boolean
         affiliate-campaign:
-          description: The affiliate campaign the person is a participant of.
+          description: |-
+            The affiliate campaign the person is a participant of.
           type: string
           enum:
             - lead
             - community
         marketing-slug:
-          description: A person's unique, primary marketing slug used, e.g., for the Azure Share program.
+          description: |-
+            A person's unique, primary marketing slug used, e.g., for the Azure Share program.
           type: string
         recency:
-          description: Order recency ranking. Higher rankings for customers with more recent orders.
+          description: |-
+            Order recency ranking. Higher rankings for customers with more recent orders.
           type: integer
           format: int32
           minimum: 1
           maximum: 5
         frequency:
-          description: Order frequency ranking. Higher rankings for customers with more frequent orders.
+          description: |-
+            Order frequency ranking. Higher rankings for customers with more frequent orders.
           type: integer
           format: int32
           minimum: 1
           maximum: 5
         monetary:
-          description: Order value ranking. Higher rankings for customers with larger orders.
+          description: |-
+            Order value ranking. Higher rankings for customers with larger orders.
           type: integer
           format: int32
           minimum: 1
           maximum: 5
         first-order-placed:
-          description: When this customer's first order was placed. This timestamp does not change once set, even if the initial order is subsequently deleted.
+          description: |-
+            When this customer's first order was placed. This timestamp does not change once set, even if the initial order is subsequently deleted.
           type: string
           format: date-time
         last-order-placed:
-          description: When this customer's most recent order was placed. This timestamp includes all open-to-placed transitions, regardless of whether the related order is subsequently deleted.
+          description: |-
+            When this customer's most recent order was placed. This timestamp includes all open-to-placed transitions, regardless of whether the related order is subsequently deleted.
           type: string
           format: date-time
         is-drop-coordinator:
-          description: Is a drop coordinator (inclusive of both primary contact and managers). Only set if the "inline" query parameter contains "is-drop-coordinator".
+          description: |-
+            Is a drop coordinator (inclusive of both primary contact and managers). Only set if the "inline" query parameter contains "is-drop-coordinator".
           type: boolean
       required:
         - id
         - name
         - notifications
     updatePerson:
-      description: A person (customer, vendor, employee, ..).
+      description: |-
+        A person (customer, vendor, employee, ..).
       type: object
       properties:
         name:
           type: string
         password:
-          description: Password for authentication.
+          description: |-
+            Password for authentication.
           type: string
         can-email:
-          description: Can Azure contact this person for reasons other than registration? Defaults to true when creating a person.
+          description: |-
+            Can Azure contact this person for reasons other than registration? Defaults to true when creating a person.
           type: boolean
         sale-magazine:
-          description: Subscribed to receive the sale magazine?  Defaults to false when creating a person.
+          description: |-
+            Subscribed to receive the sale magazine?  Defaults to false when creating a person.
           type: boolean
         company:
-          description: Employer name.
+          description: |-
+            Employer name.
           type: string
         allow-social-media:
-          description: Does this person want social media links to display?  Defaults to true when creating a person.
+          description: |-
+            Does this person want social media links to display?  Defaults to true when creating a person.
           type: boolean
         notifications:
           $ref: '#/components/schemas/personNotifications'
         affiliate-code:
-          description: Affiliate code to be used with URL shares. Only users with the update-person permission can edit this information.
+          description: |-
+            Affiliate code to be used with URL shares. Only users with the update-person permission can edit this information.
           type: string
         is-allowed-to-be-affiliate:
-          description: Is allowed to be an affiliate. Only users with the update-person permission can edit this information.
+          description: |-
+            Is allowed to be an affiliate. Only users with the update-person permission can edit this information.
           type: boolean
     updatePersonUserPassword:
-      description: A person (customer, vendor, employee, ..) with the logged in user's password.
+      description: |-
+        A person (customer, vendor, employee, ..) with the logged in user's password.
       type: object
       properties:
         name:
           type: string
         password:
-          description: Password for authentication.
+          description: |-
+            Password for authentication.
           type: string
         can-email:
-          description: Can Azure contact this person for reasons other than registration.
+          description: |-
+            Can Azure contact this person for reasons other than registration.
           type: boolean
         sale-magazine:
-          description: Subscribed to receive the sale magazine.
+          description: |-
+            Subscribed to receive the sale magazine.
           type: boolean
         company:
-          description: Employer name.
+          description: |-
+            Employer name.
           type: string
         allow-social-media:
-          description: Does this person want social media links to display.
+          description: |-
+            Does this person want social media links to display.
           type: boolean
         user-password:
-          description: The authenticated person's password. Required when changing password for users with a usable password.
+          description: |-
+            The authenticated person's password. Required when changing password for users with a usable password.
           type: string
         notifications:
           $ref: '#/components/schemas/personNotifications'
     personNotifications:
-      description: Configure if and how a user receives per-user notifications.
+      description: |-
+        Configure if and how a user receives per-user notifications.
       type: object
       properties:
         abandonedCart:
-          description: Sent when an unplaced order is left in a cart.
+          description: |-
+            Sent when an unplaced order is left in a cart.
           format: array
           items:
             $ref: '#/components/schemas/notificationChannel'
         checkout:
-          description: Sent after checking out orders.
+          description: |-
+            Sent after checking out orders.
           format: array
           items:
             $ref: '#/components/schemas/notificationChannel'
         delivery:
-          description: Sent after order delivery, and after updates to delivery estimates.
+          description: |-
+            Sent after order delivery, and after updates to delivery estimates.
           format: array
           items:
             $ref: '#/components/schemas/notificationChannel'
         payment:
-          description: Sent after Azure processes a payment.
+          description: |-
+            Sent after Azure processes a payment.
           format: array
           items:
             $ref: '#/components/schemas/notificationChannel'
         invoice:
-          description: Sent when new invoices are generated.
+          description: |-
+            Sent when new invoices are generated.
           format: array
           items:
             type: string
@@ -8388,11 +9585,13 @@ components:
               - paper
               - email
     address:
-      description: An address following the convention of http://microformats.org/wiki/h-adr and https://tools.ietf.org/html/rfc6350#section-6.3.1, with an additional `name` property.
+      description: |-
+        An address following the convention of http://microformats.org/wiki/h-adr and https://tools.ietf.org/html/rfc6350#section-6.3.1, with an additional `name` property.
       type: object
       properties:
         name:
-          description: Contact name for this address (e.g. "Mr. John Q. Public, Esq.").
+          description: |-
+            Contact name for this address (e.g. "Mr. John Q. Public, Esq.").
           type: string
         post-office-box:
           type: string
@@ -8403,50 +9602,60 @@ components:
         locality:
           type: string
         region:
-          description: Required for the United States and Canada, optional for other countries.
+          description: |-
+            Required for the United States and Canada, optional for other countries.
           type: string
         postal-code:
           type: string
         country:
-          description: ISO 3166-1 alpha-3 code for the country. On push, you can set the alpha-2 code or case-insensitve name instead, or you can use an inline country object.
+          description: |-
+            ISO 3166-1 alpha-3 code for the country. On push, you can set the alpha-2 code or case-insensitve name instead, or you can use an inline country object.
           type: string
         preference:
-          description: Ordering precedence for the findAddresses. Defaults to zero.
+          description: |-
+            Ordering precedence for the findAddresses. Defaults to zero.
           type: integer
           format: int32
       required:
         - locality
         - country
     country:
-      description: A country.
+      description: |-
+        A country.
       type: object
       properties:
         name:
-          description: Country name.
+          description: |-
+            Country name.
           type: string
         iso:
-          description: The country's ISO 3166-1 alpha-2 code.
+          description: |-
+            The country's ISO 3166-1 alpha-2 code.
           type: string
         iso3:
-          description: The country's ISO 3166-1 alpha-3 code.
+          description: |-
+            The country's ISO 3166-1 alpha-3 code.
           type: string
       required:
         - name
         - iso
         - iso3
     region:
-      description: A country region (US state or Canadian province).
+      description: |-
+        A country region (US state or Canadian province).
       type: object
       properties:
         name:
-          description: Region name.
+          description: |-
+            Region name.
           type: string
         abbreviation:
           type: string
         country-iso3:
           type: string
     location:
-      description: A named geographic coordinate with an enumerated label.
+      description: |-
+        A named geographic coordinate with an enumerated label.
       type: object
       properties:
         id:
@@ -8463,7 +9672,8 @@ components:
         - name
         - geo
     geo:
-      description: A geographical coordinate.
+      description: |-
+        A geographical coordinate.
       type: object
       properties:
         latitude:
@@ -8476,7 +9686,8 @@ components:
         - latitude
         - longitude
     email:
-      description: An email address.
+      description: |-
+        An email address.
       type: object
       properties:
         id:
@@ -8486,14 +9697,17 @@ components:
           type: string
           format: email
         person:
-          description: Person associated with this email.
+          description: |-
+            Person associated with this email.
           type: integer
           format: int64
         error:
-          description: Reason for not using this address (e.g. "email bounced on 2016-08-15").
+          description: |-
+            Reason for not using this address (e.g. "email bounced on 2016-08-15").
           type: string
         preference:
-          description: Ordering precedence for the findEmails.
+          description: |-
+            Ordering precedence for the findEmails.
           type: integer
           format: int32
       required:
@@ -8501,18 +9715,21 @@ components:
         - address
         - person
     updateEmailUserPassword:
-      description: A request for adding or updating an email address with the logged in user's password.
+      description: |-
+        A request for adding or updating an email address with the logged in user's password.
       type: object
       properties:
         email:
           $ref: '#/components/schemas/email'
         user-password:
-          description: The authenticated person's password. Required for users with a usable password.
+          description: |-
+            The authenticated person's password. Required for users with a usable password.
           type: string
       required:
         - email
     favorite:
-      description: A customer favorite.
+      description: |-
+        A customer favorite.
       type: object
       properties:
         id:
@@ -8535,7 +9752,8 @@ components:
         - packaged-product
         - customer
     updateFavorite:
-      description: A customer favorite.
+      description: |-
+        A customer favorite.
       type: object
       properties:
         quantity:
@@ -8551,17 +9769,20 @@ components:
         - packaged-product
         - customer
     faq:
-      description: Frequently asked question.
+      description: |-
+        Frequently asked question.
       type: object
       properties:
         id:
           type: integer
           format: int64
         question:
-          description: A frequently asked question in plain text.
+          description: |-
+            A frequently asked question in plain text.
           type: string
         answer:
-          description: The answer to the associated question in plain text.
+          description: |-
+            The answer to the associated question in plain text.
           type: string
         order:
           type: integer
@@ -8572,17 +9793,20 @@ components:
         - answer
         - order
     updateFaq:
-      description: Frequently asked question.
+      description: |-
+        Frequently asked question.
       type: object
       properties:
         id:
           type: integer
           format: int64
         question:
-          description: A frequently asked question in plain text.
+          description: |-
+            A frequently asked question in plain text.
           type: string
         answer:
-          description: The answer to the associated question in plain text.
+          description: |-
+            The answer to the associated question in plain text.
           type: string
         order:
           type: integer
@@ -8592,19 +9816,23 @@ components:
         - answer
         - order
     session:
-      description: Session cookie information.
+      description: |-
+        Session cookie information.
       type: object
       properties:
         person:
-          description: Person ID for the session owner (unset for anonymous sessions).
+          description: |-
+            Person ID for the session owner (unset for anonymous sessions).
           type: integer
           format: int64
         expires:
-          description: Current expiration date-time for this session (http://tools.ietf.org/html/rfc6265#section-5.3, covering both Max-Age and Expires representations, unset if the session expires at browser-close).
+          description: |-
+            Current expiration date-time for this session (http://tools.ietf.org/html/rfc6265#section-5.3, covering both Max-Age and Expires representations, unset if the session expires at browser-close).
           type: string
           format: date-time
     notification:
-      description: A notification to display on the website.
+      description: |-
+        A notification to display on the website.
       type: object
       properties:
         id:
@@ -8616,12 +9844,14 @@ components:
           type: boolean
         dismissed:
           type: boolean
-          description: If annotate-person is specified in the request, this field will note if the notification has been dismissed.
+          description: |-
+            If annotate-person is specified in the request, this field will note if the notification has been dismissed.
       required:
         - id
         - message
     notificationDismissal:
-      description: A dismissal used to hide a read notification.
+      description: |-
+        A dismissal used to hide a read notification.
       type: object
       properties:
         id:
@@ -8637,18 +9867,22 @@ components:
         - notification
         - person
     productAudit:
-      description: An audited or auditable product and its packaging.
+      description: |-
+        An audited or auditable product and its packaging.
       type: object
       properties:
         id:
-          description: The product ID (not unique to the audit process).
+          description: |-
+            The product ID (not unique to the audit process).
           type: integer
           format: int64
         name:
-          description: Sentence-length product name. Copied from `#definitions/product` for easier UI development.
+          description: |-
+            Sentence-length product name. Copied from `#definitions/product` for easier UI development.
           type: string
         packaging:
-          description: All related audited and/or non-audited packaged versions of this product.
+          description: |-
+            All related audited and/or non-audited packaged versions of this product.
           type: array
           items:
             $ref: '#/components/schemas/packagedProductAudit'
@@ -8657,24 +9891,29 @@ components:
         - name
         - packaging
     packagedProductAudit:
-      description: An audited or auditable packaged-product.
+      description: |-
+        An audited or auditable packaged-product.
       type: object
       properties:
         id:
-          description: The packaged-product id (not unique to the audit process).
+          description: |-
+            The packaged-product id (not unique to the audit process).
           type: string
         size:
-          description: The old size of the product (e.g. "12 oz." or "6x12 oz.").
+          description: |-
+            The old size of the product (e.g. "12 oz." or "6x12 oz.").
           type: string
         packs:
-          description: The new dimensions of package sizes (e.g. "4", "4x32.5", or "2x4x32.5").
+          description: |-
+            The new dimensions of package sizes (e.g. "4", "4x32.5", or "2x4x32.5").
           type: string
         unit:
           description: |-
             The new unit of measurement. You can use any string, but the backend will only be able to make automatic comparisons if you use SI prefixes (e.g. "mm" for millimeters) and stick to the following base units: pound, ounce, gram, gallon, liter, quart, pint, cup, fluid ounce, yard, and count
           type: string
         audited:
-          description: A datetime denoting if and when the packaged-product was last audited.
+          description: |-
+            A datetime denoting if and when the packaged-product was last audited.
           type: string
       required:
         - id
@@ -8683,20 +9922,25 @@ components:
         - unit
         - audited
     updatePackagedProductAudit:
-      description: An update to an audited packaged-product.
+      description: |-
+        An update to an audited packaged-product.
       type: object
       properties:
         packs:
-          description: The new dimensions of package sizes (e.g. "4", "4x32.5", or "2x4x32.5").
+          description: |-
+            The new dimensions of package sizes (e.g. "4", "4x32.5", or "2x4x32.5").
           type: string
         unit:
-          description: The new unit of measurement. Ideally one of "", or "", but you can use another unit if none of those fit.
+          description: |-
+            The new unit of measurement. Ideally one of "", or "", but you can use another unit if none of those fit.
           type: string
         size:
-          description: Override the auto-generated size (based on packs and unit) with a custom name. This can be useful for adding packaging information (e.g. "32 floz glass" to distinguish glass from plastic vinegar bottles).
+          description: |-
+            Override the auto-generated size (based on packs and unit) with a custom name. This can be useful for adding packaging information (e.g. "32 floz glass" to distinguish glass from plastic vinegar bottles).
           type: string
         clear-audited:
-          description: If true, clear the audited date-time for this packaged-product. If false (the default), set the audited date-time to the current time.
+          description: |-
+            If true, clear the audited date-time for this packaged-product. If false (the default), set the audited date-time to the current time.
           type: boolean
       required:
         - packs
@@ -8714,7 +9958,8 @@ components:
         format:
           $ref: '#/components/schemas/printerFormatType'
         warehouse:
-          description: The warehouse's code.
+          description: |-
+            The warehouse's code.
           type: string
       required:
         - id
@@ -8723,34 +9968,40 @@ components:
         - format
         - warehouse
     printerDeliveryType:
-      description: A property for printer delivery method.
+      description: |-
+        A property for printer delivery method.
       type: string
       enum:
         - http
         - cups
         - bartender
     printerFormatType:
-      description: A property for printer format method.
+      description: |-
+        A property for printer format method.
       type: string
       enum:
         - pdf
         - epl2
         - bartender
     warehouse:
-      description: A physical warehouse or facility.
+      description: |-
+        A physical warehouse or facility.
       type: object
       properties:
         code:
-          description: Slug for stable reference (e.g. "moro").
+          description: |-
+            Slug for stable reference (e.g. "moro").
           type: string
         name:
-          description: Human readable name (e.g. "Moro").
+          description: |-
+            Human readable name (e.g. "Moro").
           type: string
       required:
         - code
         - name
     ip2location:
-      description: Location information for an ip address.
+      description: |-
+        Location information for an ip address.
       type: object
       properties:
         address:
@@ -8761,18 +10012,22 @@ components:
         - address
         - geo
     weight:
-      description: Packaged product weight information.
+      description: |-
+        Packaged product weight information.
       properties:
         average:
-          description: An estimate of the average weight of the packaged product in pounds.
+          description: |-
+            An estimate of the average weight of the packaged product in pounds.
           type: number
           format: float
         minimum:
-          description: Minimum weight of the packaged product in pounds.
+          description: |-
+            Minimum weight of the packaged product in pounds.
           type: number
           format: float
         maximum:
-          description: Maximum weight of the packaged product in pounds.
+          description: |-
+            Maximum weight of the packaged product in pounds.
           type: number
           format: float
       required:
@@ -8783,9 +10038,11 @@ components:
         - message
       properties:
         code:
-          description: HTTP error code (https://tools.ietf.org/html/rfc7231#section-6).
+          description: |-
+            HTTP error code (https://tools.ietf.org/html/rfc7231#section-6).
           type: integer
           format: int32
         message:
-          description: A sentence or two describing the error.
+          description: |-
+            A sentence or two describing the error.
           type: string

--- a/public.yaml
+++ b/public.yaml
@@ -6475,7 +6475,7 @@ components:
           format: int64
         name:
           type: string
-        description:.
+        description:
           type: string
         cutoff-frequency:
           description: Number of days between cutoffs.
@@ -6521,7 +6521,7 @@ components:
       description: An order-delivery truck route's updated values.
       type: object
       properties:
-        description:.
+        description:
           type: string
         cutoff-frequency:
           description: Number of days between cutoffs.
@@ -6920,13 +6920,13 @@ components:
         treatAsActive:
           description: If true, this product will be published to search engines even when it is inactive (out for season, out long term, or discontinued).
           type: boolean
-        inactiveDescription:.
+        inactiveDescription:
           description: HTML description applicable only when the product is inactive (out for season, out long term, or discontinued). It should contain specific information pertinent to the inactive status of the product (e.g. details about why it is inactive and what similar products are available instead). It should not duplicate information in short-description or description.
           type: string
-        short-description:.
+        short-description:
           description: Paragraph-length, stand-alone, plain-text product description.
           type: string
-        description:.
+        description:
           description: Long-form, HTML product description. When short-description is set, this value is for additional information which did not fit into short-description. Displaying both short-description and description is not redundant. Displaying only description may be confusing when short-description is available.
           type: string
         brand:
@@ -7103,7 +7103,7 @@ components:
         seo-name:
           description: An SEO-optimized name for the category. A lengthened version of the full name that includes additional keywords or rephrasing, suitable for use in a title tag. When this is unset, the name is a reasonable fallback.
           type: string
-        description:.
+        description:
           description: A sentence or two with a stand-alone category description. When this is unset, the nearest ancestor description is a reasonable fallback.
           type: string
         image:
@@ -7156,7 +7156,7 @@ components:
         seo-name:
           description: An SEO-optimized name for the category. A lengthened version of the full name that includes additional keywords or rephrasing, suitable for use in a title tag. When this is unset, the name is a reasonable fallback.
           type: string
-        description:.
+        description:
           description: A sentence or two with a stand-alone category description. When this is unset, the nearest ancestor description is a reasonable fallback.
           type: string
         image:

--- a/public.yaml
+++ b/public.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   version: 1.0.0-oas3
   title: Azure Standard Public API
-  description: The public API behind Azure's website
+  description: The public API behind Azure's website.
   contact:
     name: Azure Standard Customer Service
     email: info@azurestandard.com
@@ -23,31 +23,31 @@ paths:
       parameters:
         - name: person
           in: query
-          description: person ID of the referring user
+          description: Person ID of the referring user.
           required: true
           schema:
             type: integer
             format: int64
         - name: limit
           in: query
-          description: maximum number of results to return
+          description: Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: affiliate referral response
+          description: Affiliate referral response.
           headers:
             Count:
-              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -59,7 +59,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/affiliateReferral'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -73,24 +73,24 @@ paths:
       parameters:
         - name: limit
           in: query
-          description: maximum number of results to return
+          description: Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: bartenderHost response
+          description: BartenderHost response.
           headers:
             Count:
-              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -102,7 +102,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/bartenderHost'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -114,13 +114,13 @@ paths:
         - bartender
       responses:
         '200':
-          description: BarTender host response
+          description: BarTender host response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/bartenderHost'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -130,7 +130,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/bartenderHost'
-        description: BarTender host to add
+        description: BarTender host to add.
         required: true
   '/bartender-host/{code}':
     get:
@@ -141,19 +141,19 @@ paths:
       parameters:
         - name: code
           in: path
-          description: code of BarTender host to fetch
+          description: Code of BarTender host to fetch.
           required: true
           schema:
             type: string
       responses:
         '200':
-          description: BarTender host response
+          description: BarTender host response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/bartenderHost'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -166,19 +166,19 @@ paths:
       parameters:
         - name: code
           in: path
-          description: code of BarTender host to update
+          description: Code of BarTender host to update.
           required: true
           schema:
             type: string
       responses:
         '200':
-          description: BarTender host response
+          description: BarTender host response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/bartenderHost'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -188,7 +188,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/bartenderHost'
-        description: Updated BarTender host parameters (can optionally include 'code')
+        description: Updated BarTender host parameters (can optionally include 'code').
         required: true
     delete:
       summary: Delete an existing BarTender host
@@ -198,15 +198,15 @@ paths:
       parameters:
         - name: code
           in: path
-          description: code of BarTender host to delete
+          description: Code of BarTender host to delete.
           required: true
           schema:
             type: string
       responses:
         '204':
-          description: delete successful
+          description: Delete successful.
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -220,24 +220,24 @@ paths:
       parameters:
         - name: limit
           in: query
-          description: maximum number of results to return
+          description: Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: bartenderTemplate response
+          description: BartenderTemplate response.
           headers:
             Count:
-              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -249,7 +249,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/bartenderTemplate'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -261,13 +261,13 @@ paths:
         - bartender
       responses:
         '200':
-          description: BarTender template response
+          description: BarTender template response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/bartenderTemplate'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -277,7 +277,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/bartenderTemplate'
-        description: BarTender template to add
+        description: BarTender template to add.
         required: true
   '/bartender-template/{id}':
     get:
@@ -288,20 +288,20 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of BarTender template to fetch
+          description: ID of BarTender template to fetch.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: BarTender template response
+          description: BarTender template response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/bartenderTemplate'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -314,20 +314,20 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of BarTender template to update
+          description: ID of BarTender template to update.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: BarTender template response
+          description: BarTender template response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/bartenderTemplate'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -337,7 +337,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/bartenderTemplate'
-        description: Updated BarTender template parameters (can optionally include 'id')
+        description: Updated BarTender template parameters (can optionally include 'id').
         required: true
     delete:
       summary: Delete an existing BarTender template
@@ -347,16 +347,16 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of BarTender template to delete
+          description: ID of BarTender template to delete.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '204':
-          description: delete successful
+          description: Delete successful.
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -370,24 +370,24 @@ paths:
       parameters:
         - name: limit
           in: query
-          description: maximum number of results to return
+          description: Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: bartenderPrintConfiguration response
+          description: BartenderPrintConfiguration response.
           headers:
             Count:
-              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -399,7 +399,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/bartenderPrintConfiguration'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -411,13 +411,13 @@ paths:
         - bartender
       responses:
         '200':
-          description: BarTender print configuration response
+          description: BarTender print configuration response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/bartenderPrintConfiguration'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -427,7 +427,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/bartenderPrintConfiguration'
-        description: BarTender print configuration to add
+        description: BarTender print configuration to add.
         required: true
   '/bartender-print-configuration/{id}':
     get:
@@ -438,20 +438,20 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of BarTender print configuration to fetch
+          description: ID of BarTender print configuration to fetch.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: BarTender print configuration response
+          description: BarTender print configuration response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/bartenderPrintConfiguration'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -464,20 +464,20 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of BarTender print configuration to update
+          description: ID of BarTender print configuration to update.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: BarTender print configuration response
+          description: BarTender print configuration response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/bartenderPrintConfiguration'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -487,7 +487,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/bartenderPrintConfiguration'
-        description: Updated BarTender print configuration parameters (can optionally include 'id')
+        description: Updated BarTender print configuration parameters (can optionally include 'id').
         required: true
     delete:
       summary: Delete an existing BarTender print configuration
@@ -497,16 +497,16 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of BarTender print configuration to delete
+          description: ID of BarTender print configuration to delete.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '204':
-          description: delete successful
+          description: Delete successful.
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -520,16 +520,16 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of BarTender print configuration to test
+          description: ID of BarTender print configuration to test.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '202':
-          description: BarTender print configuration test print request accepted
+          description: BarTender print configuration test print request accepted.
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -572,14 +572,14 @@ paths:
                   - none
         - name: start
           in: query
-          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: brand response
+          description: Brand response.
           headers:
             Count:
               description: Total number of matching results (how many you'd get if you set `limit` to `none`).
@@ -594,7 +594,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/brand'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -609,20 +609,20 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of brand to fetch
+          description: ID of brand to fetch.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: brand response
+          description: Brand response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/brand'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -666,24 +666,24 @@ paths:
               type: string
         - name: limit
           in: query
-          description: maximum number of results to return
+          description: Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: companyDirectoryEntry response
+          description: CompanyDirectoryEntry response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`)
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -723,10 +723,10 @@ paths:
             format: int32
       responses:
         '200':
-          description: Department response
+          description: Department response.
           headers:
             Count:
-              description: Total number of matching results (how many you'd get if you could set an infinite `limit`)
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -768,24 +768,24 @@ paths:
               format: int64
         - name: limit
           in: query
-          description: maximum number of results to return
+          description: Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: report response
+          description: Report response.
           headers:
             Count:
-              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -797,7 +797,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/report'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -811,19 +811,19 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of report to fetch
+          description: ID of report to fetch.
           required: true
           schema:
             type: string
       responses:
         '200':
-          description: report response
+          description: Report response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/report'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -837,30 +837,30 @@ paths:
       parameters:
         - name: customer-pricing
           in: query
-          description: Filter categories by whether or not they contain customer pricing groups
+          description: Filter categories by whether or not they contain customer pricing groups.
           required: false
           schema:
             type: boolean
         - name: limit
           in: query
-          description: maximum number of results to return
+          description: Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: reportCategory response
+          description: ReportCategory response.
           headers:
             Count:
-              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -872,7 +872,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/reportCategory'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -884,13 +884,13 @@ paths:
         - report
       responses:
         '200':
-          description: report category response
+          description: Report category response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/reportCategory'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -900,7 +900,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/reportCategory'
-        description: report category to add
+        description: Report category to add.
         required: true
   '/report-category/{id}':
     get:
@@ -911,19 +911,19 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of report category to fetch
+          description: ID of report category to fetch.
           required: true
           schema:
             type: string
       responses:
         '200':
-          description: report category response
+          description: Report category response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/reportCategory'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -936,19 +936,19 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of report category to update
+          description: ID of report category to update.
           required: true
           schema:
             type: string
       responses:
         '200':
-          description: reportCategory response
+          description: ReportCategory response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/reportCategory'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -958,7 +958,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/reportCategory'
-        description: Updated report category parameters
+        description: Updated report category parameters.
         required: true
     delete:
       summary: Delete an existing report category
@@ -968,15 +968,15 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of report category to delete
+          description: ID of report category to delete.
           required: true
           schema:
             type: string
       responses:
         '204':
-          description: delete successful
+          description: Delete successful.
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -990,13 +990,13 @@ paths:
       parameters:
         - name: active
           in: query
-          description: only return (in)active drops
+          description: Only return (in)active drops.
           required: false
           schema:
             type: boolean
         - name: exclusivity
           in: query
-          description: types of exclusivity to filter by
+          description: Types of exclusivity to filter by.
           required: false
           style: form
           schema:
@@ -1009,7 +1009,7 @@ paths:
                 - closed
         - name: route
           in: query
-          description: route names to filter by
+          description: Route names to filter by.
           required: false
           style: form
           schema:
@@ -1018,7 +1018,7 @@ paths:
               type: string
         - name: trip
           in: query
-          description: trip IDs to filter by
+          description: Trip IDs to filter by.
           required: false
           style: form
           schema:
@@ -1028,7 +1028,7 @@ paths:
               format: int64
         - name: filter-person
           in: query
-          description: person IDs to filter by
+          description: Person IDs to filter by.
           required: false
           style: form
           schema:
@@ -1044,24 +1044,24 @@ paths:
             type: string
         - name: limit
           in: query
-          description: maximum number of results to return
+          description: Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: drop response
+          description: Drop response.
           headers:
             Count:
-              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -1073,7 +1073,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/drop'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -1085,13 +1085,13 @@ paths:
         - drop
       responses:
         '200':
-          description: drop response
+          description: Drop response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/drop'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -1101,7 +1101,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/newDrop'
-        description: Drop to add
+        description: Drop to add.
         required: true
   '/drop/{id}':
     get:
@@ -1112,20 +1112,20 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of drop to fetch
+          description: ID of drop to fetch.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: drop response
+          description: Drop response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/drop'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -1138,20 +1138,20 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of drop to update
+          description: ID of drop to update.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: drop response
+          description: Drop response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/drop'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -1161,7 +1161,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updateDrop'
-        description: Updated drop parameters (can optionally include 'id')
+        description: Updated drop parameters (can optionally include 'id').
         required: true
     delete:
       summary: Delete an existing drop
@@ -1171,16 +1171,16 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of drop to delete
+          description: ID of drop to delete.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '204':
-          description: delete successful
+          description: Delete successful.
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -1194,7 +1194,7 @@ paths:
         - drop
       responses:
         '200':
-          description: drop locations response
+          description: Drop locations response.
           content:
             application/json:
               schema:
@@ -1202,7 +1202,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/location'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -1216,13 +1216,13 @@ paths:
       parameters:
         - name: active
           in: query
-          description: only return (in)active memberships
+          description: Only return (in)active memberships.
           required: false
           schema:
             type: boolean
         - name: drop
           in: query
-          description: drop IDs to filter by
+          description: Drop IDs to filter by.
           required: false
           style: form
           schema:
@@ -1232,7 +1232,7 @@ paths:
               format: int64
         - name: filter-person
           in: query
-          description: person IDs to filter by
+          description: Person IDs to filter by.
           required: false
           style: form
           schema:
@@ -1242,13 +1242,13 @@ paths:
               format: int64
         - name: pending
           in: query
-          description: only return pending (true) or accepted (false) memberships
+          description: Only return pending (true) or accepted (false) memberships.
           required: false
           schema:
             type: boolean
         - name: inline
           in: query
-          description: for convenience, include a full representation of the inlined property. Currently supports "customer", "customer.email", "drop", and "gratitude-total".
+          description: For convenience, include a full representation of the inlined property. Currently supports "customer", "customer.email", "drop", and "gratitude-total".
           required: false
           style: form
           schema:
@@ -1257,30 +1257,31 @@ paths:
               type: string
         - name: sort
           in: query
-          description: 'Order results by this field. Supported fields: `customer.name`, `drop.name`.'
+          description: |-
+            Order results by this field. Supported fields: `customer.name`, `drop.name`.
           required: false
           schema:
             type: string
         - name: limit
           in: query
-          description: maximum number of results to return
+          description: Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: drop membership response
+          description: Drop membership response.
           headers:
             Count:
-              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -1292,7 +1293,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/dropMembership'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -1304,13 +1305,13 @@ paths:
         - drop-membership
       responses:
         '200':
-          description: drop membership response
+          description: Drop membership response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/dropMembership'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -1320,25 +1321,25 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/newDropMembership'
-        description: drop membership to add
+        description: Drop membership to add.
         required: true
   '/drop-membership/{id}':
     get:
-      summary: Returns a drop membership based on a single membership ID, if the user has access.
+      summary: Returns a drop membership based on a single membership ID, if the user has access
       operationId: findDropMembershipById
       tags:
         - drop-membership
       parameters:
         - name: id
           in: path
-          description: ID of drop membership to fetch
+          description: ID of drop membership to fetch.
           required: true
           schema:
             type: integer
             format: int64
         - name: inline
           in: query
-          description: for convenience, include a full representation of the inlined property. Currently supports "customer", "drop", and "gratitude-total".
+          description: For convenience, include a full representation of the inlined property. Currently supports "customer", "drop", and "gratitude-total".
           required: false
           style: form
           schema:
@@ -1347,39 +1348,39 @@ paths:
               type: string
       responses:
         '200':
-          description: drop membership response
+          description: Drop membership response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/dropMembership'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
     put:
-      summary: Update an existing drop membership if the user has the access.
+      summary: Update an existing drop membership if the user has the access
       operationId: updateDropMembership
       tags:
         - drop-membership
       parameters:
         - name: id
           in: path
-          description: ID of drop membership to update
+          description: ID of drop membership to update.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: drop membership response
+          description: Drop membership response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/dropMembership'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -1389,7 +1390,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updateDropMembership'
-        description: Updated drop membership parameters
+        description: Updated drop membership parameters.
         required: true
     delete:
       summary: Delete an existing drop membership
@@ -1399,16 +1400,16 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of drop membership to delete
+          description: ID of drop membership to delete.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '204':
-          description: delete successful
+          description: Delete successful.
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -1482,7 +1483,9 @@ paths:
         description: File to add. The payload is the raw content, not a JSON object.
   '/file/{id}':
     delete:
-      summary: Delete an existing file. This may fail if there are any internal references to the file.
+      summary: Delete an existing file
+      description: |-
+        Note: This may fail if there are any internal references to the file.
       operationId: deleteFile
       tags:
         - file
@@ -1511,13 +1514,13 @@ paths:
       parameters:
         - name: active
           in: query
-          description: only return (in)active pickups
+          description: Only return (in)active pickups.
           required: false
           schema:
             type: boolean
         - name: route
           in: query
-          description: route names to filter by
+          description: Route names to filter by.
           required: false
           style: form
           schema:
@@ -1526,7 +1529,7 @@ paths:
               type: string
         - name: trip
           in: query
-          description: trip IDs to filter by
+          description: Trip IDs to filter by.
           required: false
           style: form
           schema:
@@ -1536,7 +1539,7 @@ paths:
               format: int64
         - name: vendor
           in: query
-          description: vendor IDs to filter by
+          description: Vendor IDs to filter by.
           required: false
           style: form
           schema:
@@ -1546,24 +1549,24 @@ paths:
               format: int64
         - name: limit
           in: query
-          description: maximum number of results to return
+          description: Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: pickup response
+          description: Pickup response.
           headers:
             Count:
-              description: total number of matching results (how many you'd get if you didn't set `limit`)
+              description: Total number of matching results (how many you'd get if you didn't set `limit`).
               schema:
                 type: integer
                 format: int32
@@ -1575,7 +1578,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/pickup'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -1589,20 +1592,20 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of pickup to fetch
+          description: ID of pickup to fetch.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: pickup response
+          description: Pickup response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/pickup'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -1616,7 +1619,7 @@ paths:
       parameters:
         - name: drop
           in: query
-          description: drop IDs to filter by
+          description: Drop IDs to filter by.
           required: false
           style: form
           schema:
@@ -1626,24 +1629,24 @@ paths:
               format: int64
         - name: limit
           in: query
-          description: maximum number of results to return
+          description: Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: route response
+          description: Route response.
           headers:
             Count:
-              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -1655,7 +1658,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/route'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -1667,13 +1670,13 @@ paths:
         - route
       responses:
         '200':
-          description: route response
+          description: Route response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/route'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -1683,7 +1686,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/newRoute'
-        description: Route to add
+        description: Route to add.
         required: true
   '/route/{name}':
     get:
@@ -1694,19 +1697,19 @@ paths:
       parameters:
         - name: name
           in: path
-          description: name of route to fetch
+          description: Name of route to fetch.
           required: true
           schema:
             type: string
       responses:
         '200':
-          description: route response
+          description: Route response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/route'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -1719,19 +1722,19 @@ paths:
       parameters:
         - name: name
           in: path
-          description: name of route to update
+          description: Name of route to update.
           required: true
           schema:
             type: string
       responses:
         '200':
-          description: route response
+          description: Route response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/route'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -1741,7 +1744,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updateRoute'
-        description: update route parameters
+        description: Update route parameters.
         required: true
     delete:
       summary: Delete an existing route
@@ -1751,15 +1754,15 @@ paths:
       parameters:
         - name: name
           in: path
-          description: name of route to delete
+          description: Name of route to delete.
           required: true
           schema:
             type: string
       responses:
         '204':
-          description: delete successful
+          description: Delete successful.
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -1767,14 +1770,14 @@ paths:
   /trips:
     get:
       summary: Returns all trips from the system that the user has access to
-      description: Trips are ordered for decreasing cutoff time
+      description: Trips are ordered for decreasing cutoff time.
       operationId: findTrips
       tags:
         - trip
       parameters:
         - name: route
           in: query
-          description: route names to filter by
+          description: Route names to filter by.
           required: false
           style: form
           schema:
@@ -1783,7 +1786,7 @@ paths:
               type: string
         - name: drop
           in: query
-          description: drop IDs to filter by
+          description: Drop IDs to filter by.
           required: false
           style: form
           schema:
@@ -1793,7 +1796,7 @@ paths:
               format: int64
         - name: stop
           in: query
-          description: stop IDs to filter by
+          description: Stop IDs to filter by.
           required: false
           style: form
           schema:
@@ -1803,44 +1806,44 @@ paths:
               format: int64
         - name: cutoff-after
           in: query
-          description: only return trips with cutoffs after or on this date
+          description: Only return trips with cutoffs after or on this date.
           required: false
           schema:
             type: string
             format: date-time
         - name: cutoff-before
           in: query
-          description: only return trips with cutoffs before this date
+          description: Only return trips with cutoffs before this date.
           required: false
           schema:
             type: string
             format: date-time
         - name: confirmed
           in: query
-          description: only return (un)confirmed trips
+          description: Only return (un)confirmed trips.
           required: false
           schema:
             type: boolean
         - name: limit
           in: query
-          description: maximum number of results to return
+          description: Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: trip response
+          description: Trip response.
           headers:
             Count:
-              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -1852,7 +1855,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/trip'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -1864,13 +1867,13 @@ paths:
         - trip
       responses:
         '200':
-          description: trip response
+          description: Trip response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/trip'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -1880,7 +1883,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updateTrip'
-        description: Trip to create
+        description: Trip to create.
         required: true
   '/trip/{id}':
     get:
@@ -1891,20 +1894,20 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of trip to fetch
+          description: ID of trip to fetch.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: trip response
+          description: Trip response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/trip'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -1917,20 +1920,20 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of trip to update
+          description: ID of trip to update.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: trip response
+          description: Trip response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/trip'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -1940,7 +1943,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updateTrip'
-        description: Trip to update
+        description: Trip to update.
         required: true
     delete:
       summary: Deletes a trip for a route, if the user has permissions
@@ -1950,16 +1953,16 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of trip to delete
+          description: ID of trip to delete.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '204':
-          description: delete successful
+          description: Delete successful.
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -1967,14 +1970,14 @@ paths:
   /route-stops:
     get:
       summary: Returns all route-stops from the system that the user has access to
-      description: Route-stops are ordered for increasing offset from the route's trip cutoff
+      description: Route-stops are ordered for increasing offset from the route's trip cutoff.
       operationId: findRouteStops
       tags:
         - stop
       parameters:
         - name: route
           in: query
-          description: route names to filter by
+          description: Route names to filter by.
           required: false
           style: form
           schema:
@@ -1983,7 +1986,7 @@ paths:
               type: string
         - name: drop
           in: query
-          description: drop IDs to filter by
+          description: Drop IDs to filter by.
           required: false
           style: form
           schema:
@@ -1993,24 +1996,24 @@ paths:
               format: int64
         - name: limit
           in: query
-          description: maximum number of results to return
+          description: Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: route-stop response
+          description: Route-stop response.
           headers:
             Count:
-              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -2022,7 +2025,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/routeStop'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -2036,20 +2039,20 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of route-stop to fetch
+          description: ID of route-stop to fetch.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: route-stop response
+          description: Route-stop response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/routeStop'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -2057,14 +2060,14 @@ paths:
   /stops:
     get:
       summary: Returns all stops from the system that the user has access to
-      description: Stops are ordered for decreasing target time
+      description: Stops are ordered for decreasing target time.
       operationId: findStops
       tags:
         - stop
       parameters:
         - name: route
           in: query
-          description: route names to filter by
+          description: Route names to filter by.
           required: false
           style: form
           schema:
@@ -2073,7 +2076,7 @@ paths:
               type: string
         - name: trip
           in: query
-          description: trip IDs names to filter by
+          description: Trip IDs names to filter by.
           required: false
           style: form
           schema:
@@ -2083,7 +2086,7 @@ paths:
               format: int64
         - name: drop
           in: query
-          description: drop IDs to filter by
+          description: Drop IDs to filter by.
           required: false
           style: form
           schema:
@@ -2093,7 +2096,7 @@ paths:
               format: int64
         - name: pickup
           in: query
-          description: pickup IDs to filter by
+          description: Pickup IDs to filter by.
           required: false
           style: form
           schema:
@@ -2103,44 +2106,44 @@ paths:
               format: int64
         - name: estimatedDeliveryAfter
           in: query
-          description: only return stops with an estimated time after or on this date
+          description: Only return stops with an estimated time after or on this date.
           required: false
           schema:
             type: string
             format: date-time
         - name: estimatedDeliveryBefore
           in: query
-          description: only return stops with an estimated time before this date
+          description: Only return stops with an estimated time before this date.
           required: false
           schema:
             type: string
             format: date-time
         - name: short-drop
           in: query
-          description: only return stops which have (not) had short-drop warnings sent.
+          description: Only return stops which have (not) had short-drop warnings sent.
           required: false
           schema:
             type: boolean
         - name: limit
           in: query
-          description: maximum number of results to return
+          description: Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: stop response
+          description: Stop response.
           headers:
             Count:
-              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -2152,7 +2155,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/stop'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -2171,13 +2174,13 @@ paths:
             type: boolean
       responses:
         '200':
-          description: stop response
+          description: Stop response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/stop'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -2187,7 +2190,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updateStop'
-        description: stop to add
+        description: Stop to add.
         required: true
   '/stop/{id}':
     get:
@@ -2198,20 +2201,20 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of stop to fetch
+          description: ID of stop to fetch.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: stop response
+          description: Stop response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/stop'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -2224,7 +2227,7 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of stop to update
+          description: ID of stop to update.
           required: true
           schema:
             type: integer
@@ -2237,19 +2240,19 @@ paths:
             type: boolean
         - name: propagate
           in: query
-          description: if true, calculate the change from the existing estimated time. Shift the estimated time of all later stops on the trip by the same amount. For pre-cutoff trips, also shift the target times.
+          description: If true, calculate the change from the existing estimated time. Shift the estimated time of all later stops on the trip by the same amount. For pre-cutoff trips, also shift the target times.
           required: false
           schema:
             type: boolean
       responses:
         '200':
-          description: stop response
+          description: Stop response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/stop'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -2259,7 +2262,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updateStop'
-        description: stop to update
+        description: Stop to update.
         required: true
     delete:
       summary: Delete an existing stop
@@ -2269,22 +2272,22 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of stop to delete
+          description: ID of stop to delete.
           required: true
           schema:
             type: integer
             format: int64
         - name: persist
           in: query
-          description: if true, for any pre-cutoff trips associated with this stop's trip's route which cutoff later than this stop's trip, delete any stops for this location (drop or pickup). Also delete any route-stop associations for this location on this stop's trip's route.
+          description: If true, for any pre-cutoff trips associated with this stop's trip's route which cutoff later than this stop's trip, delete any stops for this location (drop or pickup). Also delete any route-stop associations for this location on this stop's trip's route.
           required: false
           schema:
             type: boolean
       responses:
         '204':
-          description: delete successful
+          description: Delete successful.
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -2299,42 +2302,42 @@ paths:
       parameters:
         - name: audited
           in: query
-          description: filter for products that have or haven't been audited. When set, only products that contain (un)audited packaging are returned, and their packaging array only contains (un)audited packaging.
+          description: Filter for products that have or haven't been audited. When set, only products that contain (un)audited packaging are returned, and their packaging array only contains (un)audited packaging.
           required: false
           schema:
             type: string
         - name: search
           in: query
-          description: search string for filtering products. The logic behind this is left up to the implementation, but it should at least match words in the product name, and may optionally match the product description or other characteristics
+          description: Search string for filtering products. The logic behind this is left up to the implementation, but it should at least match words in the product name, and may optionally match the product description or other characteristics.
           required: false
           schema:
             type: string
         - name: packaged-product
           in: query
-          description: packaged-product codes to filter by.
+          description: Packaged-product codes to filter by.
           required: false
           schema:
             type: string
         - name: limit
           in: query
-          description: maximum number of results to return
+          description: Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: product audit response
+          description: Product audit response.
           headers:
             Count:
-              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -2346,7 +2349,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/productAudit'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -2361,7 +2364,7 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of product to fetch
+          description: ID of product to fetch.
           required: true
           schema:
             type: string
@@ -2373,13 +2376,13 @@ paths:
             type: string
       responses:
         '200':
-          description: product audit response
+          description: Product audit response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/productAudit'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -2394,20 +2397,20 @@ paths:
       parameters:
         - name: id
           in: path
-          description: id of packaged product being audited
+          description: Id of packaged product being audited.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: packaged-product audit response
+          description: Packaged-product audit response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/packagedProductAudit'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -2417,7 +2420,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updatePackagedProductAudit'
-        description: packaged product to update
+        description: Packaged product to update.
         required: true
   /products:
     get:
@@ -2428,13 +2431,13 @@ paths:
       parameters:
         - name: search
           in: query
-          description: search string for filtering products. The logic behind this is left up to the implementation, but it should at least match words in the product name, and may optionally match the product description or other characteristics
+          description: Search string for filtering products. The logic behind this is left up to the implementation, but it should at least match words in the product name, and may optionally match the product description or other characteristics.
           required: false
           schema:
             type: string
         - name: gtin13
           in: query
-          description: packaged-product 13-digit Global Trade Item Numbers to filter by
+          description: Packaged-product 13-digit Global Trade Item Numbers to filter by.
           required: false
           style: form
           schema:
@@ -2444,7 +2447,7 @@ paths:
               format: int64
         - name: brand
           in: query
-          description: brand IDs to filter by
+          description: Brand IDs to filter by.
           required: false
           style: form
           schema:
@@ -2454,7 +2457,7 @@ paths:
               format: int64
         - name: category
           in: query
-          description: category IDs to filter by (for products directly associated with the categories)
+          description: Category IDs to filter by (for products directly associated with the categories).
           required: false
           style: form
           schema:
@@ -2464,7 +2467,7 @@ paths:
               format: int64
         - name: primary-category
           in: query
-          description: primary-category IDs to filter by (for products directly associated with the categories)
+          description: Primary-category IDs to filter by (for products directly associated with the categories).
           required: false
           style: form
           schema:
@@ -2474,7 +2477,7 @@ paths:
               format: int64
         - name: ancestor-category
           in: query
-          description: category IDs to filter by (for products associated with the categories or their descendants)
+          description: Category IDs to filter by (for products associated with the categories or their descendants).
           required: false
           style: form
           schema:
@@ -2484,7 +2487,7 @@ paths:
               format: int64
         - name: packaged-product
           in: query
-          description: packaged product codes to filter by
+          description: Packaged product codes to filter by.
           required: false
           style: form
           schema:
@@ -2493,7 +2496,7 @@ paths:
               type: string
         - name: tag
           in: query
-          description: tags to filter by
+          description: Tags to filter by.
           required: false
           style: form
           schema:
@@ -2502,7 +2505,7 @@ paths:
               type: string
         - name: filter-person
           in: query
-          description: person IDs to filter by (selects their favorite products)
+          description: Person IDs to filter by (selects their favorite products).
           required: false
           style: form
           schema:
@@ -2512,14 +2515,14 @@ paths:
               format: int64
         - name: annotate-person
           in: query
-          description: person ID for associating additional metadata with results (e.g. whether this person has favorited a given packaged-product). If unset and you're authenticated, defaults to your authenticated ID
+          description: Person ID for associating additional metadata with results (e.g. whether this person has favorited a given packaged-product). If unset and you're authenticated, defaults to your authenticated ID.
           required: false
           schema:
             type: integer
             format: int64
         - name: inline
           in: query
-          description: for convenience, include a full representation of the inlined property. Currently supports the local "description", "favorites", and "substitutions" as well as "brand", "packaging", "vendors", and descendants.
+          description: For convenience, include a full representation of the inlined property. Currently supports the local "description", "favorites", and "substitutions" as well as "brand", "packaging", "vendors", and descendants.
           required: false
           style: form
           schema:
@@ -2528,24 +2531,24 @@ paths:
               type: string
         - name: limit
           in: query
-          description: maximum number of results to return
+          description: Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: product response
+          description: Product response.
           headers:
             Count:
-              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -2557,7 +2560,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/product'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -2571,13 +2574,13 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of product to fetch
+          description: ID of product to fetch.
           required: true
           schema:
             type: string
         - name: inline
           in: query
-          description: for convenience, include a full representation of the inlined property. Currently supports the local "description", "favorites", and "substitutions" as well as "brand", "packaging", "vendors", and descendants.
+          description: For convenience, include a full representation of the inlined property. Currently supports the local "description", "favorites", and "substitutions" as well as "brand", "packaging", "vendors", and descendants.
           required: false
           style: form
           schema:
@@ -2586,13 +2589,13 @@ paths:
               type: string
       responses:
         '200':
-          description: product response
+          description: Product response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/product'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -2606,7 +2609,7 @@ paths:
       parameters:
         - name: product
           in: query
-          description: product IDs to filter by
+          description: Product IDs to filter by.
           required: false
           style: form
           schema:
@@ -2616,7 +2619,7 @@ paths:
               format: int64
         - name: code
           in: query
-          description: packaged product codes to filter by
+          description: Packaged product codes to filter by.
           required: false
           style: form
           schema:
@@ -2625,7 +2628,7 @@ paths:
               type: string
         - name: gtin13
           in: query
-          description: 13-digit Global Trade Item Numbers to filter by
+          description: 13-digit Global Trade Item Numbers to filter by.
           required: false
           style: form
           schema:
@@ -2635,7 +2638,7 @@ paths:
               format: int64
         - name: brand
           in: query
-          description: brand IDs to filter by
+          description: Brand IDs to filter by.
           required: false
           style: form
           schema:
@@ -2645,7 +2648,7 @@ paths:
               format: int64
         - name: category
           in: query
-          description: category IDs to filter by (for products directly associated with the categories)
+          description: Category IDs to filter by (for products directly associated with the categories).
           required: false
           style: form
           schema:
@@ -2655,7 +2658,7 @@ paths:
               format: int64
         - name: primary-category
           in: query
-          description: primary-category IDs to filter by (for products directly associated with the categories)
+          description: Primary-category IDs to filter by (for products directly associated with the categories).
           required: false
           style: form
           schema:
@@ -2665,7 +2668,7 @@ paths:
               format: int64
         - name: ancestor-category
           in: query
-          description: category IDs to filter by (for packaged products associated with the categories or their descendants)
+          description: Category IDs to filter by (for packaged products associated with the categories or their descendants).
           required: false
           style: form
           schema:
@@ -2675,7 +2678,7 @@ paths:
               format: int64
         - name: tag
           in: query
-          description: tags to filter by
+          description: Tags to filter by.
           required: false
           style: form
           schema:
@@ -2684,7 +2687,7 @@ paths:
               type: string
         - name: filter-person
           in: query
-          description: person IDs to filter by (selects their favorite packaged products)
+          description: Person IDs to filter by (selects their favorite packaged products).
           required: false
           style: form
           schema:
@@ -2694,14 +2697,14 @@ paths:
               format: int64
         - name: annotate-person
           in: query
-          description: person ID for associating additional metadata with results (e.g. whether this person has favorited a given packaged-product). If unset and you're authenticated, defaults to your authenticated ID
+          description: Person ID for associating additional metadata with results (e.g. whether this person has favorited a given packaged-product). If unset and you're authenticated, defaults to your authenticated ID.
           required: false
           schema:
             type: integer
             format: int64
         - name: inline
           in: query
-          description: for convenience, include a full representation of the inlined property. Currently supports the local "favorites", "next-purchase-arrival", and "quantity-on-next-purchase" as well as "image", "product", "vendors", and descendants.
+          description: For convenience, include a full representation of the inlined property. Currently supports the local "favorites", "next-purchase-arrival", and "quantity-on-next-purchase" as well as "image", "product", "vendors", and descendants.
           required: false
           style: form
           schema:
@@ -2710,24 +2713,24 @@ paths:
               type: string
         - name: limit
           in: query
-          description: maximum number of results to return
+          description: Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: packaged product response
+          description: Packaged product response.
           headers:
             Count:
-              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -2739,7 +2742,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/packagedProduct'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -2753,13 +2756,13 @@ paths:
       parameters:
         - name: code
           in: path
-          description: code of the packaged product to fetch
+          description: Code of the packaged product to fetch.
           required: true
           schema:
             type: string
         - name: inline
           in: query
-          description: for convenience, include a full representation of the inlined property. Currently supports the local "favorites", "next-purchase-arrival", and "quantity-on-next-purchase" as well as "image", "product", "vendors", and descendants.
+          description: For convenience, include a full representation of the inlined property. Currently supports the local "favorites", "next-purchase-arrival", and "quantity-on-next-purchase" as well as "image", "product", "vendors", and descendants.
           required: false
           style: form
           schema:
@@ -2768,13 +2771,13 @@ paths:
               type: string
       responses:
         '200':
-          description: product response
+          description: Product response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/packagedProduct'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -2917,10 +2920,10 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/packagedProductImage'
-        description: Packaged product image to update
+        description: Packaged product image to update.
         required: true
     delete:
-      summary: Delete a packaged product image.
+      summary: Delete a packaged product image
       operationId: deletePackagedProductImage
       tags:
         - image
@@ -2951,13 +2954,13 @@ paths:
       parameters:
         - name: internal
           in: query
-          description: if true, only return internal tags (that the user has access to). If false, only return public tags (regardless of the user's access to internal tags). If unset, don't filter based on the tag visibility
+          description: If true, only return internal tags (that the user has access to). If false, only return public tags (regardless of the user's access to internal tags). If unset, don't filter based on the tag visibility.
           required: false
           schema:
             type: boolean
         - name: category
           in: query
-          description: categories to filter by
+          description: Categories to filter by.
           required: false
           style: form
           schema:
@@ -2966,24 +2969,24 @@ paths:
               type: string
         - name: limit
           in: query
-          description: maximum number of results to return
+          description: Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: packaged product tag response
+          description: Packaged product tag response.
           headers:
             Count:
-              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -2995,7 +2998,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/packagedProductTag'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -3009,31 +3012,31 @@ paths:
       parameters:
         - name: filter-person
           in: query
-          description: person ID to filter by
+          description: Person ID to filter by.
           required: true
           schema:
             type: integer
             format: int64
         - name: limit
           in: query
-          description: maximum number of results to return
+          description: Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: packaged product tag association response
+          description: Packaged product tag association response.
           headers:
             Count:
-              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -3045,7 +3048,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/packagedProductTagAssociation'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -3057,13 +3060,13 @@ paths:
         - packaged-product-tag
       responses:
         '200':
-          description: packaged product tag association response
+          description: Packaged product tag association response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/packagedProductTagAssociation'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -3073,7 +3076,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/packagedProductTagAssociation'
-        description: Packaged-product tag association to add
+        description: Packaged-product tag association to add.
         required: true
   '/packaged-product-tag-association/{id}':
     delete:
@@ -3084,16 +3087,16 @@ paths:
       parameters:
         - name: id
           in: path
-          description: packaged product tag association ID to delete
+          description: Packaged product tag association ID to delete.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '204':
-          description: delete successful
+          description: Delete successful.
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -3108,7 +3111,7 @@ paths:
       parameters:
         - name: parent
           in: query
-          description: category IDs to filter by
+          description: Category IDs to filter by.
           required: false
           style: form
           schema:
@@ -3118,13 +3121,13 @@ paths:
               format: int64
         - name: active
           in: query
-          description: only return (in)active categories
+          description: Only return (in)active categories.
           required: false
           schema:
             type: boolean
         - name: product
           in: query
-          description: product IDs to filter by
+          description: Product IDs to filter by.
           required: false
           style: form
           schema:
@@ -3134,7 +3137,7 @@ paths:
               format: int64
         - name: packaged-product
           in: query
-          description: packaged product codes to filter by
+          description: Packaged product codes to filter by.
           required: false
           style: form
           schema:
@@ -3152,24 +3155,24 @@ paths:
               type: string
         - name: limit
           in: query
-          description: maximum number of results to return
+          description: Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: category response
+          description: Category response.
           headers:
             Count:
-              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -3181,7 +3184,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/category'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -3193,13 +3196,13 @@ paths:
         - category
       responses:
         '200':
-          description: category response
+          description: Category response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/category'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -3209,7 +3212,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updateCategory'
-        description: Category to create
+        description: Category to create.
         required: true
   '/category/{id}':
     get:
@@ -3221,7 +3224,7 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of category to fetch
+          description: ID of category to fetch.
           required: true
           schema:
             type: integer
@@ -3237,39 +3240,39 @@ paths:
               type: string
       responses:
         '200':
-          description: category response
+          description: Category response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/category'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
     put:
-      summary: Update a category.
+      summary: Update a category
       operationId: updateCategory
       tags:
         - category
       parameters:
         - name: id
           in: path
-          description: ID of category to update
+          description: ID of category to update.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: category response
+          description: Category response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/category'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -3279,19 +3282,19 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updateCategory'
-        description: Category to update
+        description: Category to update.
         required: true
   /purchases:
     get:
       summary: Returns all purchases from the system that the user has access to
-      description: Purchases are ordered for increasing ID (creation time)
+      description: Purchases are ordered for increasing ID (creation time).
       operationId: findPurchases
       tags:
         - purchase
       parameters:
         - name: vendor
           in: query
-          description: vendor IDs to filter by
+          description: Vendor IDs to filter by.
           required: false
           style: form
           schema:
@@ -3301,7 +3304,7 @@ paths:
               format: int64
         - name: pickup
           in: query
-          description: pickup IDs to filter by
+          description: Pickup IDs to filter by.
           required: false
           style: form
           schema:
@@ -3311,7 +3314,7 @@ paths:
               format: int64
         - name: trip
           in: query
-          description: trip IDs to filter by
+          description: Trip IDs to filter by.
           required: false
           style: form
           schema:
@@ -3321,7 +3324,7 @@ paths:
               format: int64
         - name: status
           in: query
-          description: purchase-status string to filter by
+          description: Purchase-status string to filter by.
           required: false
           style: form
           schema:
@@ -3338,24 +3341,24 @@ paths:
                 - paid
         - name: limit
           in: query
-          description: maximum number of results to return
+          description: Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: purchase response
+          description: Purchase response.
           headers:
             Count:
-              description: total number of matching results (how many you'd get if you didn't set `limit`)
+              description: Total number of matching results (how many you'd get if you didn't set `limit`).
               schema:
                 type: integer
                 format: int32
@@ -3367,7 +3370,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/purchase'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -3381,20 +3384,20 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of purchase to fetch
+          description: ID of purchase to fetch.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: purchase response
+          description: Purchase response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/purchase'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -3408,7 +3411,7 @@ paths:
       parameters:
         - name: username
           in: query
-          description: usernames to filter by
+          description: Usernames to filter by.
           required: false
           style: form
           schema:
@@ -3417,7 +3420,7 @@ paths:
               type: string
         - name: email
           in: query
-          description: email addresses to filter by
+          description: Email addresses to filter by.
           required: false
           style: form
           schema:
@@ -3427,7 +3430,7 @@ paths:
               format: email
         - name: drop
           in: query
-          description: drop IDs to filter by
+          description: Drop IDs to filter by.
           required: false
           style: form
           schema:
@@ -3437,7 +3440,7 @@ paths:
               format: int64
         - name: trip
           in: query
-          description: trip IDs to filter by
+          description: Trip IDs to filter by.
           required: false
           style: form
           schema:
@@ -3447,7 +3450,7 @@ paths:
               format: int64
         - name: product
           in: query
-          description: product IDs to filter by
+          description: Product IDs to filter by.
           required: false
           style: form
           schema:
@@ -3457,7 +3460,7 @@ paths:
               format: int64
         - name: packaged-product
           in: query
-          description: packaged product codes to filter by
+          description: Packaged product codes to filter by.
           required: false
           style: form
           schema:
@@ -3466,7 +3469,7 @@ paths:
               type: string
         - name: filter-person
           in: query
-          description: person IDs to filter by
+          description: Person IDs to filter by.
           required: false
           style: form
           schema:
@@ -3476,7 +3479,7 @@ paths:
               format: int64
         - name: status
           in: query
-          description: order-status string to filter by
+          description: Order-status string to filter by.
           required: false
           style: form
           schema:
@@ -3491,21 +3494,21 @@ paths:
                 - lost
         - name: limit
           in: query
-          description: maximum number of results to return
+          description: Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
         - name: inline
           in: query
-          description: for convenience, include a full representation of the inlined property. Currently supports "dropMembershipId".
+          description: For convenience, include a full representation of the inlined property. Currently supports "dropMembershipId".
           required: false
           style: form
           schema:
@@ -3514,10 +3517,10 @@ paths:
               type: string
       responses:
         '200':
-          description: order response
+          description: Order response.
           headers:
             Count:
-              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -3529,7 +3532,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/order'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -3541,13 +3544,13 @@ paths:
         - order
       responses:
         '200':
-          description: Order response
+          description: Order response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/order'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -3557,7 +3560,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updateOrder'
-        description: Order to add
+        description: Order to add.
         required: true
   '/order/{id}':
     get:
@@ -3568,20 +3571,20 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of order to fetch
+          description: ID of order to fetch.
           required: true
           schema:
             type: integer
             format: int64
         - name: accept
           in: query
-          description: override the HTTP Accept header to chose the response type. Empty and unrecognized values will result in application/json.
+          description: Override the HTTP Accept header to chose the response type. Empty and unrecognized values will result in application/json.
           required: false
           schema:
             type: string
         - name: inline
           in: query
-          description: for convenience, include a full representation of the inlined property. Currently supports "dropMembershipId".
+          description: For convenience, include a full representation of the inlined property. Currently supports "dropMembershipId".
           required: false
           style: form
           schema:
@@ -3590,7 +3593,7 @@ paths:
               type: string
       responses:
         '200':
-          description: order response
+          description: Order response.
           content:
             application/json:
               schema:
@@ -3602,7 +3605,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/order'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -3621,26 +3624,26 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of order to update
+          description: ID of order to update.
           required: true
           schema:
             type: integer
             format: int64
         - name: save
           in: query
-          description: Whether to save the result of the PUT or not (defaults to true). Set to false if you want to preview the side-effects of a change before going through with an update
+          description: Whether to save the result of the PUT or not (defaults to true). Set to false if you want to preview the side-effects of a change before going through with an update.
           required: false
           schema:
             type: boolean
       responses:
         '200':
-          description: Order response
+          description: Order response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/changedOrder'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -3650,7 +3653,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updateOrder'
-        description: Updated order parameters (can optionally include 'id')
+        description: Updated order parameters (can optionally include 'id').
         required: true
     delete:
       summary: Delete an existing order
@@ -3660,16 +3663,16 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of order to delete
+          description: ID of order to delete.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '204':
-          description: delete successful
+          description: Delete successful.
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -3683,7 +3686,7 @@ paths:
       parameters:
         - name: order
           in: query
-          description: order IDs to filter by
+          description: Order IDs to filter by.
           required: false
           style: form
           schema:
@@ -3693,7 +3696,7 @@ paths:
               format: int64
         - name: product
           in: query
-          description: product IDs to filter by
+          description: Product IDs to filter by.
           required: false
           style: form
           schema:
@@ -3703,7 +3706,7 @@ paths:
               format: int64
         - name: packaged-product
           in: query
-          description: packaged product codes to filter by
+          description: Packaged product codes to filter by.
           required: false
           style: form
           schema:
@@ -3712,24 +3715,24 @@ paths:
               type: string
         - name: limit
           in: query
-          description: maximum number of results to return
+          description: Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: order-line response
+          description: Order-line response.
           headers:
             Count:
-              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -3741,7 +3744,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/orderLine'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -3753,13 +3756,13 @@ paths:
         - order
       responses:
         '200':
-          description: Order-line response
+          description: Order-line response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/orderLine'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -3769,7 +3772,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updateOrderLine'
-        description: Order-line to add
+        description: Order-line to add.
         required: true
   '/order-line/{id}':
     get:
@@ -3780,20 +3783,20 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of order-line to fetch
+          description: ID of order-line to fetch.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: order-line response
+          description: Order-line response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/orderLine'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -3806,20 +3809,20 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of order-line to update
+          description: ID of order-line to update.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: Order-line response
+          description: Order-line response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/orderLine'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -3829,7 +3832,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updateOrderLine'
-        description: Updated order-line parameters (can optionally include 'id')
+        description: Updated order-line parameters (can optionally include 'id').
         required: true
     delete:
       summary: Delete an existing order-line
@@ -3839,16 +3842,16 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of order-line to delete
+          description: ID of order-line to delete.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '204':
-          description: delete successful
+          description: Delete successful.
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -3862,7 +3865,7 @@ paths:
       parameters:
         - name: order
           in: query
-          description: order IDs to filter by
+          description: Order IDs to filter by.
           required: false
           style: form
           schema:
@@ -3872,24 +3875,24 @@ paths:
               format: int64
         - name: limit
           in: query
-          description: maximum number of results to return
+          description: Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: order fee response
+          description: Order fee response.
           headers:
             Count:
-              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -3901,7 +3904,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/orderFee'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -3915,20 +3918,20 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of order fee to fetch
+          description: ID of order fee to fetch.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: order fee response
+          description: Order fee response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/orderFee'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -3966,20 +3969,20 @@ paths:
   /vendors:
     get:
       summary: Returns all vendors from the system that the user has access to
-      description: Vendors are ordered for increasing ID (creation time)
+      description: Vendors are ordered for increasing ID (creation time).
       operationId: findVendors
       tags:
         - vendor
       parameters:
         - name: active
           in: query
-          description: only return (in)active vendors
+          description: Only return (in)active vendors.
           required: false
           schema:
             type: boolean
         - name: manager
           in: query
-          description: person IDs to filter by, selecting vendors that these vendor employees manage
+          description: Person IDs to filter by, selecting vendors that these vendor employees manage.
           required: false
           style: form
           schema:
@@ -3989,7 +3992,7 @@ paths:
               format: int64
         - name: buyer
           in: query
-          description: person IDs to filter by, selecting vendors that these Azure employees buy from
+          description: Person IDs to filter by, selecting vendors that these Azure employees buy from.
           required: false
           style: form
           schema:
@@ -3999,24 +4002,24 @@ paths:
               format: int64
         - name: limit
           in: query
-          description: maximum number of results to return
+          description: Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: vendor response
+          description: Vendor response.
           headers:
             Count:
-              description: total number of matching results (how many you'd get if you didn't set `limit`)
+              description: Total number of matching results (how many you'd get if you didn't set `limit`).
               schema:
                 type: integer
                 format: int32
@@ -4028,7 +4031,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/vendor'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -4042,34 +4045,35 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of vendor to fetch
+          description: ID of vendor to fetch.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: vendor response
+          description: Vendor response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/vendor'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
   /account-entries:
     get:
-      summary: Returns all dollar credits and debits from the system that the user has access to. Results are ordered by increasing settled dates, falling back to IDs when multiple entries settled on the same day.
+      summary: Returns all dollar credits and debits from the system that the user has access to. 
+      description: Results are ordered by increasing settled dates, falling back to IDs when multiple entries settled on the same day.
       operationId: findAccountEntries
       tags:
         - account
       parameters:
         - name: filter-person
           in: query
-          description: person IDs to filter by
+          description: Person IDs to filter by.
           required: false
           style: form
           schema:
@@ -4079,14 +4083,14 @@ paths:
               format: int64
         - name: date-after
           in: query
-          description: only return entries with dates after this date (inclusive)
+          description: Only return entries with dates after this date (inclusive).
           required: false
           schema:
             type: string
             format: date
         - name: date-before
           in: query
-          description: only return entries with dates before this date (exclusive)
+          description: Only return entries with dates before this date (exclusive).
           required: false
           schema:
             type: string
@@ -4110,24 +4114,24 @@ paths:
                 - affiliate-referral
         - name: limit
           in: query
-          description: maximum number of results to return
+          description: Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: account entry response
+          description: Account entry response.
           headers:
             Count:
-              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -4139,7 +4143,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/accountEntry'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -4153,20 +4157,20 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of account entry to fetch
+          description: ID of account entry to fetch.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: account entry response
+          description: Account entry response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/accountEntry'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -4179,13 +4183,13 @@ paths:
         - payment
       responses:
         '200':
-          description: account entry response
+          description: Account entry response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/accountEntry'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -4207,13 +4211,13 @@ paths:
       parameters:
         - name: active
           in: query
-          description: only return (in)active payment methods
+          description: Only return (in)active payment methods.
           required: false
           schema:
             type: boolean
         - name: filter-person
           in: query
-          description: person IDs to filter by
+          description: Person IDs to filter by.
           required: false
           style: form
           schema:
@@ -4223,24 +4227,24 @@ paths:
               format: int64
         - name: limit
           in: query
-          description: maximum number of results to return
+          description: Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: payment method response
+          description: Payment method response.
           headers:
             Count:
-              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -4252,7 +4256,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/paymentMethod'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -4264,13 +4268,13 @@ paths:
         - payment
       responses:
         '200':
-          description: payment method response
+          description: Payment method response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/paymentMethod'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -4280,7 +4284,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/newPaymentMethod'
-        description: Payment method to add
+        description: Payment method to add.
         required: true
   '/payment-method/{id}':
     get:
@@ -4291,20 +4295,20 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of payment method to fetch
+          description: ID of payment method to fetch.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: Payment method response
+          description: Payment method response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/paymentMethod'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -4317,23 +4321,24 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of payment method to deactivate
+          description: ID of payment method to deactivate.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '204':
-          description: deactivate successful
+          description: Deactivate successful.
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
   /rewards:
     get:
-      summary: Returns all reward credits and debits from the system that the user has access to. Results are ordered by increasing settled times, falling back to ID for pending debits.
+      summary: Returns all reward credits and debits from the system that the user has access to. 
+      description: Results are ordered by increasing settled times, falling back to ID for pending debits.
       operationId: findRewards
       tags:
         - account
@@ -4428,7 +4433,7 @@ paths:
                 $ref: '#/components/schemas/error'
   '/reward/{id}':
     get:
-      summary: Returns a reward credit or debit based on a single ID.
+      summary: Returns a reward credit or debit based on a single ID
       operationId: findRewardById
       tags:
         - account
@@ -4463,7 +4468,7 @@ paths:
       parameters:
         - name: filter-person
           in: query
-          description: person IDs to filter by
+          description: Person IDs to filter by.
           required: false
           style: form
           schema:
@@ -4473,7 +4478,7 @@ paths:
               format: int64
         - name: inline
           in: query
-          description: for convenience, include a full representation of the inlined property. Currently supports "country", "person", and descendants.
+          description: For convenience, include a full representation of the inlined property. Currently supports "country", "person", and descendants.
           required: false
           style: form
           schema:
@@ -4482,24 +4487,24 @@ paths:
               type: string
         - name: limit
           in: query
-          description: maximum number of results to return
+          description: Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: address response
+          description: Address response.
           headers:
             Count:
-              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -4511,7 +4516,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/address'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -4524,7 +4529,7 @@ paths:
       parameters:
         - name: inline
           in: query
-          description: for convenience, include a full representation of the inlined property. Currently supports "country", "person", and descendants.
+          description: For convenience, include a full representation of the inlined property. Currently supports "country", "person", and descendants.
           required: false
           style: form
           schema:
@@ -4533,13 +4538,13 @@ paths:
               type: string
       responses:
         '200':
-          description: address response
+          description: Address response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/address'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -4549,7 +4554,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/address'
-        description: address to add
+        description: Address to add.
         required: true
   '/address/{id}':
     get:
@@ -4560,14 +4565,14 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of address to fetch
+          description: ID of address to fetch.
           required: true
           schema:
             type: integer
             format: int64
         - name: inline
           in: query
-          description: for convenience, include a full representation of the inlined property. Currently supports "country", "person", and descendants.
+          description: For convenience, include a full representation of the inlined property. Currently supports "country", "person", and descendants.
           required: false
           style: form
           schema:
@@ -4576,13 +4581,13 @@ paths:
               type: string
       responses:
         '200':
-          description: address response
+          description: Address response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/address'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -4595,14 +4600,14 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of address to update
+          description: ID of address to update.
           required: true
           schema:
             type: integer
             format: int64
         - name: inline
           in: query
-          description: for convenience, include a full representation of the inlined property. Currently supports "country", "person", and descendants.
+          description: For convenience, include a full representation of the inlined property. Currently supports "country", "person", and descendants.
           required: false
           style: form
           schema:
@@ -4611,13 +4616,13 @@ paths:
               type: string
       responses:
         '200':
-          description: address response
+          description: Address response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/address'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -4627,7 +4632,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/address'
-        description: Address to update
+        description: Address to update.
         required: true
     delete:
       summary: Delete an existing address
@@ -4637,16 +4642,16 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of address to delete
+          description: ID of address to delete.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '204':
-          description: delete successful
+          description: Delete successful.
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -4661,24 +4666,24 @@ paths:
       parameters:
         - name: limit
           in: query
-          description: maximum number of results to return
+          description: Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: country response
+          description: Country response.
           headers:
             Count:
-              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -4690,7 +4695,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/country'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -4705,30 +4710,30 @@ paths:
       parameters:
         - name: country
           in: query
-          description: country to filter by
+          description: Country to filter by.
           required: false
           schema:
             type: string
         - name: limit
           in: query
-          description: maximum number of results to return
+          description: Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: country region response
+          description: Country region response.
           headers:
             Count:
-              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -4740,7 +4745,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/region'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -4800,7 +4805,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
     post:
-      summary: Create a new email.
+      summary: Create a new email
       operationId: addEmail
       tags:
         - email
@@ -4826,7 +4831,7 @@ paths:
         required: true
   '/email/{id}':
     get:
-      summary: Returns a email based on a single ID.
+      summary: Returns a email based on a single ID
       operationId: findEmailById
       tags:
         - email
@@ -4852,7 +4857,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
     put:
-      summary: Update an existing email.
+      summary: Update an existing email
       operationId: updateEmail
       tags:
         - email
@@ -4885,7 +4890,7 @@ paths:
         description: Email to update.
         required: true
     delete:
-      summary: Delete an existing email.
+      summary: Delete an existing email
       operationId: deleteEmail
       tags:
         - email
@@ -4915,7 +4920,7 @@ paths:
       parameters:
         - name: drop
           in: query
-          description: drop IDs to filter by
+          description: Drop IDs to filter by.
           required: false
           style: form
           schema:
@@ -4925,7 +4930,7 @@ paths:
               format: int64
         - name: inline
           in: query
-          description: for convenience, include additional information. Currently supports "email" as described in the email model, "order-place-issue", and "is-drop-coordinator".
+          description: For convenience, include additional information. Currently supports "email" as described in the email model, "order-place-issue", and "is-drop-coordinator".
           required: false
           style: form
           schema:
@@ -4934,24 +4939,24 @@ paths:
               type: string
         - name: limit
           in: query
-          description: maximum number of results to return
+          description: Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: person response
+          description: Person response.
           headers:
             Count:
-              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -4963,7 +4968,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/person'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -4977,19 +4982,19 @@ paths:
       parameters:
         - name: marketing-slug
           in: path
-          description: marketing slug of affiliate code to fetch
+          description: Marketing slug of affiliate code to fetch.
           required: true
           schema:
             type: string
       responses:
         '200':
-          description: Affiliate code response
+          description: Affiliate code response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/affiliateCode'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -5003,14 +5008,14 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of person to fetch
+          description: ID of person to fetch.
           required: true
           schema:
             type: integer
             format: int64
         - name: inline
           in: query
-          description: for convenience, include additional information. Currently supports "email" as described in the email model, "order-place-issue", and "is-drop-coordinator".
+          description: For convenience, include additional information. Currently supports "email" as described in the email model, "order-place-issue", and "is-drop-coordinator".
           required: false
           style: form
           schema:
@@ -5019,13 +5024,13 @@ paths:
               type: string
       responses:
         '200':
-          description: person response
+          description: Person response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/person'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -5038,20 +5043,20 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of person to update
+          description: ID of person to update.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: person response
+          description: Person response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/person'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -5067,7 +5072,7 @@ paths:
       parameters:
         - name: inline
           in: query
-          description: for convenience, include additional information. Currently supports "email" as described in the email model and "order-place-issue".
+          description: For convenience, include additional information. Currently supports "email" as described in the email model and "order-place-issue".
           required: false
           style: form
           schema:
@@ -5076,13 +5081,13 @@ paths:
               type: string
       responses:
         '200':
-          description: person response
+          description: Person response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/person'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -5094,13 +5099,13 @@ paths:
         - person
       responses:
         '200':
-          description: person response
+          description: Person response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/person'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -5117,13 +5122,13 @@ paths:
         - sessionCookie: []
       responses:
         '200':
-          description: session response
+          description: Session response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/session'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -5136,13 +5141,13 @@ paths:
         - session
       responses:
         '200':
-          description: session response
+          description: Session response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/session'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -5164,13 +5169,13 @@ paths:
         - sessionCookie: []
       responses:
         '200':
-          description: session response
+          description: Session response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/session'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -5192,7 +5197,7 @@ paths:
       parameters:
         - name: inline
           in: query
-          description: for convenience, include a full representation of the inlined property. Currently supports "session.person" and descendants.
+          description: For convenience, include a full representation of the inlined property. Currently supports "session.person" and descendants.
           required: false
           style: form
           schema:
@@ -5201,13 +5206,13 @@ paths:
               type: string
       responses:
         '200':
-          description: registration request response
+          description: Registration request response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/registrationResponse'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -5220,18 +5225,18 @@ paths:
         required: true
   /registration/resend:
     post:
-      summary: Resend the registration notification to the user.
+      summary: Resend the registration notification to the user
       operationId: resendRegistrationNotification
       tags:
         - registration
       responses:
         '204':
-          description: Registration email re-sent
+          description: Registration email re-sent.
           content:
             application/json:
               schema: {}
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -5250,9 +5255,9 @@ paths:
         - password
       responses:
         '204':
-          description: Password-reset email sent (if the registration email corresponded to an existing person. Otherwise, you'll still get a 204 to avoid leaking information about member email addresses)
+          description: Password-reset email sent (if the registration email corresponded to an existing person. Otherwise, you'll still get a 204 to avoid leaking information about member email addresses).
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -5271,13 +5276,13 @@ paths:
         - password
       responses:
         '200':
-          description: person response
+          description: Person response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/person'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -5287,7 +5292,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/passwordResetConfirmation'
-        description: The registrant's confirmation token
+        description: The registrant's confirmation token.
         required: true
   /notifications:
     get:
@@ -5298,13 +5303,13 @@ paths:
       parameters:
         - name: active
           in: query
-          description: only return (in)active notifications
+          description: Only return (in)active notifications.
           required: false
           schema:
             type: boolean
         - name: filter-person
           in: query
-          description: person IDs to filter by
+          description: Person IDs to filter by.
           required: false
           style: form
           schema:
@@ -5314,23 +5319,23 @@ paths:
               format: int64
         - name: annotate-person
           in: query
-          description: add a boolean dismissed field to the results with whether or not the annotate-person has dismissed this notification, required with dismissed
+          description: Add a boolean dismissed field to the results with whether or not the annotate-person has dismissed this notification, required with dismissed.
           required: false
           schema:
             type: integer
             format: int64
         - name: dismissed
           in: query
-          description: only return notifications that are (not) dismissed by the annotate-person
+          description: Only return notifications that are (not) dismissed by the annotate-person.
           required: false
           schema:
             type: boolean
       responses:
         '200':
-          description: notification response
+          description: Notification response.
           headers:
             Count:
-              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -5342,7 +5347,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/notification'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -5355,13 +5360,13 @@ paths:
         - notification
       responses:
         '200':
-          description: notification dismissal response
+          description: Notification dismissal response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/notificationDismissal'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -5371,7 +5376,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/notificationDismissal'
-        description: Notification dismissal to add
+        description: Notification dismissal to add.
         required: true
   /favorites:
     get:
@@ -5382,7 +5387,7 @@ paths:
       parameters:
         - name: filter-person
           in: query
-          description: person IDs to filter by
+          description: Person IDs to filter by.
           required: false
           style: form
           schema:
@@ -5392,13 +5397,13 @@ paths:
               format: int64
         - name: active
           in: query
-          description: only return favorites associated with (in)active packaged products. For example, we sometimes discontinue products and then pick them back up later. In this context, "active" means "for sale to at least some customers".
+          description: Only return favorites associated with (in)active packaged products. For example, we sometimes discontinue products and then pick them back up later. In this context, "active" means "for sale to at least some customers".
           required: false
           schema:
             type: boolean
         - name: inline
           in: query
-          description: for convenience, include a full representation of the inlined property. Currently supports "packaged-product" and descendants.
+          description: For convenience, include a full representation of the inlined property. Currently supports "packaged-product" and descendants.
           required: false
           style: form
           schema:
@@ -5407,24 +5412,24 @@ paths:
               type: string
         - name: limit
           in: query
-          description: maximum number of results to return
+          description: Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: array of favorites response
+          description: Array of favorites response.
           headers:
             Count:
-              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -5436,7 +5441,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/favorite'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -5448,13 +5453,13 @@ paths:
         - favorite
       responses:
         '200':
-          description: favorite response
+          description: Favorite response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/favorite'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -5464,7 +5469,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updateFavorite'
-        description: favorite to create
+        description: Favorite to create.
         required: true
   '/favorite/{id}':
     get:
@@ -5475,14 +5480,14 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of favorite to fetch
+          description: ID of favorite to fetch.
           required: true
           schema:
             type: integer
             format: int64
         - name: inline
           in: query
-          description: for convenience, include a full representation of the inlined property. Currently supports "packaged-product" and descendants.
+          description: For convenience, include a full representation of the inlined property. Currently supports "packaged-product" and descendants.
           required: false
           style: form
           schema:
@@ -5491,13 +5496,13 @@ paths:
               type: string
       responses:
         '200':
-          description: favorite response
+          description: Favorite response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/favorite'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -5510,20 +5515,20 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of favorite to update
+          description: ID of favorite to update.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: favorite response
+          description: Favorite response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/favorite'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -5533,7 +5538,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updateFavorite'
-        description: Favorite to update
+        description: Favorite to update.
         required: true
     delete:
       summary: Deletes a customer favorite
@@ -5543,16 +5548,16 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of favorite to update
+          description: ID of favorite to update.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '204':
-          description: delete successful
+          description: Delete successful.
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -5566,21 +5571,21 @@ paths:
       parameters:
         - name: limit
           in: query
-          description: maximum number of results to return
+          description: Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: array of faq response
+          description: Array of faq response.
           content:
             application/json:
               schema:
@@ -5588,7 +5593,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/faq'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -5600,13 +5605,13 @@ paths:
         - faq
       responses:
         '200':
-          description: faq response
+          description: Faq response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/faq'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -5616,7 +5621,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updateFaq'
-        description: faq to create
+        description: Faq to create.
         required: true
   '/faq/{id}':
     get:
@@ -5627,20 +5632,20 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of faq to fetch
+          description: ID of faq to fetch.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: faq response
+          description: Faq response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/faq'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -5653,20 +5658,20 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of faq to update
+          description: ID of faq to update.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '200':
-          description: faq response
+          description: Faq response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/faq'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -5676,7 +5681,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/updateFaq'
-        description: Faq to update
+        description: Faq to update.
         required: true
     delete:
       summary: Deletes a faq
@@ -5686,16 +5691,16 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of faq to delete
+          description: ID of faq to delete.
           required: true
           schema:
             type: integer
             format: int64
       responses:
         '204':
-          description: delete successful
+          description: Delete successful.
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -5709,7 +5714,7 @@ paths:
       parameters:
         - name: delivery
           in: query
-          description: printer delivery method
+          description: Printer delivery method.
           required: false
           style: form
           schema:
@@ -5722,7 +5727,7 @@ paths:
                 - bartender
         - name: format
           in: query
-          description: printer format
+          description: Printer format.
           required: false
           style: form
           schema:
@@ -5735,24 +5740,24 @@ paths:
                 - bartender
         - name: limit
           in: query
-          description: maximum number of results to return
+          description: Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: printer response
+          description: Printer response.
           headers:
             Count:
-              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -5764,7 +5769,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/printer'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -5778,20 +5783,20 @@ paths:
       parameters:
         - name: id
           in: path
-          description: ID of printer to fetch
+          description: ID of printer to fetch.
           required: true
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: printer response
+          description: Printer response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/printer'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -5805,24 +5810,24 @@ paths:
       parameters:
         - name: limit
           in: query
-          description: maximum number of results to return
+          description: Maximum number of results to return.
           required: false
           schema:
             type: integer
             format: int32
         - name: start
           in: query
-          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
       responses:
         '200':
-          description: warehouse response
+          description: Warehouse response.
           headers:
             Count:
-              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -5834,7 +5839,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/warehouse'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -5848,31 +5853,31 @@ paths:
       parameters:
         - name: code
           in: path
-          description: code of warehouse to fetch
+          description: Code of warehouse to fetch.
           required: true
           schema:
             type: string
       responses:
         '200':
-          description: warehouse response
+          description: Warehouse response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/warehouse'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
   /ip2location:
     get:
-      summary: Returns location data for the requesting ip address.
+      summary: Returns location data for the requesting ip address
       operationId: ip2Location
       parameters:
         - name: inline
           in: query
-          description: for convenience, include a full representation of the inlined property. Currently supports "address.country".
+          description: For convenience, include a full representation of the inlined property. Currently supports "address.country".
           required: false
           style: form
           schema:
@@ -5881,20 +5886,21 @@ paths:
               type: string
       responses:
         '200':
-          description: ip2location response
+          description: Ip2location response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ip2location'
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
   /order-frequency-segment:
     get:
-      summary: Returns "active" if the customer has ordered within the last 120 days, "activeag" (for "active aging") if they've ordered before but not within 120 days, "activereg" if they've never ordered. If no customer exists, returns "new".
+      summary: Get a customer order frequency
+      description: Returns 'active' if the customer has ordered within the last 120 days, 'activeag' (for "active aging") if they've ordered before but not within 120 days, `activereg` if they've never ordered. If no customer exists, returns `new`.
       operationId: orderFrequencySegment
       parameters:
         - name: email
@@ -5905,7 +5911,7 @@ paths:
             type: string
       responses:
         '200':
-          description: Returns "active" if the customer has ordered within the last 120 days, "activeag" (for "active aging") if they've ordered before but not within 120 days, "activereg" if they've never ordered. If no customer exists, returns "new".
+          description: Returns 'active' if the customer has ordered within the last 120 days, 'activeag' (for "active aging") if they've ordered before but not within 120 days, `activereg` if they've never ordered. If no customer exists, returns `new`.
           content:
             application/json:
               schema:
@@ -5922,7 +5928,7 @@ paths:
                       - activeag
                       - activereg
         default:
-          description: unexpected error
+          description: Unexpected error.
           content:
             application/json:
               schema:
@@ -5936,45 +5942,45 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/updatePersonUserPassword'
-      description: Person to update
+      description: Person to update.
       required: true
   securitySchemes:
     basic:
       type: http
-      description: Basic authentication (http://tools.ietf.org/html/rfc2617#section-2)
+      description: Basic authentication (http://tools.ietf.org/html/rfc2617#section-2).
       scheme: basic
     sessionCookie:
       type: apiKey
       in: header
       name: cookie
-      description: Session cookie (http://tools.ietf.org/html/rfc6265)
+      description: Session cookie (http://tools.ietf.org/html/rfc6265).
   schemas:
     affiliateCode:
-      description: an affiliate code and associated marketing slug of a person
+      description: An affiliate code and associated marketing slug of a person.
       type: object
       properties:
         marketing-slug:
-          description: unique marketing slug of a person
+          description: Unique marketing slug of a person.
           type: string
         affiliate-code:
-          description: unique affiliate code of the same person
+          description: Unique affiliate code of the same person.
           type: string
       required:
         - marketing-slug
         - affiliate-code
     affiliateReferral:
-      description: an affiliate referral
+      description: An affiliate referral.
       type: object
       properties:
         referred:
-          description: date-time the referred person's account was referred
+          description: Date-time the referred person's account was referred.
           type: string
           format: date-time
         name:
-          description: name of the person referred
+          description: Name of the person referred.
           type: string
         amount-earned:
-          description: dollar value for the sum of account credits to the referrer that were caused by this referral
+          description: Dollar value for the sum of account credits to the referrer that were caused by this referral.
           type: number
           format: float
       required:
@@ -5982,20 +5988,20 @@ components:
         - name
         - amount-earned
     bartenderHost:
-      description: a BarTender host/instance
+      description: A BarTender host/instance.
       type: object
       properties:
         code:
-          description: slug for stable reference (e.g. "bt1")
+          description: Slug for stable reference (e.g. "bt1").
           type: string
         name:
-          description: human readable name (e.g. "Bar Tender 1")
+          description: Human readable name (e.g. "Bar Tender 1").
           type: string
       required:
         - code
         - name
     bartenderTemplate:
-      description: a BarTender template/document
+      description: A BarTender template/document.
       type: object
       properties:
         id:
@@ -6015,7 +6021,7 @@ components:
           type: integer
           format: int64
         host:
-          description: the BarTender host's code
+          description: The BarTender host's code.
           type: string
         printer:
           description: The printer ID. The referenced printer must support the `bartender` format and delivery methods.
@@ -6031,7 +6037,7 @@ components:
         - printer
         - template
     companyDirectoryEntry:
-      description: a company directory entry
+      description: A company directory entry.
       type: object
       properties:
         full-name:
@@ -6107,7 +6113,7 @@ components:
         - name
         - customer-pricing
     drop:
-      description: an order-delivery location
+      description: An order-delivery location.
       type: object
       properties:
         id:
@@ -6116,10 +6122,10 @@ components:
         name:
           type: string
         coordinators:
-          description: coordinators for this drop. The first entry is the primary contact
+          description: Coordinators for this drop. The first entry is the primary contact.
           type: array
           items:
-            description: person ID for this coordinator
+            description: Person ID for this coordinator.
             type: integer
             format: int32
         address:
@@ -6127,19 +6133,19 @@ components:
         geo:
           $ref: '#/components/schemas/geo'
         active:
-          description: whether or not this drop is actively ordering
+          description: Whether or not this drop is actively ordering.
           type: boolean
         accounts-payable-contact:
-          description: name of the drop employee Azure's accounts-payable should contact, if different from the primary contact
+          description: Name of the drop employee Azure's accounts-payable should contact, if different from the primary contact.
           type: string
         after-hours-phone:
-          description: E.123 telephone number Azure should call if we need to contact the drop after business hours
+          description: E.123 telephone number Azure should call if we need to contact the drop after business hours.
           type: string
         business-hours:
-          description: regular business hours for the drop (e.g. "8:30-6 Mon-Fri, 9-5 Sat, closed Sun")
+          description: Regular business hours for the drop (e.g. "8:30-6 Mon-Fri, 9-5 Sat, closed Sun").
           type: string
         business-type:
-          description: what type of business do you run?
+          description: What type of business do you run?.
           type: array
           items:
             type: string
@@ -6152,10 +6158,10 @@ components:
               - seasonal
               - wholesale-distributor
         buyer:
-          description: name of the drop employee who usually places orders for this drop, if different from the primary contact
+          description: Name of the drop employee who usually places orders for this drop, if different from the primary contact.
           type: string
         pickup-contact:
-          description: do customers need to contact you to pick up their orders?  Retail preference. Only available when how-members-receive is "can-hold-sometimes" or "can-hold"
+          description: Do customers need to contact you to pick up their orders?  Retail preference. Only available when how-members-receive is "can-hold-sometimes" or "can-hold".
           type: string
           enum:
             - 'yes'
@@ -6164,7 +6170,7 @@ components:
         contact-person:
           type: string
         contact-type:
-          description: how can customers contact you?
+          description: How can customers contact you?.
           type: array
           items:
             type: string
@@ -6173,16 +6179,16 @@ components:
               - email
               - other
         contact-type-other-notes:
-          description: description of the alternative contact method. Available when contact-type includes "other"
+          description: Description of the alternative contact method. Available when contact-type includes "other".
           type: string
         contact-type-phone:
-          description: E.123 telephone number customers should call to contact this drop. Available when contact-type includes "phone"
+          description: E.123 telephone number customers should call to contact this drop. Available when contact-type includes "phone".
           type: string
         directions:
-          description: driving directions for a truck approaching this drop (e.g. avoiding low bridges, tight turns, etc. on more obvious routes)
+          description: Driving directions for a truck approaching this drop (e.g. avoiding low bridges, tight turns, etc. on more obvious routes).
           type: string
         driver-callable-phone:
-          description: E.123 telephone number for a driver approaching this drop
+          description: E.123 telephone number for a driver approaching this drop.
           type: string
         exclusivity:
           type: string
@@ -6191,33 +6197,33 @@ components:
             - semi-open
             - closed
         food-stamps:
-          description: does your drop accept food stamps?  Business preference.
+          description: Does your drop accept food stamps?  Business preference.
           type: string
           enum:
             - 'yes'
             - 'no'
             - limited
         food-stamps-limited-notes:
-          description: description of limited food-stamp acceptance. Business preference. Only available when food-stamps is "limited"
+          description: Description of limited food-stamp acceptance. Business preference. Only available when food-stamps is "limited".
           type: string
         hold-time:
-          description: how long will you hold a customer's order?  For example, "24 hours", "three days for dry, frozen by arrangement", etc. Retail preference. Only available when how-members-receive is "can-hold-sometimes" or "can-hold"
+          description: How long will you hold a customer's order?  For example, "24 hours", "three days for dry, frozen by arrangement", etc. Retail preference. Only available when how-members-receive is "can-hold-sometimes" or "can-hold".
           type: string
         how-members-receive:
-          description: how do your members receive their items?  Retail preference
+          description: How do your members receive their items?  Retail preference.
           type: string
           enum:
             - must-show
             - can-hold-sometimes
             - can-hold
         invoice-always:
-          description: always print paper invoices, regardless of the customer's invoice-delivery preference
+          description: Always print paper invoices, regardless of the customer's invoice-delivery preference.
           type: boolean
         okay-to-text-phone:
-          description: can the driver send text messages to the driver-callable phone?
+          description: Can the driver send text messages to the driver-callable phone?.
           type: boolean
         parking:
-          description: parking location ownership for this drop
+          description: Parking location ownership for this drop.
           type: string
           enum:
             - home
@@ -6226,43 +6232,43 @@ components:
             - public
             - other-building
         special-orders:
-          description: do you take special orders for Azure products from customers? Wholesale preference
+          description: Do you take special orders for Azure products from customers? Wholesale preference.
           type: boolean
         storage:
-          description: storage environments available at this drop
+          description: Storage environments available at this drop.
           type: array
           items:
             $ref: '#/components/schemas/storage'
         fees:
           $ref: '#/components/schemas/dropFees'
         order-minimum:
-          description: the minimum total order value (in dollars) required to ship a particular trip to this drop. For example, if the minimum is $400 and there are three $100 orders placed for a stop, that stop will be under-minimum, and the orders will not be shipped. If, on the other hand, there were four $100 orders placed for a stop, that stop would be (just) over-minimum, and the orders would be shipped.
+          description: The minimum total order value (in dollars) required to ship a particular trip to this drop. For example, if the minimum is $400 and there are three $100 orders placed for a stop, that stop will be under-minimum, and the orders will not be shipped. If, on the other hand, there were four $100 orders placed for a stop, that stop would be (just) over-minimum, and the orders would be shipped.
           type: number
           format: float
         members:
-          description: number of customers on this drop
+          description: Number of customers on this drop.
           type: integer
           format: int32
         order-frequency:
-          description: order counts for this drop over the past year
+          description: Order counts for this drop over the past year.
           type: object
           properties:
             orders:
-              description: count of orders for this route-trip-drop
+              description: Count of orders for this route-trip-drop.
               type: integer
               format: int32
             cutoff:
-              description: cutoff date for this route-trip
+              description: Cutoff date for this route-trip.
               type: string
               format: date
         notes:
-          description: free-form Markdown notes for any member-oriented drop information that doesn't fit into an existing field. This information is public for open and semi-open drops, and visible to all members for closed drops
+          description: Free-form Markdown notes for any member-oriented drop information that doesn't fit into an existing field. This information is public for open and semi-open drops, and visible to all members for closed drops.
           type: string
         sells-finished-goods-to-azure:
-          description: do you also sell your finished good to Azure?  Only available if business-type includes "manufacturing-business"
+          description: Do you also sell your finished good to Azure?  Only available if business-type includes "manufacturing-business".
           type: boolean
         uses-azure-to-drop-ship:
-          description: Do you drop ship Azure orders (have Azure ship directly to your customers)?  Only available if business-type includes "online-store"
+          description: Do you drop ship Azure orders (have Azure ship directly to your customers)?  Only available if business-type includes "online-store".
           type: boolean
       required:
         - id
@@ -6274,7 +6280,7 @@ components:
     newDrop:
       $ref: '#/components/schemas/drop'
     updateDrop:
-      description: an order-delivery location
+      description: An order-delivery location.
       type: object
       properties:
         id:
@@ -6287,10 +6293,10 @@ components:
         geo:
           $ref: '#/components/schemas/geo'
         active:
-          description: whether or not this drop is actively ordering
+          description: Whether or not this drop is actively ordering.
           type: boolean
         parking:
-          description: parking location ownership for this drop
+          description: Parking location ownership for this drop.
           type: string
           enum:
             - home
@@ -6298,69 +6304,69 @@ components:
             - non-profit
             - public
         storage:
-          description: storage environments available at this drop
+          description: Storage environments available at this drop.
           type: array
           items:
             $ref: '#/components/schemas/storage'
         fees:
           $ref: '#/components/schemas/dropFees'
         notes:
-          description: free-form Markdown notes for any member-oriented drop information that doesn't fit into an existing field. This information is public for open and semi-open drops, and visible to all members for closed drops
+          description: Free-form Markdown notes for any member-oriented drop information that doesn't fit into an existing field. This information is public for open and semi-open drops, and visible to all members for closed drops.
           type: string
       required:
         - name
         - active
     dropFees:
-      description: additional costs for members receiving at a drop
+      description: Additional costs for members receiving at a drop.
       type: object
       properties:
         medium:
-          description: payment medium (nothing, volunteer time, or a monetary payment)
+          description: Payment medium (nothing, volunteer time, or a monetary payment).
           type: string
           enum:
             - volunteer
             - payment
         condition:
-          description: fee trigger (never, only when orders are held, or for every order)
+          description: Fee trigger (never, only when orders are held, or for every order).
           type: string
           enum:
             - held
             - order
         notes:
-          description: fee amount and structure
+          description: Fee amount and structure.
           type: string
     dropMembership:
-      description: a drop membership
+      description: A drop membership.
       type: object
       properties:
         id:
           type: integer
           format: int64
         customer:
-          description: customer that has the drop membership
+          description: Customer that has the drop membership.
           type: integer
           format: int64
         drop:
-          description: the drop this membership is for
+          description: The drop this membership is for.
           type: integer
           format: int64
         active:
-          description: whether or not this membership is active. Pending memberships are active, and the usual flow for semi-open drops is (active true, pending true) -> (active true, pending false) -> (active false, pending false).
+          description: Whether or not this membership is active. Pending memberships are active, and the usual flow for semi-open drops is (active true, pending true) -> (active true, pending false) -> (active false, pending false).
           type: boolean
         pending:
-          description: whether the membership is pending (true) or accepted (false).
+          description: Whether the membership is pending (true) or accepted (false).
           type: boolean
         created:
-          description: date-time the drop-membership was created
+          description: Date-time the drop-membership was created.
           type: string
           format: date-time
         heavy:
-          description: whether the member can get pallets, totes, barrels, and other heavy objects off a truck (defaults to false).
+          description: Whether the member can get pallets, totes, barrels, and other heavy objects off a truck (defaults to false).
           type: boolean
         notifications:
           $ref: '#/components/schemas/dropMembershipNotifications'
         gratitude-total:
-          description: total "Azure Gratitude" (monetary incentive for hosting a drop) received from being this drop's coordinator. Only set if the "inline" query parameter contains "gratitude-total".
+          description: Total "Azure Gratitude" (monetary incentive for hosting a drop) received from being this drop's coordinator. Only set if the "inline" query parameter contains "gratitude-total".
           type: number
           format: float
           minimum: 0
@@ -6369,7 +6375,7 @@ components:
           type: object
           properties:
             lastOrderPlaced:
-              description: date-time the member last placed an order on this drop
+              description: Date-time the member last placed an order on this drop.
               type: string
               format: date-time
       required:
@@ -6381,25 +6387,25 @@ components:
         - created
         - notifications
     updateDropMembership:
-      description: a drop membership to update
+      description: A drop membership to update.
       type: object
       properties:
         customer:
-          description: customer that has the drop membership
+          description: Customer that has the drop membership.
           type: integer
           format: int64
         drop:
-          description: the drop this membership is for
+          description: The drop this membership is for.
           type: integer
           format: int64
         active:
-          description: whether or not this membership is active.
+          description: Whether or not this membership is active.
           type: boolean
         pending:
-          description: whether the membership is pending (true) or accepted (false).
+          description: Whether the membership is pending (true) or accepted (false).
           type: boolean
         heavy:
-          description: whether the member can get pallets, totes, barrels, and other heavy objects off a truck (defaults to false).
+          description: Whether the member can get pallets, totes, barrels, and other heavy objects off a truck (defaults to false).
           type: boolean
         notifications:
           $ref: '#/components/schemas/dropMembershipNotifications'
@@ -6410,11 +6416,11 @@ components:
     newDropMembership:
       $ref: '#/components/schemas/updateDropMembership'
     dropMembershipNotifications:
-      description: configure if and how a user receives per-drop notifications
+      description: Configure if and how a user receives per-drop notifications.
       type: object
       properties:
         cutoff:
-          description: receive notifications from Azure before cutoffs for this drop.
+          description: Receive notifications from Azure before cutoffs for this drop.
           format: array
           items:
             $ref: '#/components/schemas/notificationChannel'
@@ -6428,7 +6434,7 @@ components:
       required:
         - id
     pickup:
-      description: a purchase-pickup location
+      description: A purchase-pickup location.
       type: object
       properties:
         id:
@@ -6437,10 +6443,10 @@ components:
         name:
           type: string
         vendors:
-          description: vendors supplying this pickup
+          description: Vendors supplying this pickup.
           type: array
           items:
-            description: vendor ID
+            description: Vendor ID.
             type: integer
             format: int32
         address:
@@ -6448,10 +6454,10 @@ components:
         geo:
           $ref: '#/components/schemas/geo'
         active:
-          description: whether or not this pickup is actively supplying purchases
+          description: Whether or not this pickup is actively supplying purchases.
           type: boolean
         notes:
-          description: free-form Markdown notes for any pickup information that doesn't fit into an existing field
+          description: Free-form Markdown notes for any pickup information that doesn't fit into an existing field.
           type: string
       required:
         - id
@@ -6461,7 +6467,7 @@ components:
         - geo
         - active
     route:
-      description: an order-delivery truck route
+      description: An order-delivery truck route.
       type: object
       properties:
         id:
@@ -6469,38 +6475,38 @@ components:
           format: int64
         name:
           type: string
-        description:
+        description:.
           type: string
         cutoff-frequency:
-          description: number of days between cutoffs
+          description: Number of days between cutoffs.
           type: integer
           format: int32
         delivery-offset:
-          description: number of days after cutoff before the first stop
+          description: Number of days after cutoff before the first stop.
           type: integer
           format: int32
         internal:
           description: Is the route for internal use? This controls whether customers can access the route via the API (they can't if internal is true).
           type: boolean
         backhaul-cost-per-pound:
-          description: route backhaul cost per pound
+          description: Route backhaul cost per pound.
           type: number
           format: float
         backhaul-cost-per-pickup:
-          description: route backhaul cost per pickup
+          description: Route backhaul cost per pickup.
           type: number
           format: float
         hub:
           description: A hub route is a delivery route that occurs after we ship an entire route to a distribution hub (such as a big loading dock in Kansas City). The route is unloaded at the hub and reloaded onto another carrier's truck for actual delivery. In terms of Customer Care, It is a one-way route; the truck, trailer, and any shipped goods refused by a customer never return to the warehouse.
           type: boolean
         driverName:
-          description: Truck drivers name
+          description: Truck drivers name.
           type: string
         driverPhone:
-          description: Truck drivers phone
+          description: Truck drivers phone.
           type: string
         notes:
-          description: General notes about the route
+          description: General notes about the route.
           type: string
       required:
         - name
@@ -6512,41 +6518,41 @@ components:
         - driverPhone
         - notes
     updateRoute:
-      description: an order-delivery truck route's updated values
+      description: An order-delivery truck route's updated values.
       type: object
       properties:
-        description:
+        description:.
           type: string
         cutoff-frequency:
-          description: number of days between cutoffs
+          description: Number of days between cutoffs.
           type: integer
           format: int32
         delivery-offset:
-          description: number of days after cutoff before the first stop
+          description: Number of days after cutoff before the first stop.
           type: integer
           format: int32
         internal:
           description: Is the route for internal use? This controls whether customers can access the route via the API (they can't if internal is true).
           type: boolean
         backhaul-cost-per-pound:
-          description: route backhaul cost per pound
+          description: Route backhaul cost per pound.
           type: number
           format: float
         backhaul-cost-per-pickup:
-          description: route backhaul cost per pickup
+          description: Route backhaul cost per pickup.
           type: number
           format: float
         hub:
           description: A hub route is a delivery route that occurs after we ship an entire route to a distribution hub (such as a big loading dock in Kansas City). The route is unloaded at the hub and reloaded onto another carrier's truck for actual delivery. In terms of Customer Care, It is a one-way route; the truck, trailer, and any shipped goods refused by a customer never return to the warehouse.
           type: boolean
         driverName:
-          description: Truck drivers name
+          description: Truck drivers name.
           type: string
         driverPhone:
-          description: Truck drivers phone
+          description: Truck drivers phone.
           type: string
         notes:
-          description: General notes about the route
+          description: General notes about the route.
           type: string
       required:
         - cutoff-frequency
@@ -6555,56 +6561,56 @@ components:
     newRoute:
       $ref: '#/components/schemas/route'
     trip:
-      description: a truck delivering orders along a route
+      description: A truck delivering orders along a route.
       type: object
       properties:
         id:
           type: integer
           format: int64
         route:
-          description: name of the followed route
+          description: Name of the followed route.
           type: string
         cutoff:
-          description: cutoff for placing orders on this trip
+          description: Cutoff for placing orders on this trip.
           type: string
           format: date-time
         confirmed:
-          description: when the trip was reviewed and orders were either accepted or (for short drops) bumped to the next trip. This will always be set before the trip is confirmed, and will be unset until then. Customer service and customers who have received a short-drop notification can continue to manipulate placed orders in the window between cutoff and confirmation.
+          description: When the trip was reviewed and orders were either accepted or (for short drops) bumped to the next trip. This will always be set before the trip is confirmed, and will be unset until then. Customer service and customers who have received a short-drop notification can continue to manipulate placed orders in the window between cutoff and confirmation.
           type: string
           format: date-time
         pick-date:
-          description: date-time that orders for this trip should be picked
+          description: Date-time that orders for this trip should be picked.
           type: string
           format: date-time
         shipped:
-          description: approximately when the truck left the warehouse. This will always be set after the truck has left, and will be unset until then.
+          description: Approximately when the truck left the warehouse. This will always be set after the truck has left, and will be unset until then.
           type: string
           format: date-time
         delivery-start:
-          description: estimated stop-time for the first stop
+          description: Estimated stop-time for the first stop.
           type: string
           format: date-time
         delivery-end:
-          description: estimated stop-time for the last stop
+          description: Estimated stop-time for the last stop.
           type: string
           format: date-time
         backhaul-start:
-          description: estimated date-time for the first backhaul
+          description: Estimated date-time for the first backhaul.
           type: string
           format: date-time
         backhaul-end:
-          description: estimated date-time for the last backhaul
+          description: Estimated date-time for the last backhaul.
           type: string
           format: date-time
         warehouse-arrival:
-          description: estimated date-time for warehouse arrival
+          description: Estimated date-time for warehouse arrival.
           type: string
           format: date-time
         notes:
-          description: free-form Markdown notes for additional trip information. We expect this will mostly be for delay causes (e.g. "High winds in Laramie" or "The truck broke down")
+          description: Free-form Markdown notes for additional trip information. We expect this will mostly be for delay causes (e.g. "High winds in Laramie" or "The truck broke down").
           type: string
         status:
-          description: current stage of a trip's lifecycle
+          description: Current stage of a trip's lifecycle.
           type: string
           enum:
             - new
@@ -6617,38 +6623,38 @@ components:
         - cutoff
         - delivery-start
     updateTrip:
-      description: a truck delivering orders along a route to be updated
+      description: A truck delivering orders along a route to be updated.
       type: object
       properties:
         route:
-          description: name of the followed route
+          description: Name of the followed route.
           type: string
         cutoff:
-          description: cutoff for placing orders on this trip
+          description: Cutoff for placing orders on this trip.
           type: string
           format: date-time
         pick-date:
-          description: date-time that orders for this trip should be picked
+          description: Date-time that orders for this trip should be picked.
           type: string
           format: date-time
         delivery-start:
-          description: estimated stop-time for the first stop
+          description: Estimated stop-time for the first stop.
           type: string
           format: date-time
         delivery-end:
-          description: estimated stop-time for the last stop
+          description: Estimated stop-time for the last stop.
           type: string
           format: date-time
         backhaul-start:
-          description: estimated date-time for the first backhaul
+          description: Estimated date-time for the first backhaul.
           type: string
           format: date-time
         backhaul-end:
-          description: estimated date-time for the last backhaul
+          description: Estimated date-time for the last backhaul.
           type: string
           format: date-time
         warehouse-arrival:
-          description: estimated date-time for warehouse arrival
+          description: Estimated date-time for warehouse arrival.
           type: string
           format: date-time
       required:
@@ -6656,21 +6662,21 @@ components:
         - cutoff
         - delivery-start
     routeStop:
-      description: a template used to create stops when a trip is created
+      description: A template used to create stops when a trip is created.
       type: object
       properties:
         id:
           type: integer
           format: int64
         route:
-          description: route name for the route-stop
+          description: Route name for the route-stop.
           type: string
         drop:
-          description: drop ID for the route-stop
+          description: Drop ID for the route-stop.
           type: integer
           format: int64
         delivery-offset:
-          description: offset from midnight on the morning of the trips's delivery start until the usual delivery time for this drop
+          description: Offset from midnight on the morning of the trips's delivery start until the usual delivery time for this drop.
           type: string
           format: duration
         drop-shipping-fee:
@@ -6681,40 +6687,40 @@ components:
         - drop
         - delivery-offset
     stop:
-      description: a trip stop or waypoint. Stops are created for all route-stops when a trip is created for that route. At confirmation time, stops that will not be visited (e.g. because they missed their order-minimum) are deleted
+      description: A trip stop or waypoint. Stops are created for all route-stops when a trip is created for that route. At confirmation time, stops that will not be visited (e.g. because they missed their order-minimum) are deleted.
       type: object
       properties:
         id:
           type: integer
           format: int64
         trip:
-          description: trip ID for the stop
+          description: Trip ID for the stop.
           type: integer
           format: int64
         drop:
-          description: drop ID for the stop
+          description: Drop ID for the stop.
           type: integer
           format: int64
         short-drop:
-          description: whether short-drop warnings were sent out for this stop. If they were, customers can manipulate placed orders after cutoff time, although nobody can edit orders after the trip is confirmed.
+          description: Whether short-drop warnings were sent out for this stop. If they were, customers can manipulate placed orders after cutoff time, although nobody can edit orders after the trip is confirmed.
           type: boolean
         pickup:
-          description: pickup ID for the stop
+          description: Pickup ID for the stop.
           type: integer
           format: int64
         timezone:
-          description: IANA time zone location (https://www.iana.org/time-zones, e.g. America/Los_Angeles)
+          description: IANA time zone location (https://www.iana.org/time-zones, e.g. America/Los_Angeles).
           type: string
         estimatedDelivery:
-          description: editable until verification
+          description: Editable until verification.
           type: string
           format: date-time
         finalizedDelivery:
-          description: editable between verification and delivery
+          description: Editable between verification and delivery.
           type: string
           format: date-time
         actualDelivery:
-          description: when the stop is actually reached
+          description: When the stop is actually reached.
           type: string
           format: date-time
         drop-shipping-fee:
@@ -6725,31 +6731,31 @@ components:
         - estimatedDelivery
         - finalizedDelivery
     updateStop:
-      description: an update to a trip stop or waypoint
+      description: An update to a trip stop or waypoint.
       type: object
       properties:
         trip:
-          description: trip ID for the stop
+          description: Trip ID for the stop.
           type: integer
           format: int64
         drop:
-          description: drop ID for the stop
+          description: Drop ID for the stop.
           type: integer
           format: int64
         pickup:
-          description: pickup ID for the stop
+          description: Pickup ID for the stop.
           type: integer
           format: int64
         estimatedDelivery:
-          description: editable until verification
+          description: Editable until verification.
           type: string
           format: date-time
         finalizedDelivery:
-          description: editable between verification and delivery
+          description: Editable between verification and delivery.
           type: string
           format: date-time
         actualDelivery:
-          description: when the stop is actually reached
+          description: When the stop is actually reached.
           type: string
           format: date-time
       required:
@@ -6780,7 +6786,7 @@ components:
         - frozen
         - greenhouse
     packagedProduct:
-      description: a particular packaged form of a product
+      description: A particular packaged form of a product.
       type: object
       properties:
         code:
@@ -6792,10 +6798,10 @@ components:
           description: Size of the product (e.g. 12 oz., or 6x12 oz.).
           type: string
         packs:
-          description: Package organization (e.g. "4", "4x32.5", or "2x4x32.5")
+          description: Package organization (e.g. "4", "4x32.5", or "2x4x32.5").
           type: string
         unit:
-          description: Unit of measurement ("ounce", "liter", etc.)
+          description: Unit of measurement ("ounce", "liter", etc.).
           type: string
         weight:
           $ref: '#/components/schemas/weight'
@@ -6866,24 +6872,24 @@ components:
         - packaged-product
         - image
     packagedProductTag:
-      description: a type of packaged product or other boolean marker
+      description: A type of packaged product or other boolean marker.
       type: object
       properties:
         slug:
-          description: code used as the primary key for tags
+          description: Code used as the primary key for tags.
           type: string
         name:
-          description: human-readable tag name
+          description: Human-readable tag name.
           type: string
         category:
-          description: category code describing the type of tag
+          description: Category code describing the type of tag.
           type: string
           enum:
             - status
             - price-level
             - characteristic
     packagedProductTagAssociation:
-      description: a packaged product tag representing a saved filter for a person
+      description: A packaged product tag representing a saved filter for a person.
       type: object
       properties:
         id:
@@ -6899,14 +6905,14 @@ components:
         - person
         - tag
     product:
-      description: a product available for sale (independent of packaging)
+      description: A product available for sale (independent of packaging).
       type: object
       properties:
         id:
           type: integer
           format: int64
         name:
-          description: sentence-length product name
+          description: Sentence-length product name.
           type: string
         seo-name:
           description: An SEO-optimized name. A lengthened version of the full name that includes additional keywords or rephrasing, suitable for use in a title tag. When this is unset, the name is a reasonable fallback.
@@ -6914,33 +6920,33 @@ components:
         treatAsActive:
           description: If true, this product will be published to search engines even when it is inactive (out for season, out long term, or discontinued).
           type: boolean
-        inactiveDescription:
+        inactiveDescription:.
           description: HTML description applicable only when the product is inactive (out for season, out long term, or discontinued). It should contain specific information pertinent to the inactive status of the product (e.g. details about why it is inactive and what similar products are available instead). It should not duplicate information in short-description or description.
           type: string
-        short-description:
-          description: paragraph-length, stand-alone, plain-text product description
+        short-description:.
+          description: Paragraph-length, stand-alone, plain-text product description.
           type: string
-        description:
-          description: long-form, HTML product description. When short-description is set, this value is for additional information which did not fit into short-description. Displaying both short-description and description is not redundant. Displaying only description may be confusing when short-description is available.
+        description:.
+          description: Long-form, HTML product description. When short-description is set, this value is for additional information which did not fit into short-description. Displaying both short-description and description is not redundant. Displaying only description may be confusing when short-description is available.
           type: string
         brand:
-          description: the brand associated with this product
+          description: The brand associated with this product.
           type: integer
           format: int64
         directions:
-          description: product use directions (e.g., cooking suggestions)
+          description: Product use directions (e.g., cooking suggestions).
           type: string
         favorites:
-          description: number of people who've marked this product as a favorite
+          description: Number of people who've marked this product as a favorite.
           type: integer
           format: int32
         ingredients:
-          description: ingredients used in this product (e.g., "dried cranberries (organic cranberries, organic cane sugar, organic sunflower oil)")
+          description: Ingredients used in this product (e.g., "dried cranberries (organic cranberries, organic cane sugar, organic sunflower oil)").
           type: string
         nutrition-facts:
           $ref: '#/components/schemas/nutritionFacts'
         packaging:
-          description: packaged versions of this product
+          description: Packaged versions of this product.
           type: array
           items:
             type: integer
@@ -6962,49 +6968,49 @@ components:
                 type: integer
                 format: int64
         country-of-origin:
-          description: country of origin for this product
+          description: Country of origin for this product.
           type: string
         storage:
           $ref: '#/components/schemas/storage'
         slug:
-          description: a slug generated from the product name
+          description: A slug generated from the product name.
           type: string
       required:
         - id
         - name
     nutritionFacts:
-      description: nutrition facts
+      description: Nutrition facts.
       type: object
       properties:
         headers:
-          description: nutrition-fact headers (e.g. "Serving Size 1 cake (19g)" or "Calories 60")
+          description: Nutrition-fact headers (e.g. "Serving Size 1 cake (19g)" or "Calories 60").
           type: array
           items:
             type: string
         daily-values:
-          description: nutrition facts daily values
+          description: Nutrition facts daily values.
           type: array
           items:
             $ref: '#/components/schemas/nutritionFactsDailyValue'
     nutritionFactsDailyValue:
-      description: a nutrition facts daily value
+      description: A nutrition facts daily value.
       type: object
       properties:
         indent:
-          description: if true, this label should be indented (e.g. an indented "Dietary Fiber" entry might follow a non-indented "Total Carbohydrate" entry)
+          description: If true, this label should be indented (e.g. an indented "Dietary Fiber" entry might follow a non-indented "Total Carbohydrate" entry).
           type: boolean
         label:
-          description: daily value label (e.g. "Total Carbohydrate 14g", "Calcium")
+          description: Daily value label (e.g. "Total Carbohydrate 14g", "Calcium").
           type: string
         percentage:
-          description: daily value percentage (e.g., "10" or "<1")
+          description: Daily value percentage (e.g., "10" or "<1").
           type: string
       required:
         - indent
         - label
         - percentage
     brand:
-      description: a brand which may be associated with several products
+      description: A brand which may be associated with several products.
       type: object
       properties:
         id:
@@ -7013,11 +7019,11 @@ components:
         name:
           type: string
         url:
-          description: homepage for the brand
+          description: Homepage for the brand.
           type: string
           format: url
         slug:
-          description: a slug generated from the brand name
+          description: A slug generated from the brand name.
           type: string
       required:
         - id
@@ -7059,20 +7065,20 @@ components:
         - maxRewardsRate
         - dollars
     priceLevel:
-      description: a customer property to pick the right price from 'price'
+      description: A customer property to pick the right price from 'price'.
       type: string
       enum:
         - retail
         - wholesale
         - member
     permission:
-      description: an API authorization or authorization category
+      description: An API authorization or authorization category.
       type: string
       enum:
         - staff
         - superuser
     price:
-      description: product price information
+      description: Product price information.
       type: object
       properties:
         retail:
@@ -7092,12 +7098,12 @@ components:
           description: A phrase naming the category. This should be understandable (but not necessarily unique) without any further context. It must be unique for categories sharing a given parent.
           type: string
         short-name:
-          description: A word or two naming the category. A shortened version of the full name that drops any words already contained in the category's ancestors' short names. This will be used in places where the ancestor short names are in close proximity (e.g. URL slugs) to avoid having the same word many times. When this is unset, the name is a reasonable fallback
+          description: A word or two naming the category. A shortened version of the full name that drops any words already contained in the category's ancestors' short names. This will be used in places where the ancestor short names are in close proximity (e.g. URL slugs) to avoid having the same word many times. When this is unset, the name is a reasonable fallback.
           type: string
         seo-name:
           description: An SEO-optimized name for the category. A lengthened version of the full name that includes additional keywords or rephrasing, suitable for use in a title tag. When this is unset, the name is a reasonable fallback.
           type: string
-        description:
+        description:.
           description: A sentence or two with a stand-alone category description. When this is unset, the nearest ancestor description is a reasonable fallback.
           type: string
         image:
@@ -7117,10 +7123,10 @@ components:
           type: integer
           format: int32
         primary:
-          description: Is this a primary category?
+          description: Is this a primary category?.
           type: boolean
         active:
-          description: Is this category active?
+          description: Is this category active?.
           type: boolean
         keywords:
           type: array
@@ -7145,12 +7151,12 @@ components:
           description: A phrase naming the category. This should be understandable (but not necessarily unique) without any further context. It must be unique for categories sharing a given parent.
           type: string
         short-name:
-          description: A word or two naming the category. A shortened version of the full name that drops any words already contained in the category's ancestors' short names. This will be used in places where the ancestor short names are in close proximity (e.g. URL slugs) to avoid having the same word many times. When this is unset, the name is a reasonable fallback
+          description: A word or two naming the category. A shortened version of the full name that drops any words already contained in the category's ancestors' short names. This will be used in places where the ancestor short names are in close proximity (e.g. URL slugs) to avoid having the same word many times. When this is unset, the name is a reasonable fallback.
           type: string
         seo-name:
           description: An SEO-optimized name for the category. A lengthened version of the full name that includes additional keywords or rephrasing, suitable for use in a title tag. When this is unset, the name is a reasonable fallback.
           type: string
-        description:
+        description:.
           description: A sentence or two with a stand-alone category description. When this is unset, the nearest ancestor description is a reasonable fallback.
           type: string
         image:
@@ -7161,10 +7167,10 @@ components:
           type: integer
           format: int64
         primary:
-          description: Is this a primary category?
+          description: Is this a primary category?.
           type: boolean
         active:
-          description: Is this category active?
+          description: Is this category active?.
           type: boolean
         keywords:
           type: array
@@ -7181,18 +7187,18 @@ components:
       required:
         - name
     purchase:
-      description: a purchase order placed by Azure
+      description: A purchase order placed by Azure.
       type: object
       properties:
         id:
           type: integer
           format: int64
         vendor:
-          description: vendor supplying the order
+          description: Vendor supplying the order.
           type: integer
           format: int64
         status:
-          description: purchase's lifecycle stage
+          description: Purchase's lifecycle stage.
           type: string
           enum:
             - open
@@ -7204,45 +7210,45 @@ components:
             - reconciled
             - paid
         submitted:
-          description: when the purchase was submitted
+          description: When the purchase was submitted.
           type: string
           format: date-time
         confirmed:
-          description: when the purchase was confirmed
+          description: When the purchase was confirmed.
           type: string
           format: date-time
         delivered:
-          description: when the purchase was delivered
+          description: When the purchase was delivered.
           type: string
           format: date-time
         reconciled:
-          description: when the purchase was reconciled
+          description: When the purchase was reconciled.
           type: string
           format: date-time
         pickup:
-          description: drop the purchase is destined for (only set for backhaul purchases)
+          description: Drop the purchase is destined for (only set for backhaul purchases).
           type: integer
           format: int64
         trip:
-          description: trip delivering the purchase (only set for backhaul purchases)
+          description: Trip delivering the purchase (only set for backhaul purchases).
           type: integer
           format: int64
         notes:
-          description: free-form Markdown notes for any purchase information that doesn't fit into an existing field
+          description: Free-form Markdown notes for any purchase information that doesn't fit into an existing field.
           type: string
       required:
         - id
         - vendor
         - status
     order:
-      description: an order placed by a customer
+      description: An order placed by a customer.
       type: object
       properties:
         id:
           type: integer
           format: int64
         customer:
-          description: customer making the order
+          description: Customer making the order.
           type: integer
           format: int64
         inline:
@@ -7254,7 +7260,7 @@ components:
               type: integer
               format: int64
         status:
-          description: order's lifecycle stage
+          description: Order's lifecycle stage.
           type: string
           enum:
             - open
@@ -7263,23 +7269,23 @@ components:
             - shipped
             - lost
         placed:
-          description: when the order was placed
+          description: When the order was placed.
           type: string
           format: date-time
         shipped:
-          description: when the order was shipped
+          description: When the order was shipped.
           type: string
           format: date-time
         target-delivery:
-          description: planned delivery time (fixed before the trip starts, and unset for parcel-carrier orders)
+          description: Planned delivery time (fixed before the trip starts, and unset for parcel-carrier orders).
           type: string
           format: date-time
         estimated-delivery:
-          description: estimated delivery time (updated after the trip starts until the order is delivered, and unset for parcel-carrier orders)
+          description: Estimated delivery time (updated after the trip starts until the order is delivered, and unset for parcel-carrier orders).
           type: string
           format: date-time
         delivered:
-          description: when the order was delivered
+          description: When the order was delivered.
           type: string
           format: date-time
         checkout-payment:
@@ -7289,11 +7295,11 @@ components:
           type: number
           format: float
         drop:
-          description: drop the order is destined for (unset for parcel-carrier orders)
+          description: Drop the order is destined for (unset for parcel-carrier orders).
           type: integer
           format: int64
         trip:
-          description: trip delivering the order (automatically populated for parcel-carrier orders)
+          description: Trip delivering the order (automatically populated for parcel-carrier orders).
           type: integer
           format: int64
         address:
@@ -7304,16 +7310,16 @@ components:
           description: If true, the customer has accepted the warning regarding shipping perishable product.
           type: boolean
         cases-shipped:
-          description: Total quantity of shipped boxes and bulk stock
+          description: Total quantity of shipped boxes and bulk stock.
           type: integer
           format: int64
         casesShippedBreakdown:
           $ref: '#/components/schemas/orderCaseQuantitiesByTemperature'
         notes:
-          description: Warehouse packing instructions
+          description: Warehouse packing instructions.
           type: string
         lastApiUpdate:
-          description: a datetime denoting when the order or its order-lines were last updated via the API
+          description: A datetime denoting when the order or its order-lines were last updated via the API.
           type: string
         holdShipmentUntilStockAvailable:
           description: If true, the customer has requested to hold shipment of the order until all requested stock is available.
@@ -7496,15 +7502,15 @@ components:
         - customer
         - status
     updateOrder:
-      description: an order placed by a customer
+      description: An order placed by a customer.
       type: object
       properties:
         customer:
-          description: customer making the order
+          description: Customer making the order.
           type: integer
           format: int64
         status:
-          description: order's lifecycle stage
+          description: Order's lifecycle stage.
           type: string
           enum:
             - open
@@ -7514,11 +7520,11 @@ components:
         checkout-payment:
           $ref: '#/components/schemas/payment'
         drop:
-          description: drop the order is destined for (unset for parcel-carrier orders)
+          description: Drop the order is destined for (unset for parcel-carrier orders).
           type: integer
           format: int64
         trip:
-          description: trip delivering the order (automatically populated for parcel-carrier orders)
+          description: Trip delivering the order (automatically populated for parcel-carrier orders).
           type: integer
           format: int64
         address:
@@ -7529,7 +7535,7 @@ components:
           description: If true, the customer has accepted the warning regarding shipping perishable product.
           type: boolean
         notes:
-          description: Additional information about the order, including special instructions for Azure's pickers
+          description: Additional information about the order, including special instructions for Azure's pickers.
           type: string
         holdShipmentUntilStockAvailable:
           description: If true, the customer has requested to hold shipment of the order until all requested stock is available.
@@ -7538,29 +7544,29 @@ components:
         - customer
         - status
     changedOrder:
-      description: an updated order and a list of any side-effects from the update
+      description: An updated order and a list of any side-effects from the update.
       type: object
       properties:
         order:
           $ref: '#/components/schemas/order'
         changes:
-          description: An array of side-effects. Will be set if there were side-effects and unset if there were none
+          description: An array of side-effects. Will be set if there were side-effects and unset if there were none.
           type: array
           items:
             $ref: '#/components/schemas/orderChange'
       required:
         - order
     orderChange:
-      description: A side-effect from an order update
+      description: A side-effect from an order update.
       type: object
       properties:
         type:
-          description: A slug identifying the type of change
+          description: A slug identifying the type of change.
           type: string
           enum:
             - remove-order-line
         reason:
-          description: A human-readable description of the change
+          description: A human-readable description of the change.
           type: string
         order-line:
           $ref: '#/components/schemas/orderLine'
@@ -7568,60 +7574,60 @@ components:
         - change
         - reason
     orderCaseQuantitiesByTemperature:
-      description: Quantity of shipped boxes and bulk stock by temperature type
+      description: Quantity of shipped boxes and bulk stock by temperature type.
       type: object
       properties:
         frozen:
-          description: Quantity of shipped boxes and bulk stock with the frozen climate
+          description: Quantity of shipped boxes and bulk stock with the frozen climate.
           type: integer
           format: int32
         refrigerated:
-          description: Quantity of shipped boxes and bulk stock with the refrigerated climate
+          description: Quantity of shipped boxes and bulk stock with the refrigerated climate.
           type: integer
           format: int32
         roomTemp:
-          description: Quantity of shipped boxes and bulk stock with the room temperature climate
+          description: Quantity of shipped boxes and bulk stock with the room temperature climate.
           type: integer
           format: int32
     orderLine:
-      description: a per-product entry in an order
+      description: A per-product entry in an order.
       type: object
       properties:
         id:
           type: integer
           format: int64
         order:
-          description: order that the order-line belongs to
+          description: Order that the order-line belongs to.
           type: integer
           format: int64
         packaged-product:
-          description: packaged product code that is being ordered
+          description: Packaged product code that is being ordered.
           type: string
         product:
-          description: product ID of the packaged product that is being ordered
+          description: Product ID of the packaged product that is being ordered.
           type: integer
           format: int64
         name:
-          description: most order lines are for packaged products, but Azure sometimes bills for less concrete items like catalog ads. This field holds a brief description of the line, and should be used for invoices instead of following packaged-product (which may not be set).
+          description: Most order lines are for packaged products, but Azure sometimes bills for less concrete items like catalog ads. This field holds a brief description of the line, and should be used for invoices instead of following packaged-product (which may not be set).
           type: string
         quantity-ordered:
-          description: number of product instances requested
+          description: Number of product instances requested.
           type: integer
           format: int32
         quantity-shipped:
-          description: number of product instances delivered
+          description: Number of product instances delivered.
           type: number
           format: float
         weight:
-          description: weight of the shipped products in pounds (estimated until picking time)
+          description: Weight of the shipped products in pounds (estimated until picking time).
           type: number
           format: float
         volume:
-          description: volume of the shipped products in cubic feet (estimated until picking time)
+          description: Volume of the shipped products in cubic feet (estimated until picking time).
           type: number
           format: float
         price:
-          description: the total price for this line in dollars (estimated until picking time). The per-unit price used to calculate this total is currently locked in when you place the order.
+          description: The total price for this line in dollars (estimated until picking time). The per-unit price used to calculate this total is currently locked in when you place the order.
           type: number
           format: float
         rewards:
@@ -7632,7 +7638,7 @@ components:
           description: An array of warnings about this product.
           type: array
           items:
-            description: Warnings about products that a customer can associate with this order, but maybe should not (e.g. that is is likely to expire before reaching the customer)
+            description: Warnings about products that a customer can associate with this order, but maybe should not (e.g. that is is likely to expire before reaching the customer).
             type: string
       required:
         - id
@@ -7642,21 +7648,21 @@ components:
         - weight
         - volume
     updateOrderLine:
-      description: a per-product entry in an order
+      description: A per-product entry in an order.
       type: object
       properties:
         order:
-          description: order that the order-line belongs to
+          description: Order that the order-line belongs to.
           type: integer
           format: int64
         packaged-product:
-          description: packaged product code that is being ordered
+          description: Packaged product code that is being ordered.
           type: string
         name:
-          description: most order lines are for packaged products, but Azure sometimes bills for less concrete items like catalog ads. This field holds a brief description of the line, and should be used for invoices instead of following packaged-product (which may not be set).
+          description: Most order lines are for packaged products, but Azure sometimes bills for less concrete items like catalog ads. This field holds a brief description of the line, and should be used for invoices instead of following packaged-product (which may not be set).
           type: string
         quantity-ordered:
-          description: number of product instances requested
+          description: Number of product instances requested.
           type: integer
           format: int32
       required:
@@ -7670,13 +7676,13 @@ components:
           type: integer
           format: int64
         order:
-          description: Order that the fee belongs to
+          description: Order that the fee belongs to.
           type: integer
           format: int64
         type:
           $ref: '#/components/schemas/orderFeeType'
         amount:
-          description: Dollar value for the fee
+          description: Dollar value for the fee.
           type: number
           format: float
         climate:
@@ -7684,24 +7690,24 @@ components:
         shipping-service:
           $ref: '#/components/schemas/shippingService'
         notes:
-          description: Additional information about the reason or amount for the fee
+          description: Additional information about the reason or amount for the fee.
           type: string
       required:
         - order
         - type
         - amount
     orderFeeType:
-      description: A property for an order fee
+      description: A property for an order fee.
       type: string
       enum:
         - shipping
         - small-order
     dropShippingFee:
-      description: information for calculating shipping costs for orders delivered to a stop
+      description: Information for calculating shipping costs for orders delivered to a stop.
       type: object
       properties:
         percent:
-          description: the `shipping` order fee is the total order-line price over all lines on the order, multiplied by this percentage, and then rounded to the nearest cent.
+          description: The `shipping` order fee is the total order-line price over all lines on the order, multiplied by this percentage, and then rounded to the nearest cent.
           type: number
           format: float
     orderParcelCarrierEstimate:
@@ -7764,7 +7770,7 @@ components:
         chilled/frozen:
           $ref: '#/components/schemas/shippingService'
     vendor:
-      description: a company that sells products to Azure
+      description: A company that sells products to Azure.
       type: object
       properties:
         id:
@@ -7773,17 +7779,17 @@ components:
         name:
           type: string
         active:
-          description: whether or not this vendor is actively supplying purchases
+          description: Whether or not this vendor is actively supplying purchases.
           type: boolean
         url:
-          description: homepage for the vendor
+          description: Homepage for the vendor.
           type: string
           format: url
         indie:
-          description: whether or not this vendor is a privately held company
+          description: Whether or not this vendor is a privately held company.
           type: boolean
         account:
-          description: vendor's identifier for Azure
+          description: Vendor's identifier for Azure.
           type: string
       required:
         - id
@@ -7797,22 +7803,22 @@ components:
           type: integer
           format: int64
         person:
-          description: person associated with the account
+          description: Person associated with the account.
           type: integer
           format: int64
         amount:
-          description: dollar value for the entry (positive for credits like customer payments, negative for debits like order charges)
+          description: Dollar value for the entry (positive for credits like customer payments, negative for debits like order charges).
           type: number
           format: float
         date:
-          description: when the entry was added
+          description: When the entry was added.
           type: string
           format: date
         notes:
-          description: a line of Markdown identifying the entry (e.g. "charge for order 123" or "payed with card ending in 0123").
+          description: A line of Markdown identifying the entry (e.g. "charge for order 123" or "payed with card ending in 0123").
           type: string
         balance:
-          description: account balance after this account entry
+          description: Account balance after this account entry.
           type: number
           format: float
       required:
@@ -7821,37 +7827,37 @@ components:
         - amount
         - date
     creditCard:
-      description: a credit card (one of our supported payment methods)
+      description: A credit card (one of our supported payment methods).
       type: object
       properties:
         id:
           type: integer
           format: int64
         type:
-          description: string identifying this payment method
+          description: String identifying this payment method.
           type: string
           enum:
             - credit-card
         active:
-          description: whether or not this payment method is available for further activity
+          description: Whether or not this payment method is available for further activity.
           type: boolean
         person:
-          description: person associated with this payment method
+          description: Person associated with this payment method.
           type: integer
           format: int64
         name:
-          description: billing name (which may differ from the associated person's name)
+          description: Billing name (which may differ from the associated person's name).
           type: string
         address:
           $ref: '#/components/schemas/address'
         issuer:
-          description: provider network. You can determine this from the leading digits of the card number, but we don't store those digits
+          description: Provider network. You can determine this from the leading digits of the card number, but we don't store those digits.
           type: string
         last-four:
-          description: last four digits of the card number for identification
+          description: Last four digits of the card number for identification.
           type: string
         expiration:
-          description: expiration date. We only use the month and year; the day will always be '01'.
+          description: Expiration date. We only use the month and year; the day will always be '01'.
           type: string
           format: date
       required:
@@ -7868,32 +7874,32 @@ components:
       type: object
       properties:
         type:
-          description: string identifying this payment method
+          description: String identifying this payment method.
           type: string
           enum:
             - credit-card
         active:
-          description: whether or not this payment method is available for further activity. Defaults to true
+          description: Whether or not this payment method is available for further activity. Defaults to true.
           type: boolean
         person:
-          description: person associated with this payment method
+          description: Person associated with this payment method.
           type: integer
           format: int64
         name:
-          description: billing name (which may differ from the associated person's name)
+          description: Billing name (which may differ from the associated person's name).
           type: string
         address:
-          description: billing address associated with this credit card
+          description: Billing address associated with this credit card.
           type: integer
           format: int64
         number:
-          description: card number
+          description: Card number.
           type: string
         security-code:
-          description: security code (also known as the verification value)
+          description: Security code (also known as the verification value).
           type: string
         expiration:
-          description: expiration date. We only use the month and year and ignore the day (which you should set to '01').
+          description: Expiration date. We only use the month and year and ignore the day (which you should set to '01').
           type: string
           format: date
       required:
@@ -7905,14 +7911,14 @@ components:
         - security-code
         - expiration
     genericPaymentMethod:
-      description: one of our supported payment methods that does not have properties beyond the generic payment-method properties
+      description: One of our supported payment methods that does not have properties beyond the generic payment-method properties.
       type: object
       properties:
         id:
           type: integer
           format: int64
         type:
-          description: string identifying this payment method. cash-on-delivery means customers must pay for their order in cash to pick up the order. hold-for-payment means customers must pay for the order before Azure will ship it. net-N means the order must be paid for within N days. payroll-deduction means the invoiced price will be deducted from the customer's (an Azure employee) next paycheck.
+          description: String identifying this payment method. cash-on-delivery means customers must pay for their order in cash to pick up the order. hold-for-payment means customers must pay for the order before Azure will ship it. net-N means the order must be paid for within N days. payroll-deduction means the invoiced price will be deducted from the customer's (an Azure employee) next paycheck.
           type: string
           enum:
             - cash-on-delivery
@@ -7921,10 +7927,10 @@ components:
             - net-30-days
             - payroll-deduction
         active:
-          description: whether or not this payment method is available for further activity
+          description: Whether or not this payment method is available for further activity.
           type: boolean
         person:
-          description: person associated with this payment method
+          description: Person associated with this payment method.
           type: integer
           format: int64
       required:
@@ -7944,26 +7950,26 @@ components:
       type: object
       properties:
         payment-method:
-          description: Payment-method ID to use (or which was used)
+          description: Payment-method ID to use (or which was used).
           type: integer
           format: int64
         type:
-          description: The type of payment used
+          description: The type of payment used.
           type: string
         last-four:
-          description: The last four digits of the credit card used. Only included if the payment type is Credit Card
+          description: The last four digits of the credit card used. Only included if the payment type is Credit Card.
           type: string
         amount:
-          description: Amount to charge (or which was charged) in dollars
+          description: Amount to charge (or which was charged) in dollars.
           type: number
           format: float
         paid:
-          description: Has the payment been charged?
+          description: Has the payment been charged?.
           type: boolean
       required:
         - payment-method
     registrationRequest:
-      description: A request for registering a new person
+      description: A request for registering a new person.
       type: object
       properties:
         person:
@@ -7978,12 +7984,12 @@ components:
           type: string
           format: email
         telephone:
-          description: The registrant's telephone numbers (currently only supports 'voice' and 'text' types)
+          description: The registrant's telephone numbers (currently only supports 'voice' and 'text' types).
           type: array
           items:
             $ref: '#/components/schemas/telephone'
         drop:
-          description: The registrant's chosen drop
+          description: The registrant's chosen drop.
           type: integer
           format: int64
         context:
@@ -8077,7 +8083,7 @@ components:
         - referrer
         - visitor
     registrationResponse:
-      description: The registration response
+      description: The registration response.
       type: object
       properties:
         session:
@@ -8108,7 +8114,7 @@ components:
         - authentication-base-url
         - token
     token:
-      description: Authentication credentials
+      description: Authentication credentials.
       type: object
       properties:
         token:
@@ -8117,20 +8123,20 @@ components:
       required:
         - token
     usernamePassword:
-      description: Authentication credentials
+      description: Authentication credentials.
       type: object
       properties:
         username:
-          description: Username for authentication. Instead of your username, you could also use your primary email address or your person ID here
+          description: Username for authentication. Instead of your username, you could also use your primary email address or your person ID here.
           type: string
         password:
-          description: Password for authentication
+          description: Password for authentication.
           type: string
       required:
         - username
         - password
     passwordResetRequest:
-      description: A request for a password-reset token
+      description: A request for a password-reset token.
       type: object
       properties:
         base-url:
@@ -8138,57 +8144,57 @@ components:
           type: string
           format: url
         email:
-          description: The email address for the person whose password will be reset. Instead of the email address, you may also use your username or person ID here
+          description: The email address for the person whose password will be reset. Instead of the email address, you may also use your username or person ID here.
           type: string
       required:
         - base-url
         - email
     passwordResetConfirmation:
-      description: A request to reset a password using a password-reset token
+      description: A request to reset a password using a password-reset token.
       type: object
       properties:
         token:
-          description: The password-reset confirmation token
+          description: The password-reset confirmation token.
           type: string
         password:
-          description: The new password
+          description: The new password.
           type: string
       required:
         - token
         - password
     notificationChannel:
-      description: channel technology for pushing user notifications
+      description: Channel technology for pushing user notifications.
       type: string
       enum:
         - email
         - text
     telephone:
-      description: A telephone number
+      description: A telephone number.
       type: object
       properties:
         pref:
-          description: Mark a preferred-use telephone number (assumed false)
+          description: Mark a preferred-use telephone number (assumed false).
           type: boolean
         type:
-          description: An array of properties for this number
+          description: An array of properties for this number.
           type: array
           items:
             $ref: '#/components/schemas/telephoneType'
         number:
-          description: E.123 telephone number
+          description: E.123 telephone number.
           type: string
           format: telephone
       required:
         - type
         - number
     telephoneType:
-      description: a property of a telephone number
+      description: A property of a telephone number.
       type: string
       enum:
         - text
         - voice
     person:
-      description: a person (customer, vendor, employee, ...)
+      description: A person (customer, vendor, employee, ..).
       type: object
       properties:
         id:
@@ -8207,16 +8213,16 @@ components:
           type: string
           format: email
         can-email:
-          description: Can Azure contact this person for reasons other than registration
+          description: Can Azure contact this person for reasons other than registration.
           type: boolean
         sale-magazine:
-          description: Set to true to receive the sale magazine
+          description: Set to true to receive the sale magazine.
           type: boolean
         company:
-          description: Employer name
+          description: Employer name.
           type: string
         allow-social-media:
-          description: Does this person want social media links to display
+          description: Does this person want social media links to display.
           type: boolean
         price-level:
           $ref: '#/components/schemas/priceLevel'
@@ -8228,7 +8234,7 @@ components:
         notifications:
           $ref: '#/components/schemas/personNotifications'
         permissions:
-          description: API permissions for this person
+          description: API permissions for this person.
           type: array
           items:
             $ref: '#/components/schemas/permission'
@@ -8240,13 +8246,13 @@ components:
             - outstanding-balance-pay
             - outstanding-balance-warn
         internal-notes:
-          description: free-form Markdown notes for any internal information that doesn't fit into an existing field. Only Azure employees can view or edit this information, although it may be passed into the registerPerson endpoint when registering new people.
+          description: Free-form Markdown notes for any internal information that doesn't fit into an existing field. Only Azure employees can view or edit this information, although it may be passed into the registerPerson endpoint when registering new people.
           type: string
         affiliate-code:
           description: Affiliate code to be used with URL shares.
           type: string
         affiliate-username:
-          description: Affiliate username (email)
+          description: Affiliate username (email).
           type: string
           format: email
         is-allowed-to-be-affiliate:
@@ -8295,25 +8301,25 @@ components:
         - name
         - notifications
     updatePerson:
-      description: a person (customer, vendor, employee, ...)
+      description: A person (customer, vendor, employee, ..).
       type: object
       properties:
         name:
           type: string
         password:
-          description: Password for authentication
+          description: Password for authentication.
           type: string
         can-email:
-          description: Can Azure contact this person for reasons other than registration? Defaults to true when creating a person
+          description: Can Azure contact this person for reasons other than registration? Defaults to true when creating a person.
           type: boolean
         sale-magazine:
-          description: Subscribed to receive the sale magazine?  Defaults to false when creating a person
+          description: Subscribed to receive the sale magazine?  Defaults to false when creating a person.
           type: boolean
         company:
-          description: Employer name
+          description: Employer name.
           type: string
         allow-social-media:
-          description: Does this person want social media links to display?  Defaults to true when creating a person
+          description: Does this person want social media links to display?  Defaults to true when creating a person.
           type: boolean
         notifications:
           $ref: '#/components/schemas/personNotifications'
@@ -8324,25 +8330,25 @@ components:
           description: Is allowed to be an affiliate. Only users with the update-person permission can edit this information.
           type: boolean
     updatePersonUserPassword:
-      description: a person (customer, vendor, employee, ...) with the logged in user's password
+      description: A person (customer, vendor, employee, ..) with the logged in user's password.
       type: object
       properties:
         name:
           type: string
         password:
-          description: Password for authentication
+          description: Password for authentication.
           type: string
         can-email:
-          description: Can Azure contact this person for reasons other than registration
+          description: Can Azure contact this person for reasons other than registration.
           type: boolean
         sale-magazine:
-          description: Subscribed to receive the sale magazine
+          description: Subscribed to receive the sale magazine.
           type: boolean
         company:
-          description: Employer name
+          description: Employer name.
           type: string
         allow-social-media:
-          description: Does this person want social media links to display
+          description: Does this person want social media links to display.
           type: boolean
         user-password:
           description: The authenticated person's password. Required when changing password for users with a usable password.
@@ -8350,7 +8356,7 @@ components:
         notifications:
           $ref: '#/components/schemas/personNotifications'
     personNotifications:
-      description: configure if and how a user receives per-user notifications
+      description: Configure if and how a user receives per-user notifications.
       type: object
       properties:
         abandonedCart:
@@ -8359,22 +8365,22 @@ components:
           items:
             $ref: '#/components/schemas/notificationChannel'
         checkout:
-          description: sent after checking out orders.
+          description: Sent after checking out orders.
           format: array
           items:
             $ref: '#/components/schemas/notificationChannel'
         delivery:
-          description: sent after order delivery, and after updates to delivery estimates.
+          description: Sent after order delivery, and after updates to delivery estimates.
           format: array
           items:
             $ref: '#/components/schemas/notificationChannel'
         payment:
-          description: sent after Azure processes a payment.
+          description: Sent after Azure processes a payment.
           format: array
           items:
             $ref: '#/components/schemas/notificationChannel'
         invoice:
-          description: sent when new invoices are generated
+          description: Sent when new invoices are generated.
           format: array
           items:
             type: string
@@ -8382,11 +8388,11 @@ components:
               - paper
               - email
     address:
-      description: An address following the convention of http://microformats.org/wiki/h-adr and https://tools.ietf.org/html/rfc6350#section-6.3.1, with an additional `name` property
+      description: An address following the convention of http://microformats.org/wiki/h-adr and https://tools.ietf.org/html/rfc6350#section-6.3.1, with an additional `name` property.
       type: object
       properties:
         name:
-          description: contact name for this address (e.g. "Mr. John Q. Public, Esq.")
+          description: Contact name for this address (e.g. "Mr. John Q. Public, Esq.").
           type: string
         post-office-box:
           type: string
@@ -8397,7 +8403,7 @@ components:
         locality:
           type: string
         region:
-          description: required for the United States and Canada, optional for other countries
+          description: Required for the United States and Canada, optional for other countries.
           type: string
         postal-code:
           type: string
@@ -8405,42 +8411,42 @@ components:
           description: ISO 3166-1 alpha-3 code for the country. On push, you can set the alpha-2 code or case-insensitve name instead, or you can use an inline country object.
           type: string
         preference:
-          description: ordering precedence for the findAddresses. Defaults to zero.
+          description: Ordering precedence for the findAddresses. Defaults to zero.
           type: integer
           format: int32
       required:
         - locality
         - country
     country:
-      description: a country
+      description: A country.
       type: object
       properties:
         name:
-          description: country name
+          description: Country name.
           type: string
         iso:
-          description: The country's ISO 3166-1 alpha-2 code
+          description: The country's ISO 3166-1 alpha-2 code.
           type: string
         iso3:
-          description: The country's ISO 3166-1 alpha-3 code
+          description: The country's ISO 3166-1 alpha-3 code.
           type: string
       required:
         - name
         - iso
         - iso3
     region:
-      description: a country region (US state or Canadian province)
+      description: A country region (US state or Canadian province).
       type: object
       properties:
         name:
-          description: region name
+          description: Region name.
           type: string
         abbreviation:
           type: string
         country-iso3:
           type: string
     location:
-      description: a named geographic coordinate with an enumerated label
+      description: A named geographic coordinate with an enumerated label.
       type: object
       properties:
         id:
@@ -8457,7 +8463,7 @@ components:
         - name
         - geo
     geo:
-      description: a geographical coordinate
+      description: A geographical coordinate.
       type: object
       properties:
         latitude:
@@ -8495,7 +8501,7 @@ components:
         - address
         - person
     updateEmailUserPassword:
-      description: A request for adding or updating an email address with the logged in user's password
+      description: A request for adding or updating an email address with the logged in user's password.
       type: object
       properties:
         email:
@@ -8506,7 +8512,7 @@ components:
       required:
         - email
     favorite:
-      description: a customer favorite
+      description: A customer favorite.
       type: object
       properties:
         id:
@@ -8529,7 +8535,7 @@ components:
         - packaged-product
         - customer
     updateFavorite:
-      description: a customer favorite
+      description: A customer favorite.
       type: object
       properties:
         quantity:
@@ -8545,17 +8551,17 @@ components:
         - packaged-product
         - customer
     faq:
-      description: frequently asked question
+      description: Frequently asked question.
       type: object
       properties:
         id:
           type: integer
           format: int64
         question:
-          description: a frequently asked question in plain text.
+          description: A frequently asked question in plain text.
           type: string
         answer:
-          description: the answer to the associated question in plain text.
+          description: The answer to the associated question in plain text.
           type: string
         order:
           type: integer
@@ -8566,17 +8572,17 @@ components:
         - answer
         - order
     updateFaq:
-      description: frequently asked question
+      description: Frequently asked question.
       type: object
       properties:
         id:
           type: integer
           format: int64
         question:
-          description: a frequently asked question in plain text.
+          description: A frequently asked question in plain text.
           type: string
         answer:
-          description: the answer to the associated question in plain text.
+          description: The answer to the associated question in plain text.
           type: string
         order:
           type: integer
@@ -8586,19 +8592,19 @@ components:
         - answer
         - order
     session:
-      description: session cookie information
+      description: Session cookie information.
       type: object
       properties:
         person:
-          description: person ID for the session owner (unset for anonymous sessions)
+          description: Person ID for the session owner (unset for anonymous sessions).
           type: integer
           format: int64
         expires:
-          description: current expiration date-time for this session (http://tools.ietf.org/html/rfc6265#section-5.3, covering both Max-Age and Expires representations, unset if the session expires at browser-close)
+          description: Current expiration date-time for this session (http://tools.ietf.org/html/rfc6265#section-5.3, covering both Max-Age and Expires representations, unset if the session expires at browser-close).
           type: string
           format: date-time
     notification:
-      description: a notification to display on the website
+      description: A notification to display on the website.
       type: object
       properties:
         id:
@@ -8610,12 +8616,12 @@ components:
           type: boolean
         dismissed:
           type: boolean
-          description: if annotate-person is specified in the request, this field will note if the notification has been dismissed
+          description: If annotate-person is specified in the request, this field will note if the notification has been dismissed.
       required:
         - id
         - message
     notificationDismissal:
-      description: a dismissal used to hide a read notification
+      description: A dismissal used to hide a read notification.
       type: object
       properties:
         id:
@@ -8631,18 +8637,18 @@ components:
         - notification
         - person
     productAudit:
-      description: an audited or auditable product and its packaging
+      description: An audited or auditable product and its packaging.
       type: object
       properties:
         id:
-          description: the product ID (not unique to the audit process)
+          description: The product ID (not unique to the audit process).
           type: integer
           format: int64
         name:
-          description: sentence-length product name. Copied from `#definitions/product` for easier UI development
+          description: Sentence-length product name. Copied from `#definitions/product` for easier UI development.
           type: string
         packaging:
-          description: all related audited and/or non-audited packaged versions of this product
+          description: All related audited and/or non-audited packaged versions of this product.
           type: array
           items:
             $ref: '#/components/schemas/packagedProductAudit'
@@ -8651,23 +8657,24 @@ components:
         - name
         - packaging
     packagedProductAudit:
-      description: an audited or auditable packaged-product
+      description: An audited or auditable packaged-product.
       type: object
       properties:
         id:
-          description: the packaged-product id (not unique to the audit process)
+          description: The packaged-product id (not unique to the audit process).
           type: string
         size:
-          description: the old size of the product (e.g. "12 oz." or "6x12 oz.")
+          description: The old size of the product (e.g. "12 oz." or "6x12 oz.").
           type: string
         packs:
-          description: the new dimensions of package sizes (e.g. "4", "4x32.5", or "2x4x32.5")
+          description: The new dimensions of package sizes (e.g. "4", "4x32.5", or "2x4x32.5").
           type: string
         unit:
-          description: 'The new unit of measurement. You can use any string, but the backend will only be able to make automatic comparisons if you use SI prefixes (e.g. "mm" for millimeters) and stick to the following base units: pound, ounce, gram, gallon, liter, quart, pint, cup, fluid ounce, yard, and count'
+          description: |-
+            The new unit of measurement. You can use any string, but the backend will only be able to make automatic comparisons if you use SI prefixes (e.g. "mm" for millimeters) and stick to the following base units: pound, ounce, gram, gallon, liter, quart, pint, cup, fluid ounce, yard, and count
           type: string
         audited:
-          description: a datetime denoting if and when the packaged-product was last audited
+          description: A datetime denoting if and when the packaged-product was last audited.
           type: string
       required:
         - id
@@ -8676,17 +8683,17 @@ components:
         - unit
         - audited
     updatePackagedProductAudit:
-      description: an update to an audited packaged-product
+      description: An update to an audited packaged-product.
       type: object
       properties:
         packs:
-          description: the new dimensions of package sizes (e.g. "4", "4x32.5", or "2x4x32.5")
+          description: The new dimensions of package sizes (e.g. "4", "4x32.5", or "2x4x32.5").
           type: string
         unit:
-          description: the new unit of measurement. Ideally one of "", or "", but you can use another unit if none of those fit.
+          description: The new unit of measurement. Ideally one of "", or "", but you can use another unit if none of those fit.
           type: string
         size:
-          description: override the auto-generated size (based on packs and unit) with a custom name. This can be useful for adding packaging information (e.g. "32 floz glass" to distinguish glass from plastic vinegar bottles).
+          description: Override the auto-generated size (based on packs and unit) with a custom name. This can be useful for adding packaging information (e.g. "32 floz glass" to distinguish glass from plastic vinegar bottles).
           type: string
         clear-audited:
           description: If true, clear the audited date-time for this packaged-product. If false (the default), set the audited date-time to the current time.
@@ -8707,7 +8714,7 @@ components:
         format:
           $ref: '#/components/schemas/printerFormatType'
         warehouse:
-          description: the warehouse's code
+          description: The warehouse's code.
           type: string
       required:
         - id
@@ -8716,34 +8723,34 @@ components:
         - format
         - warehouse
     printerDeliveryType:
-      description: A property for printer delivery method
+      description: A property for printer delivery method.
       type: string
       enum:
         - http
         - cups
         - bartender
     printerFormatType:
-      description: A property for printer format method
+      description: A property for printer format method.
       type: string
       enum:
         - pdf
         - epl2
         - bartender
     warehouse:
-      description: a physical warehouse or facility
+      description: A physical warehouse or facility.
       type: object
       properties:
         code:
-          description: slug for stable reference (e.g. "moro")
+          description: Slug for stable reference (e.g. "moro").
           type: string
         name:
-          description: human readable name (e.g. "Moro")
+          description: Human readable name (e.g. "Moro").
           type: string
       required:
         - code
         - name
     ip2location:
-      description: location information for an ip address
+      description: Location information for an ip address.
       type: object
       properties:
         address:

--- a/public.yaml
+++ b/public.yaml
@@ -1328,7 +1328,7 @@ paths:
                 $ref: '#/components/schemas/error'
   /drops/locations:
     get:
-      summary: Returns an array of locations for all active drops that the user has access to.
+      summary: Returns an array of locations for all active drops that the user has access to
       description: |-
         For example, you can use this to draw markers on map.
       operationId: findDropLocations
@@ -4544,7 +4544,7 @@ paths:
                 $ref: '#/components/schemas/error'
   /account-entries:
     get:
-      summary: Returns all dollar credits and debits from the system that the user has access to. 
+      summary: Returns all dollar credits and debits from the system that the user has access to
       description: |-
         Results are ordered by increasing settled dates, falling back to IDs when multiple entries settled on the same day.
       operationId: findAccountEntries
@@ -4850,7 +4850,7 @@ paths:
                 $ref: '#/components/schemas/error'
   /rewards:
     get:
-      summary: Returns all reward credits and debits from the system that the user has access to. 
+      summary: Returns all reward credits and debits from the system that the user has access to
       description: |-
         Results are ordered by increasing settled times, falling back to ID for pending debits.
       operationId: findRewards

--- a/public.yaml
+++ b/public.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "1.0.0-oas3"
+  version: 1.0.0-oas3
   title: Azure Standard Public API
   description: The public API behind Azure's website
   contact:
@@ -16,9 +16,7 @@ security:
 paths:
   /affiliate-referrals:
     get:
-      summary: >-
-        Returns all affiliate referrals for the given referring user, in
-        descending order of the date the referred person's account was created
+      summary: Returns all affiliate referrals for the given referring user, in descending order of the date the referred person's account was created
       operationId: findAffiliateReferrals
       tags:
         - affiliate-referral
@@ -39,9 +37,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -51,9 +47,7 @@ paths:
           description: affiliate referral response
           headers:
             Count:
-              description: >-
-                total number of matching results (how many you'd get if you
-                could set an infinite `limit`)
+              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
               schema:
                 type: integer
                 format: int32
@@ -86,9 +80,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -98,9 +90,7 @@ paths:
           description: bartenderHost response
           headers:
             Count:
-              description: >-
-                total number of matching results (how many you'd get if you
-                could set an infinite `limit`)
+              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
               schema:
                 type: integer
                 format: int32
@@ -144,9 +134,7 @@ paths:
         required: true
   '/bartender-host/{code}':
     get:
-      summary: >-
-        Returns a BarTender host based on a single code, if the user has access
-        to it
+      summary: Returns a BarTender host based on a single code, if the user has access to it
       operationId: findBartenderHostByCode
       tags:
         - bartender
@@ -225,9 +213,7 @@ paths:
                 $ref: '#/components/schemas/error'
   /bartender-templates:
     get:
-      summary: >-
-        Returns all BarTender templates from the system that the user has access
-        to
+      summary: Returns all BarTender templates from the system that the user has access to
       operationId: findBartenderTemplates
       tags:
         - bartender
@@ -241,9 +227,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -253,9 +237,7 @@ paths:
           description: bartenderTemplate response
           headers:
             Count:
-              description: >-
-                total number of matching results (how many you'd get if you
-                could set an infinite `limit`)
+              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
               schema:
                 type: integer
                 format: int32
@@ -299,9 +281,7 @@ paths:
         required: true
   '/bartender-template/{id}':
     get:
-      summary: >-
-        Returns a BarTender template based on a single ID, if the user has
-        access to it
+      summary: Returns a BarTender template based on a single ID, if the user has access to it
       operationId: findBartenderTemplateById
       tags:
         - bartender
@@ -383,9 +363,7 @@ paths:
                 $ref: '#/components/schemas/error'
   /bartender-print-configurations:
     get:
-      summary: >-
-        Returns all BarTender print configurations from the system that the user
-        has access to
+      summary: Returns all BarTender print configurations from the system that the user has access to
       operationId: findBartenderPrintConfigurations
       tags:
         - bartender
@@ -399,9 +377,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -411,9 +387,7 @@ paths:
           description: bartenderPrintConfiguration response
           headers:
             Count:
-              description: >-
-                total number of matching results (how many you'd get if you
-                could set an infinite `limit`)
+              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
               schema:
                 type: integer
                 format: int32
@@ -457,9 +431,7 @@ paths:
         required: true
   '/bartender-print-configuration/{id}':
     get:
-      summary: >-
-        Returns a BarTender print configuration based on a single ID, if the
-        user has access to it
+      summary: Returns a BarTender print configuration based on a single ID, if the user has access to it
       operationId: findBartenderPrintConfigurationById
       tags:
         - bartender
@@ -515,9 +487,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/bartenderPrintConfiguration'
-        description: >-
-          Updated BarTender print configuration parameters (can optionally
-          include 'id')
+        description: Updated BarTender print configuration parameters (can optionally include 'id')
         required: true
     delete:
       summary: Delete an existing BarTender print configuration
@@ -543,10 +513,7 @@ paths:
                 $ref: '#/components/schemas/error'
   '/bartender-print-configuration/{id}/actions/test-print':
     post:
-      summary: >-
-        Create a test BarTender print request using this print configuration.
-        The print request uses hard-coded dummy data if a stock ID is not
-        provided.
+      summary: Create a test BarTender print request using this print configuration. The print request uses hard-coded dummy data if a stock ID is not provided.
       operationId: actionTestBartenderPrintConfiguration
       tags:
         - bartender
@@ -576,9 +543,7 @@ paths:
                 stock:
                   type: integer
                   format: int64
-        description: >-
-          Test data to use in the test print request.  The payload must be a
-          JSON object, but the 'stock' property is optional.
+        description: Test data to use in the test print request. The payload must be a JSON object, but the `stock` property is optional.
         required: true
   /brands:
     get:
@@ -590,9 +555,7 @@ paths:
       parameters:
         - name: name
           in: query
-          description: >-
-            Only return brands whose name contains this value (case
-            insensitive).
+          description: Only return brands whose name contains this value (case insensitive).
           required: false
           schema:
             type: string
@@ -609,9 +572,7 @@ paths:
                   - none
         - name: start
           in: query
-          description: >-
-            offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -621,9 +582,7 @@ paths:
           description: brand response
           headers:
             Count:
-              description: >-
-                Total number of matching results (how many you'd get if you set
-                `limit` to `none`).
+              description: Total number of matching results (how many you'd get if you set `limit` to `none`).
               schema:
                 type: integer
                 format: int32
@@ -677,20 +636,13 @@ paths:
       parameters:
         - name: query
           in: query
-          description: >-
-            Query to perform within the directory.  The use of a `*` at the
-            beginning or end of the string is treated as a wildcard.  This
-            parameter is case insensitive.
+          description: Query to perform within the directory. The use of a `*` at the beginning or end of the string is treated as a wildcard. This parameter is case insensitive.
           required: false
           schema:
             type: string
         - name: query-field
           in: query
-          description: >-
-            Fields to search.  Any property included in a companyDirectoryEntry
-            response may be queried.  Defaults to `full-name`, `first-name`,
-            `last-name`, `title`, `department.name`, `phone-number`,
-            `phone-ext`, `mobile`, `email`, and `office`.
+          description: Fields to search. Any property included in a companyDirectoryEntry response may be queried. Defaults to `full-name`, `first-name`, `last-name`, `title`, `department.name`, `phone-number`, `phone-ext`, `mobile`, `email`, and `office`.
           required: false
           style: form
           schema:
@@ -699,19 +651,13 @@ paths:
               type: string
         - name: department
           in: query
-          description: >-
-            Filter by department.  If this parameter is used then department
-            will be ignored in the query-field parameter.  This parameter is
-            case insensitive.
+          description: Filter by department. If this parameter is used then department will be ignored in the query-field parameter. This parameter is case insensitive.
           required: false
           schema:
             type: string
         - name: sort
           in: query
-          description: >-
-            Order results by this field.  Any property included in a
-            companyDirectoryEntry response may be used here.  Defaults to
-            `department.name`, `first-name` and `last-name`.
+          description: Order results by this field. Any property included in a companyDirectoryEntry response may be used here. Defaults to `department.name`, `first-name` and `last-name`.
           required: false
           style: form
           schema:
@@ -727,9 +673,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -739,9 +683,7 @@ paths:
           description: companyDirectoryEntry response
           headers:
             Count:
-              description: >-
-                Total number of matching results (how many you'd get if you
-                could set an infinite `limit`)
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`)
               schema:
                 type: integer
                 format: int32
@@ -774,9 +716,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            Offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -786,9 +726,7 @@ paths:
           description: Department response
           headers:
             Count:
-              description: >-
-                Total number of matching results (how many you'd get if you
-                could set an infinite `limit`)
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`)
               schema:
                 type: integer
                 format: int32
@@ -820,9 +758,7 @@ paths:
             type: string
         - name: category
           in: query
-          description: >-
-            Report category IDs to filter by.  `null` may be used to return
-            reports that are uncategorized.
+          description: Report category IDs to filter by. `null` may be used to return reports that are uncategorized.
           required: false
           style: form
           schema:
@@ -839,9 +775,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -851,9 +785,7 @@ paths:
           description: report response
           headers:
             Count:
-              description: >-
-                total number of matching results (how many you'd get if you
-                could set an infinite `limit`)
+              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
               schema:
                 type: integer
                 format: int32
@@ -872,7 +804,7 @@ paths:
                 $ref: '#/components/schemas/error'
   '/report/{id}':
     get:
-      summary: 'Returns a report based on an ID, if the user has access to it'
+      summary: Returns a report based on an ID, if the user has access to it
       operationId: findReportById
       tags:
         - report
@@ -898,18 +830,14 @@ paths:
                 $ref: '#/components/schemas/error'
   /report-categories:
     get:
-      summary: >-
-        Returns all report categories from the system that the user has access
-        to
+      summary: Returns all report categories from the system that the user has access to
       operationId: findReportCategories
       tags:
         - report
       parameters:
         - name: customer-pricing
           in: query
-          description: >-
-            Filter categories by whether or not they contain customer pricing
-            groups
+          description: Filter categories by whether or not they contain customer pricing groups
           required: false
           schema:
             type: boolean
@@ -922,9 +850,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -934,9 +860,7 @@ paths:
           description: reportCategory response
           headers:
             Count:
-              description: >-
-                total number of matching results (how many you'd get if you
-                could set an infinite `limit`)
+              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
               schema:
                 type: integer
                 format: int32
@@ -980,7 +904,7 @@ paths:
         required: true
   '/report-category/{id}':
     get:
-      summary: 'Returns a report category based on an ID, if the user has access to it'
+      summary: Returns a report category based on an ID, if the user has access to it
       operationId: findReportCategoryById
       tags:
         - report
@@ -1114,10 +1038,7 @@ paths:
               format: int64
         - name: sort
           in: query
-          description: >-
-            Order results by this field.  Only one special sort field is
-            supported, distance(lat:45.45|lon:-121.13), which will sort drops by
-            increasing distance from the lat and lon combination.
+          description: Order results by this field. Only one special sort field is supported, distance(lat:45.45|lon:-121.13), which will sort drops by increasing distance from the lat and lon combination.
           required: false
           schema:
             type: string
@@ -1130,9 +1051,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -1142,9 +1061,7 @@ paths:
           description: drop response
           headers:
             Count:
-              description: >-
-                total number of matching results (how many you'd get if you
-                could set an infinite `limit`)
+              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
               schema:
                 type: integer
                 format: int32
@@ -1188,7 +1105,7 @@ paths:
         required: true
   '/drop/{id}':
     get:
-      summary: 'Returns a drop based on a single ID, if the user has access to the drop'
+      summary: Returns a drop based on a single ID, if the user has access to the drop
       operationId: findDropById
       tags:
         - drop
@@ -1270,10 +1187,8 @@ paths:
                 $ref: '#/components/schemas/error'
   /drops/locations:
     get:
-      summary: >-
-        Returns an array of locations for all active drops that the user has
-        access to.
-      description: 'For example, you can use this to draw markers on map.'
+      summary: Returns an array of locations for all active drops that the user has access to.
+      description: For example, you can use this to draw markers on map.
       operationId: findDropLocations
       tags:
         - drop
@@ -1333,10 +1248,7 @@ paths:
             type: boolean
         - name: inline
           in: query
-          description: >-
-            for convenience, include a full representation of the inlined
-            property.  Currently supports "customer", "customer.email", "drop",
-            and "gratitude-total".
+          description: for convenience, include a full representation of the inlined property. Currently supports "customer", "customer.email", "drop", and "gratitude-total".
           required: false
           style: form
           schema:
@@ -1345,9 +1257,7 @@ paths:
               type: string
         - name: sort
           in: query
-          description: >-
-            Order results by this field.  Supported fields: "customer.name",
-            "drop.name".
+          description: 'Order results by this field. Supported fields: `customer.name`, `drop.name`.'
           required: false
           schema:
             type: string
@@ -1360,9 +1270,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -1372,9 +1280,7 @@ paths:
           description: drop membership response
           headers:
             Count:
-              description: >-
-                total number of matching results (how many you'd get if you
-                could set an infinite `limit`)
+              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
               schema:
                 type: integer
                 format: int32
@@ -1418,9 +1324,7 @@ paths:
         required: true
   '/drop-membership/{id}':
     get:
-      summary: >-
-        Returns a drop membership based on a single membership ID, if the user
-        has access.
+      summary: Returns a drop membership based on a single membership ID, if the user has access.
       operationId: findDropMembershipById
       tags:
         - drop-membership
@@ -1434,10 +1338,7 @@ paths:
             format: int64
         - name: inline
           in: query
-          description: >-
-            for convenience, include a full representation of the inlined
-            property.  Currently supports "customer", "drop", and
-            "gratitude-total".
+          description: for convenience, include a full representation of the inlined property. Currently supports "customer", "drop", and "gratitude-total".
           required: false
           style: form
           schema:
@@ -1528,9 +1429,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            Offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -1540,9 +1439,7 @@ paths:
           description: File response.
           headers:
             Count:
-              description: >-
-                Total number of matching results (how many you'd get if you
-                didn't set `limit`).
+              description: Total number of matching results (how many you'd get if you didn't set `limit`).
               schema:
                 type: integer
                 format: int32
@@ -1582,12 +1479,10 @@ paths:
           application/json:
             schema:
               type: string
-        description: 'File to add.  The payload is the raw content, not a JSON object.'
+        description: File to add. The payload is the raw content, not a JSON object.
   '/file/{id}':
     delete:
-      summary: >-
-        Delete an existing file.  This may fail if there are any internal
-        references to the file.
+      summary: Delete an existing file. This may fail if there are any internal references to the file.
       operationId: deleteFile
       tags:
         - file
@@ -1658,9 +1553,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -1670,9 +1563,7 @@ paths:
           description: pickup response
           headers:
             Count:
-              description: >-
-                total number of matching results (how many you'd get if you
-                didn't set `limit`)
+              description: total number of matching results (how many you'd get if you didn't set `limit`)
               schema:
                 type: integer
                 format: int32
@@ -1691,9 +1582,7 @@ paths:
                 $ref: '#/components/schemas/error'
   '/pickup/{id}':
     get:
-      summary: >-
-        Returns a pickup based on a single ID, if the user has access to the
-        pickup
+      summary: Returns a pickup based on a single ID, if the user has access to the pickup
       operationId: findPickupById
       tags:
         - pickup
@@ -1744,9 +1633,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -1756,9 +1643,7 @@ paths:
           description: route response
           headers:
             Count:
-              description: >-
-                total number of matching results (how many you'd get if you
-                could set an infinite `limit`)
+              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
               schema:
                 type: integer
                 format: int32
@@ -1802,9 +1687,7 @@ paths:
         required: true
   '/route/{name}':
     get:
-      summary: >-
-        Returns a route based on a single ID, if the user has access to the
-        route
+      summary: Returns a route based on a single ID, if the user has access to the route
       operationId: findRouteById
       tags:
         - route
@@ -1947,9 +1830,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -1959,9 +1840,7 @@ paths:
           description: trip response
           headers:
             Count:
-              description: >-
-                total number of matching results (how many you'd get if you
-                could set an infinite `limit`)
+              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
               schema:
                 type: integer
                 format: int32
@@ -1979,7 +1858,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
     post:
-      summary: 'Creates a trip for a route, if the user has permissions'
+      summary: Creates a trip for a route, if the user has permissions
       operationId: addTrip
       tags:
         - trip
@@ -2005,7 +1884,7 @@ paths:
         required: true
   '/trip/{id}':
     get:
-      summary: 'Returns a trip based on a single ID, if the user has access to the trip'
+      summary: Returns a trip based on a single ID, if the user has access to the trip
       operationId: findTripById
       tags:
         - trip
@@ -2031,7 +1910,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
     put:
-      summary: 'Updates a trip for a route, if the user has permissions'
+      summary: Updates a trip for a route, if the user has permissions
       operationId: updateTrip
       tags:
         - trip
@@ -2064,7 +1943,7 @@ paths:
         description: Trip to update
         required: true
     delete:
-      summary: 'Deletes a trip for a route, if the user has permissions'
+      summary: Deletes a trip for a route, if the user has permissions
       operationId: deleteTrip
       tags:
         - trip
@@ -2088,9 +1967,7 @@ paths:
   /route-stops:
     get:
       summary: Returns all route-stops from the system that the user has access to
-      description: >-
-        Route-stops are ordered for increasing offset from the route's trip
-        cutoff
+      description: Route-stops are ordered for increasing offset from the route's trip cutoff
       operationId: findRouteStops
       tags:
         - stop
@@ -2123,9 +2000,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -2135,9 +2010,7 @@ paths:
           description: route-stop response
           headers:
             Count:
-              description: >-
-                total number of matching results (how many you'd get if you
-                could set an infinite `limit`)
+              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
               schema:
                 type: integer
                 format: int32
@@ -2156,9 +2029,7 @@ paths:
                 $ref: '#/components/schemas/error'
   '/route-stop/{id}':
     get:
-      summary: >-
-        Returns a route-stop based on a single ID, if the user has access to the
-        route-stop
+      summary: Returns a route-stop based on a single ID, if the user has access to the route-stop
       operationId: findRouteStopById
       tags:
         - stop
@@ -2259,9 +2130,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -2271,9 +2140,7 @@ paths:
           description: stop response
           headers:
             Count:
-              description: >-
-                total number of matching results (how many you'd get if you
-                could set an infinite `limit`)
+              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
               schema:
                 type: integer
                 format: int32
@@ -2298,19 +2165,7 @@ paths:
       parameters:
         - name: persist
           in: query
-          description: >-
-            If true, calculate the offset between the trips's delivery start and
-            this stop's estimated time. For any pre-cutoff trips associated
-            with this stop's trip's route which cutoff later than this stop's
-            trip, create a stop for this location (drop or pickup) if it does
-            not already exist and update that stop's target and estimated times
-            to have the same offset from that stops's trip's delivery start.
-            Also create a route-stop association, if it does not already exist,
-            for this location on this stop's trip's route and update that
-            route-stop with the same delivery offset. API users should always pass 
-            `persist=true` if there are estimated delivery changes. For finalized and/or 
-            actual delivery changes, passing `persist=true` will not actually persist them
-            but will slow down the response.
+          description: If true, calculate the offset between the trips's delivery start and this stop's estimated time. For any pre-cutoff trips associated with this stop's trip's route which cutoff later than this stop's trip, create a stop for this location (drop or pickup) if it does not already exist and update that stop's target and estimated times to have the same offset from that stops's trip's delivery start. Also create a route-stop association, if it does not already exist, for this location on this stop's trip's route and update that route-stop with the same delivery offset. API users should always pass  `persist=true` if there are estimated delivery changes. For finalized and/or  actual delivery changes, passing `persist=true` will not actually persist them but will slow down the response.
           required: false
           schema:
             type: boolean
@@ -2336,7 +2191,7 @@ paths:
         required: true
   '/stop/{id}':
     get:
-      summary: 'Returns a stop based on a single ID, if the user has access to the stop'
+      summary: Returns a stop based on a single ID, if the user has access to the stop
       operationId: findStopById
       tags:
         - stop
@@ -2376,29 +2231,13 @@ paths:
             format: int64
         - name: persist
           in: query
-          description: >-
-            If true, calculate the offset between the trips's delivery start and
-            this stop's estimated time. For any pre-cutoff trips associated
-            with this stop's trip's route which cutoff later than this stop's
-            trip, create a stop for this location (drop or pickup) if it does
-            not already exist and update that stop's target and estimated times
-            to have the same offset from that stops's trip's delivery start.
-            Also create a route-stop association, if it does not already exist,
-            for this location on this stop's trip's route and update that
-            route-stop with the same delivery offset. If propagate is set,
-            apply the persistance logic to the later stops on the trip as well. API users 
-            should always pass `persist=true` if there are estimated delivery changes. For 
-            finalized and/or actual delivery changes, passing `persist=true` will not actually 
-            persist them but will slow down the response.
+          description: If true, calculate the offset between the trips's delivery start and this stop's estimated time. For any pre-cutoff trips associated with this stop's trip's route which cutoff later than this stop's trip, create a stop for this location (drop or pickup) if it does not already exist and update that stop's target and estimated times to have the same offset from that stops's trip's delivery start. Also create a route-stop association, if it does not already exist, for this location on this stop's trip's route and update that route-stop with the same delivery offset. If propagate is set, apply the persistance logic to the later stops on the trip as well. API users  should always pass `persist=true` if there are estimated delivery changes. For  finalized and/or actual delivery changes, passing `persist=true` will not actually  persist them but will slow down the response.
           required: false
           schema:
             type: boolean
         - name: propagate
           in: query
-          description: >-
-            if true, calculate the change from the existing estimated time.
-            Shift the estimated time of all later stops on the trip by the same
-            amount.  For pre-cutoff trips, also shift the target times.
+          description: if true, calculate the change from the existing estimated time. Shift the estimated time of all later stops on the trip by the same amount. For pre-cutoff trips, also shift the target times.
           required: false
           schema:
             type: boolean
@@ -2437,11 +2276,7 @@ paths:
             format: int64
         - name: persist
           in: query
-          description: >-
-            if true, for any pre-cutoff trips associated with this stop's trip's
-            route which cutoff later than this stop's trip, delete any stops for
-            this location (drop or pickup).  Also delete any route-stop
-            associations for this location on this stop's trip's route.
+          description: if true, for any pre-cutoff trips associated with this stop's trip's route which cutoff later than this stop's trip, delete any stops for this location (drop or pickup). Also delete any route-stop associations for this location on this stop's trip's route.
           required: false
           schema:
             type: boolean
@@ -2464,20 +2299,13 @@ paths:
       parameters:
         - name: audited
           in: query
-          description: >-
-            filter for products that have or haven't been audited.  When set,
-            only products that contain (un)audited packaging are returned, and
-            their packaging array only contains (un)audited packaging.
+          description: filter for products that have or haven't been audited. When set, only products that contain (un)audited packaging are returned, and their packaging array only contains (un)audited packaging.
           required: false
           schema:
             type: string
         - name: search
           in: query
-          description: >-
-            search string for filtering products.  The logic behind this is left
-            up to the implementation, but it should at least match words in the
-            product name, and may optionally match the product description or
-            other characteristics
+          description: search string for filtering products. The logic behind this is left up to the implementation, but it should at least match words in the product name, and may optionally match the product description or other characteristics
           required: false
           schema:
             type: string
@@ -2496,9 +2324,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -2508,9 +2334,7 @@ paths:
           description: product audit response
           headers:
             Count:
-              description: >-
-                total number of matching results (how many you'd get if you
-                could set an infinite `limit`)
+              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
               schema:
                 type: integer
                 format: int32
@@ -2543,7 +2367,7 @@ paths:
             type: string
         - name: audited
           in: query
-          description: 'When set, the packaging array only contains (un)audited packaging.'
+          description: When set, the packaging array only contains (un)audited packaging.
           required: false
           schema:
             type: string
@@ -2604,11 +2428,7 @@ paths:
       parameters:
         - name: search
           in: query
-          description: >-
-            search string for filtering products.  The logic behind this is left
-            up to the implementation, but it should at least match words in the
-            product name, and may optionally match the product description or
-            other characteristics
+          description: search string for filtering products. The logic behind this is left up to the implementation, but it should at least match words in the product name, and may optionally match the product description or other characteristics
           required: false
           schema:
             type: string
@@ -2634,9 +2454,7 @@ paths:
               format: int64
         - name: category
           in: query
-          description: >-
-            category IDs to filter by (for products directly associated with the
-            categories)
+          description: category IDs to filter by (for products directly associated with the categories)
           required: false
           style: form
           schema:
@@ -2646,9 +2464,7 @@ paths:
               format: int64
         - name: primary-category
           in: query
-          description: >-
-            primary-category IDs to filter by (for products directly associated
-            with the categories)
+          description: primary-category IDs to filter by (for products directly associated with the categories)
           required: false
           style: form
           schema:
@@ -2658,9 +2474,7 @@ paths:
               format: int64
         - name: ancestor-category
           in: query
-          description: >-
-            category IDs to filter by (for products associated with the
-            categories or their descendants)
+          description: category IDs to filter by (for products associated with the categories or their descendants)
           required: false
           style: form
           schema:
@@ -2698,21 +2512,14 @@ paths:
               format: int64
         - name: annotate-person
           in: query
-          description: >-
-            person ID for associating additional metadata with results (e.g.
-            whether this person has favorited a given packaged-product).  If
-            unset and you're authenticated, defaults to your authenticated ID
+          description: person ID for associating additional metadata with results (e.g. whether this person has favorited a given packaged-product). If unset and you're authenticated, defaults to your authenticated ID
           required: false
           schema:
             type: integer
             format: int64
         - name: inline
           in: query
-          description: >-
-            for convenience, include a full representation of the inlined
-            property. Currently supports the local "description", "favorites",
-            and "substitutions" as well as "brand", "packaging", "vendors", and
-            descendants.
+          description: for convenience, include a full representation of the inlined property. Currently supports the local "description", "favorites", and "substitutions" as well as "brand", "packaging", "vendors", and descendants.
           required: false
           style: form
           schema:
@@ -2728,9 +2535,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -2740,9 +2545,7 @@ paths:
           description: product response
           headers:
             Count:
-              description: >-
-                total number of matching results (how many you'd get if you
-                could set an infinite `limit`)
+              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
               schema:
                 type: integer
                 format: int32
@@ -2761,9 +2564,7 @@ paths:
                 $ref: '#/components/schemas/error'
   '/product/{id}':
     get:
-      summary: >-
-        Returns a product based on a single ID, if the user has access to the
-        product
+      summary: Returns a product based on a single ID, if the user has access to the product
       operationId: findProductById
       tags:
         - product
@@ -2776,11 +2577,7 @@ paths:
             type: string
         - name: inline
           in: query
-          description: >-
-            for convenience, include a full representation of the inlined
-            property. Currently supports the local "description", "favorites",
-            and "substitutions" as well as "brand", "packaging", "vendors", and
-            descendants.
+          description: for convenience, include a full representation of the inlined property. Currently supports the local "description", "favorites", and "substitutions" as well as "brand", "packaging", "vendors", and descendants.
           required: false
           style: form
           schema:
@@ -2802,9 +2599,7 @@ paths:
                 $ref: '#/components/schemas/error'
   /packaged-products:
     get:
-      summary: >-
-        Returns all packaged products from the system that the user has access
-        to
+      summary: Returns all packaged products from the system that the user has access to
       operationId: findPackagedProduct
       tags:
         - product
@@ -2850,9 +2645,7 @@ paths:
               format: int64
         - name: category
           in: query
-          description: >-
-            category IDs to filter by (for products directly associated with the
-            categories)
+          description: category IDs to filter by (for products directly associated with the categories)
           required: false
           style: form
           schema:
@@ -2862,9 +2655,7 @@ paths:
               format: int64
         - name: primary-category
           in: query
-          description: >-
-            primary-category IDs to filter by (for products directly associated
-            with the categories)
+          description: primary-category IDs to filter by (for products directly associated with the categories)
           required: false
           style: form
           schema:
@@ -2874,9 +2665,7 @@ paths:
               format: int64
         - name: ancestor-category
           in: query
-          description: >-
-            category IDs to filter by (for packaged products associated with the
-            categories or their descendants)
+          description: category IDs to filter by (for packaged products associated with the categories or their descendants)
           required: false
           style: form
           schema:
@@ -2905,21 +2694,14 @@ paths:
               format: int64
         - name: annotate-person
           in: query
-          description: >-
-            person ID for associating additional metadata with results (e.g.
-            whether this person has favorited a given packaged-product).  If
-            unset and you're authenticated, defaults to your authenticated ID
+          description: person ID for associating additional metadata with results (e.g. whether this person has favorited a given packaged-product). If unset and you're authenticated, defaults to your authenticated ID
           required: false
           schema:
             type: integer
             format: int64
         - name: inline
           in: query
-          description: >-
-            for convenience, include a full representation of the inlined
-            property. Currently supports the local "favorites",
-            "next-purchase-arrival", and "quantity-on-next-purchase" as well as
-            "image", "product", "vendors", and descendants.
+          description: for convenience, include a full representation of the inlined property. Currently supports the local "favorites", "next-purchase-arrival", and "quantity-on-next-purchase" as well as "image", "product", "vendors", and descendants.
           required: false
           style: form
           schema:
@@ -2935,9 +2717,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -2947,9 +2727,7 @@ paths:
           description: packaged product response
           headers:
             Count:
-              description: >-
-                total number of matching results (how many you'd get if you
-                could set an infinite `limit`)
+              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
               schema:
                 type: integer
                 format: int32
@@ -2968,9 +2746,7 @@ paths:
                 $ref: '#/components/schemas/error'
   '/packaged-product/{code}':
     get:
-      summary: >-
-        Returns a packaged product based on a single ID, if the user has access
-        to the packaged product
+      summary: Returns a packaged product based on a single ID, if the user has access to the packaged product
       operationId: findPackagedProductById
       tags:
         - product
@@ -2983,11 +2759,7 @@ paths:
             type: string
         - name: inline
           in: query
-          description: >-
-            for convenience, include a full representation of the inlined
-            property. Currently supports the local "favorites",
-            "next-purchase-arrival", and "quantity-on-next-purchase" as well as
-            "image", "product", "vendors", and descendants.
+          description: for convenience, include a full representation of the inlined property. Currently supports the local "favorites", "next-purchase-arrival", and "quantity-on-next-purchase" as well as "image", "product", "vendors", and descendants.
           required: false
           style: form
           schema:
@@ -3009,9 +2781,7 @@ paths:
                 $ref: '#/components/schemas/error'
   /packaged-product-images:
     get:
-      summary: >-
-        Returns all packaged product images from the system that the user has
-        access to
+      summary: Returns all packaged product images from the system that the user has access to
       operationId: findPackagedProductImages
       tags:
         - image
@@ -3035,9 +2805,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            Offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -3047,9 +2815,7 @@ paths:
           description: Packaged product image response.
           headers:
             Count:
-              description: >-
-                Total number of matching results (how many you'd get if you
-                could set an infinite `limit`).
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -3094,9 +2860,7 @@ paths:
         required: true
   '/packaged-product-image/{id}':
     get:
-      summary: >-
-        Returns a packaged product image based on a single ID, if the user has
-        access to that object
+      summary: Returns a packaged product image based on a single ID, if the user has access to that object
       operationId: findPackagedProductImageById
       tags:
         - image
@@ -3180,20 +2944,14 @@ paths:
                 $ref: '#/components/schemas/error'
   /packaged-product-tags:
     get:
-      summary: >-
-        Returns all packaged product tags from the system that the user has
-        access to
+      summary: Returns all packaged product tags from the system that the user has access to
       operationId: findPackagedProductTag
       tags:
         - packaged-product-tag
       parameters:
         - name: internal
           in: query
-          description: >-
-            if true, only return internal tags (that the user has access to).
-            If false, only return public tags (regardless of the user's access
-            to internal tags).  If unset, don't filter based on the tag
-            visibility
+          description: if true, only return internal tags (that the user has access to). If false, only return public tags (regardless of the user's access to internal tags). If unset, don't filter based on the tag visibility
           required: false
           schema:
             type: boolean
@@ -3215,9 +2973,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -3227,9 +2983,7 @@ paths:
           description: packaged product tag response
           headers:
             Count:
-              description: >-
-                total number of matching results (how many you'd get if you
-                could set an infinite `limit`)
+              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
               schema:
                 type: integer
                 format: int32
@@ -3269,9 +3023,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -3281,9 +3033,7 @@ paths:
           description: packaged product tag association response
           headers:
             Count:
-              description: >-
-                total number of matching results (how many you'd get if you
-                could set an infinite `limit`)
+              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
               schema:
                 type: integer
                 format: int32
@@ -3327,9 +3077,7 @@ paths:
         required: true
   '/packaged-product-tag-association/{id}':
     delete:
-      summary: >-
-        Delete a packaged product tag association from a person's filter
-        preferences
+      summary: Delete a packaged product tag association from a person's filter preferences
       operationId: deletePackagedProductTagAssociation
       tags:
         - packaged-product-tag
@@ -3352,9 +3100,7 @@ paths:
                 $ref: '#/components/schemas/error'
   /categories:
     get:
-      summary: >-
-        Returns all categories from the system, ordered by decreasing 'featured'
-        values
+      summary: Returns all categories from the system, ordered by decreasing `featured` values
       operationId: findCategories
       tags:
         - category
@@ -3397,9 +3143,7 @@ paths:
               type: string
         - name: inline
           in: query
-          description: >-
-            For convenience, include a full representation of the inlined
-            property.  Currently supports "ancestors" and "depth".
+          description: For convenience, include a full representation of the inlined property. Currently supports `ancestors` and `depth`.
           required: false
           style: form
           schema:
@@ -3415,9 +3159,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -3427,9 +3169,7 @@ paths:
           description: category response
           headers:
             Count:
-              description: >-
-                total number of matching results (how many you'd get if you
-                could set an infinite `limit`)
+              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
               schema:
                 type: integer
                 format: int32
@@ -3488,9 +3228,7 @@ paths:
             format: int64
         - name: inline
           in: query
-          description: >-
-            For convenience, include a full representation of the inlined
-            property.  Currently supports "ancestors" and "depth".
+          description: For convenience, include a full representation of the inlined property. Currently supports "ancestors" and "depth".
           required: false
           style: form
           schema:
@@ -3607,9 +3345,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -3619,9 +3355,7 @@ paths:
           description: purchase response
           headers:
             Count:
-              description: >-
-                total number of matching results (how many you'd get if you
-                didn't set `limit`)
+              description: total number of matching results (how many you'd get if you didn't set `limit`)
               schema:
                 type: integer
                 format: int32
@@ -3764,18 +3498,14 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
             format: int32
         - name: inline
           in: query
-          description: >-
-            for convenience, include a full representation of the inlined
-            property. Currently supports "dropMembershipId".
+          description: for convenience, include a full representation of the inlined property. Currently supports "dropMembershipId".
           required: false
           style: form
           schema:
@@ -3787,9 +3517,7 @@ paths:
           description: order response
           headers:
             Count:
-              description: >-
-                total number of matching results (how many you'd get if you
-                could set an infinite `limit`)
+              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
               schema:
                 type: integer
                 format: int32
@@ -3847,17 +3575,13 @@ paths:
             format: int64
         - name: accept
           in: query
-          description: >-
-            override the HTTP Accept header to chose the response type.  Empty
-            and unrecognized values will result in application/json.
+          description: override the HTTP Accept header to chose the response type. Empty and unrecognized values will result in application/json.
           required: false
           schema:
             type: string
         - name: inline
           in: query
-          description: >-
-            for convenience, include a full representation of the inlined
-            property. Currently supports "dropMembershipId".
+          description: for convenience, include a full representation of the inlined property. Currently supports "dropMembershipId".
           required: false
           style: form
           schema:
@@ -3904,10 +3628,7 @@ paths:
             format: int64
         - name: save
           in: query
-          description: >-
-            Whether to save the result of the PUT or not (defaults to true).
-            Set to false if you want to preview the side-effects of a change
-            before going through with an update
+          description: Whether to save the result of the PUT or not (defaults to true). Set to false if you want to preview the side-effects of a change before going through with an update
           required: false
           schema:
             type: boolean
@@ -3998,9 +3719,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -4010,9 +3729,7 @@ paths:
           description: order-line response
           headers:
             Count:
-              description: >-
-                total number of matching results (how many you'd get if you
-                could set an infinite `limit`)
+              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
               schema:
                 type: integer
                 format: int32
@@ -4162,9 +3879,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -4174,9 +3889,7 @@ paths:
           description: order fee response
           headers:
             Count:
-              description: >-
-                total number of matching results (how many you'd get if you
-                could set an infinite `limit`)
+              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
               schema:
                 type: integer
                 format: int32
@@ -4222,9 +3935,7 @@ paths:
                 $ref: '#/components/schemas/error'
   '/order/{id}/parcel-carrier-fee-estimates':
     get:
-      summary: >-
-        Returns all parcel carrier shipping options and their costs for an order
-        ID
+      summary: Returns all parcel carrier shipping options and their costs for an order ID
       operationId: listOrderParcelCarrier
       tags:
         - order
@@ -4268,9 +3979,7 @@ paths:
             type: boolean
         - name: manager
           in: query
-          description: >-
-            person IDs to filter by, selecting vendors that these vendor
-            employees manage
+          description: person IDs to filter by, selecting vendors that these vendor employees manage
           required: false
           style: form
           schema:
@@ -4280,9 +3989,7 @@ paths:
               format: int64
         - name: buyer
           in: query
-          description: >-
-            person IDs to filter by, selecting vendors that these Azure
-            employees buy from
+          description: person IDs to filter by, selecting vendors that these Azure employees buy from
           required: false
           style: form
           schema:
@@ -4299,9 +4006,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -4311,9 +4016,7 @@ paths:
           description: vendor response
           headers:
             Count:
-              description: >-
-                total number of matching results (how many you'd get if you
-                didn't set `limit`)
+              description: total number of matching results (how many you'd get if you didn't set `limit`)
               schema:
                 type: integer
                 format: int32
@@ -4359,10 +4062,7 @@ paths:
                 $ref: '#/components/schemas/error'
   /account-entries:
     get:
-      summary: >-
-        Returns all dollar credits and debits from the system that the user has
-        access to.  Results are ordered by increasing settled dates, falling
-        back to IDs when multiple entries settled on the same day.
+      summary: Returns all dollar credits and debits from the system that the user has access to. Results are ordered by increasing settled dates, falling back to IDs when multiple entries settled on the same day.
       operationId: findAccountEntries
       tags:
         - account
@@ -4417,9 +4117,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -4429,9 +4127,7 @@ paths:
           description: account entry response
           headers:
             Count:
-              description: >-
-                total number of matching results (how many you'd get if you
-                could set an infinite `limit`)
+              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
               schema:
                 type: integer
                 format: int32
@@ -4499,15 +4195,12 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/payment'
-        description: Payment to create.  Amount and payment-method are both required.
+        description: Payment to create. Amount and payment-method are both required.
         required: true
   /payment-methods:
     get:
       summary: Returns all payment methods from the system that the user has access to
-      description: >-
-        Methods associated with a person are ordered by decreasing preference.
-        The ordering between methods associated with different people is
-        undefined.
+      description: Methods associated with a person are ordered by decreasing preference. The ordering between methods associated with different people is undefined.
       operationId: findPayments
       tags:
         - payment
@@ -4537,9 +4230,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -4549,9 +4240,7 @@ paths:
           description: payment method response
           headers:
             Count:
-              description: >-
-                total number of matching results (how many you'd get if you
-                could set an infinite `limit`)
+              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
               schema:
                 type: integer
                 format: int32
@@ -4644,10 +4333,7 @@ paths:
                 $ref: '#/components/schemas/error'
   /rewards:
     get:
-      summary: >-
-        Returns all reward credits and debits from the system that the user has
-        access to.  Results are ordered by increasing settled times, falling
-        back to ID for pending debits.
+      summary: Returns all reward credits and debits from the system that the user has access to. Results are ordered by increasing settled times, falling back to ID for pending debits.
       operationId: findRewards
       tags:
         - account
@@ -4700,9 +4386,7 @@ paths:
               format: int64
         - name: totals
           in: query
-          description: >-
-            Add the `total-credit`, `total-debit`, and `total-pending`
-            properties to returned entries.
+          description: Add the `total-credit`, `total-debit`, and `total-pending` properties to returned entries.
           required: false
           schema:
             type: boolean
@@ -4715,9 +4399,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            Offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -4727,9 +4409,7 @@ paths:
           description: Reward response.
           headers:
             Count:
-              description: >-
-                Total number of matching results (how many you'd get if you
-                could set an infinite `limit`).
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -4776,11 +4456,7 @@ paths:
   /addresses:
     get:
       summary: Returns all addresses from the system that the user has access to
-      description: >-
-        Addresses associated with a person are ordered by decreasing
-        preference.  The ordering between addresses associated with different
-        people or (for the same person) with the same preference value is
-        undefined.
+      description: Addresses associated with a person are ordered by decreasing preference. The ordering between addresses associated with different people or (for the same person) with the same preference value is undefined.
       operationId: findAddresses
       tags:
         - address
@@ -4797,9 +4473,7 @@ paths:
               format: int64
         - name: inline
           in: query
-          description: >-
-            for convenience, include a full representation of the inlined
-            property.  Currently supports "country", "person", and descendants.
+          description: for convenience, include a full representation of the inlined property. Currently supports "country", "person", and descendants.
           required: false
           style: form
           schema:
@@ -4815,9 +4489,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -4827,9 +4499,7 @@ paths:
           description: address response
           headers:
             Count:
-              description: >-
-                total number of matching results (how many you'd get if you
-                could set an infinite `limit`)
+              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
               schema:
                 type: integer
                 format: int32
@@ -4854,9 +4524,7 @@ paths:
       parameters:
         - name: inline
           in: query
-          description: >-
-            for convenience, include a full representation of the inlined
-            property.  Currently supports "country", "person", and descendants.
+          description: for convenience, include a full representation of the inlined property. Currently supports "country", "person", and descendants.
           required: false
           style: form
           schema:
@@ -4899,9 +4567,7 @@ paths:
             format: int64
         - name: inline
           in: query
-          description: >-
-            for convenience, include a full representation of the inlined
-            property.  Currently supports "country", "person", and descendants.
+          description: for convenience, include a full representation of the inlined property. Currently supports "country", "person", and descendants.
           required: false
           style: form
           schema:
@@ -4936,9 +4602,7 @@ paths:
             format: int64
         - name: inline
           in: query
-          description: >-
-            for convenience, include a full representation of the inlined
-            property.  Currently supports "country", "person", and descendants.
+          description: for convenience, include a full representation of the inlined property. Currently supports "country", "person", and descendants.
           required: false
           style: form
           schema:
@@ -4990,7 +4654,7 @@ paths:
   /countries:
     get:
       summary: Returns all countries from the system
-      description: 'Countries that are allowed to be used with addresses, ordered by name.'
+      description: Countries that are allowed to be used with addresses, ordered by name.
       operationId: findCountries
       tags:
         - country
@@ -5004,9 +4668,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -5016,9 +4678,7 @@ paths:
           description: country response
           headers:
             Count:
-              description: >-
-                total number of matching results (how many you'd get if you
-                could set an infinite `limit`)
+              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
               schema:
                 type: integer
                 format: int32
@@ -5038,10 +4698,7 @@ paths:
   /regions:
     get:
       summary: Returns all country regions from the system
-      description: >-
-        Regions that are allowed to be used with addresses in the United States
-        and Canada, ordered alphabetically.  Other countries may use any string
-        values for their regions.
+      description: Regions that are allowed to be used with addresses in the United States and Canada, ordered alphabetically. Other countries may use any string values for their regions.
       operationId: findRegions
       tags:
         - region
@@ -5061,9 +4718,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -5073,9 +4728,7 @@ paths:
           description: country region response
           headers:
             Count:
-              description: >-
-                total number of matching results (how many you'd get if you
-                could set an infinite `limit`)
+              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
               schema:
                 type: integer
                 format: int32
@@ -5095,10 +4748,7 @@ paths:
   /emails:
     get:
       summary: Returns all emails from the system that the user has access to.
-      description: >-
-        Emails associated with a person are ordered by decreasing preference.
-        The ordering between emails associated with different people or (for the
-        same person) with the same preference value is undefined.
+      description: Emails associated with a person are ordered by decreasing preference. The ordering between emails associated with different people or (for the same person) with the same preference value is undefined.
       operationId: findEmails
       tags:
         - email
@@ -5122,9 +4772,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            Offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: Offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -5134,9 +4782,7 @@ paths:
           description: Email response.
           headers:
             Count:
-              description: >-
-                Total number of matching results (how many you'd get if you
-                could set an infinite `limit`).
+              description: Total number of matching results (how many you'd get if you could set an infinite `limit`).
               schema:
                 type: integer
                 format: int32
@@ -5279,10 +4925,7 @@ paths:
               format: int64
         - name: inline
           in: query
-          description: >-
-            for convenience, include additional information.  Currently supports
-            "email" as described in the email model, "order-place-issue", and
-            "is-drop-coordinator".
+          description: for convenience, include additional information. Currently supports "email" as described in the email model, "order-place-issue", and "is-drop-coordinator".
           required: false
           style: form
           schema:
@@ -5298,9 +4941,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -5310,9 +4951,7 @@ paths:
           description: person response
           headers:
             Count:
-              description: >-
-                total number of matching results (how many you'd get if you
-                could set an infinite `limit`)
+              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
               schema:
                 type: integer
                 format: int32
@@ -5331,9 +4970,7 @@ paths:
                 $ref: '#/components/schemas/error'
   '/people/actions/find-affiliate-code-by-marketing-slug/{marketing-slug}':
     get:
-      summary: >-
-        Returns an affiliate code based on a marketing slug (no authorization
-        required)
+      summary: Returns an affiliate code based on a marketing slug (no authorization required)
       operationId: findAffiliateCodeByMarketingSlug
       tags:
         - person
@@ -5359,9 +4996,7 @@ paths:
                 $ref: '#/components/schemas/error'
   '/person/{id}':
     get:
-      summary: >-
-        Returns a person based on a single ID, if the user has access to the
-        person
+      summary: Returns a person based on a single ID, if the user has access to the person
       operationId: findPersonById
       tags:
         - person
@@ -5375,10 +5010,7 @@ paths:
             format: int64
         - name: inline
           in: query
-          description: >-
-            for convenience, include additional information.  Currently supports
-            "email" as described in the email model, "order-place-issue", and
-            "is-drop-coordinator".
+          description: for convenience, include additional information. Currently supports "email" as described in the email model, "order-place-issue", and "is-drop-coordinator".
           required: false
           style: form
           schema:
@@ -5435,9 +5067,7 @@ paths:
       parameters:
         - name: inline
           in: query
-          description: >-
-            for convenience, include additional information.  Currently supports
-            "email" as described in the email model and "order-place-issue".
+          description: for convenience, include additional information. Currently supports "email" as described in the email model and "order-place-issue".
           required: false
           style: form
           schema:
@@ -5548,34 +5178,21 @@ paths:
   /registration/register:
     post:
       summary: Register a new person
-      description: >-
-        When the user provides an email address, check for existing accounts
-        which use that email address.
+      description: |-
+        When the user provides an email address, check for existing accounts which use that email address.
 
+        * If an inactive account using the email address is found, send an inactive-member email pointing the user at customer service. Do not authenticate the user.
 
-        * If an inactive account using the email address is found, send an
-        inactive-member email pointing the user at customer service.  Do not
-        authenticate the user.
+        * If an active account using the email address is found, send an active-member email with an authenticating URL with an authentication token. Following that URL will (possibly indirectly) send the token to this API's login endpoint to authenticate the bearer.
 
-
-        * If an active account using the email address is found, send an
-        active-member email with an authenticating URL with an authentication
-        token.  Following that URL will (possibly indirectly) send the token to
-        this API's login endpoint to authenticate the bearer.
-
-
-        * If no account using that email address is found, create a new account
-        and immediately authenticate the user.  If they provided an email
-        address or SMS number, potentially send a welcome-aboard notification.
+        * If no account using that email address is found, create a new account and immediately authenticate the user. If they provided an email address or SMS number, potentially send a welcome-aboard notification.
       operationId: registerPerson
       tags:
         - registration
       parameters:
         - name: inline
           in: query
-          description: >-
-            for convenience, include a full representation of the inlined
-            property. Currently supports "session.person" and descendants.
+          description: for convenience, include a full representation of the inlined property. Currently supports "session.person" and descendants.
           required: false
           style: form
           schema:
@@ -5627,18 +5244,13 @@ paths:
         required: true
   /password/reset:
     post:
-      summary: >-
-        Initiate a password reset, to be completed by a call to
-        /password/confirm
+      summary: Initiate a password reset, to be completed by a call to /password/confirm
       operationId: resetPasswordRequest
       tags:
         - password
       responses:
         '204':
-          description: >-
-            Password-reset email sent (if the registration email corresponded to
-            an existing person.  Otherwise, you'll still get a 204 to avoid
-            leaking information about member email addresses)
+          description: Password-reset email sent (if the registration email corresponded to an existing person. Otherwise, you'll still get a 204 to avoid leaking information about member email addresses)
         default:
           description: unexpected error
           content:
@@ -5702,19 +5314,14 @@ paths:
               format: int64
         - name: annotate-person
           in: query
-          description: >-
-            add a boolean dismissed field to the results with whether or not the
-            annotate-person has dismissed this notification, required with
-            dismissed
+          description: add a boolean dismissed field to the results with whether or not the annotate-person has dismissed this notification, required with dismissed
           required: false
           schema:
             type: integer
             format: int64
         - name: dismissed
           in: query
-          description: >-
-            only return notifications that are (not) dismissed by the
-            annotate-person
+          description: only return notifications that are (not) dismissed by the annotate-person
           required: false
           schema:
             type: boolean
@@ -5723,9 +5330,7 @@ paths:
           description: notification response
           headers:
             Count:
-              description: >-
-                total number of matching results (how many you'd get if you
-                could set an infinite `limit`)
+              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
               schema:
                 type: integer
                 format: int32
@@ -5744,9 +5349,7 @@ paths:
                 $ref: '#/components/schemas/error'
   /notification-dismissals:
     post:
-      summary: >-
-        Create a notification dismissal (a user may only dismiss notifications
-        for himself)
+      summary: Create a notification dismissal (a user may only dismiss notifications for himself)
       operationId: addNotificationDismissal
       tags:
         - notification
@@ -5789,19 +5392,13 @@ paths:
               format: int64
         - name: active
           in: query
-          description: >-
-            only return favorites associated with (in)active packaged products.
-            For example, we sometimes discontinue products and then pick them
-            back up later.  In this context, "active" means "for sale to at
-            least some customers".
+          description: only return favorites associated with (in)active packaged products. For example, we sometimes discontinue products and then pick them back up later. In this context, "active" means "for sale to at least some customers".
           required: false
           schema:
             type: boolean
         - name: inline
           in: query
-          description: >-
-            for convenience, include a full representation of the inlined
-            property. Currently supports "packaged-product" and descendants.
+          description: for convenience, include a full representation of the inlined property. Currently supports "packaged-product" and descendants.
           required: false
           style: form
           schema:
@@ -5817,9 +5414,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -5829,9 +5424,7 @@ paths:
           description: array of favorites response
           headers:
             Count:
-              description: >-
-                total number of matching results (how many you'd get if you
-                could set an infinite `limit`)
+              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
               schema:
                 type: integer
                 format: int32
@@ -5889,9 +5482,7 @@ paths:
             format: int64
         - name: inline
           in: query
-          description: >-
-            for convenience, include a full representation of the inlined
-            property. Currently supports "packaged-product" and descendants.
+          description: for convenience, include a full representation of the inlined property. Currently supports "packaged-product" and descendants.
           required: false
           style: form
           schema:
@@ -5982,9 +5573,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -6153,9 +5742,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -6165,9 +5752,7 @@ paths:
           description: printer response
           headers:
             Count:
-              description: >-
-                total number of matching results (how many you'd get if you
-                could set an infinite `limit`)
+              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
               schema:
                 type: integer
                 format: int32
@@ -6186,7 +5771,7 @@ paths:
                 $ref: '#/components/schemas/error'
   '/printer/{id}':
     get:
-      summary: 'Returns a printer based on a single ID, if the user has access to it'
+      summary: Returns a printer based on a single ID, if the user has access to it
       operationId: findPrinterById
       tags:
         - printer
@@ -6227,9 +5812,7 @@ paths:
             format: int32
         - name: start
           in: query
-          description: >-
-            offset to the first result to return.  Use negative numbers to
-            offset from the end of the result list.
+          description: offset to the first result to return. Use negative numbers to offset from the end of the result list.
           required: false
           schema:
             type: integer
@@ -6239,9 +5822,7 @@ paths:
           description: warehouse response
           headers:
             Count:
-              description: >-
-                total number of matching results (how many you'd get if you
-                could set an infinite `limit`)
+              description: total number of matching results (how many you'd get if you could set an infinite `limit`)
               schema:
                 type: integer
                 format: int32
@@ -6260,7 +5841,7 @@ paths:
                 $ref: '#/components/schemas/error'
   '/warehouse/{code}':
     get:
-      summary: 'Returns a warehouse based on a single code, if the user has access to it'
+      summary: Returns a warehouse based on a single code, if the user has access to it
       operationId: findWarehouseByCode
       tags:
         - warehouse
@@ -6291,9 +5872,7 @@ paths:
       parameters:
         - name: inline
           in: query
-          description: >-
-            for convenience, include a full representation of the inlined
-            property.  Currently supports "address.country".
+          description: for convenience, include a full representation of the inlined property. Currently supports "address.country".
           required: false
           style: form
           schema:
@@ -6315,11 +5894,7 @@ paths:
                 $ref: '#/components/schemas/error'
   /order-frequency-segment:
     get:
-      summary: >-
-        Returns "active" if the customer has ordered within the last 120 days,
-        "activeag" (for "active aging") if they've ordered before but not within
-        120 days, "activereg" if they've never ordered. If no customer exists,
-        returns "new".
+      summary: Returns "active" if the customer has ordered within the last 120 days, "activeag" (for "active aging") if they've ordered before but not within 120 days, "activereg" if they've never ordered. If no customer exists, returns "new".
       operationId: orderFrequencySegment
       parameters:
         - name: email
@@ -6330,11 +5905,7 @@ paths:
             type: string
       responses:
         '200':
-          description: >-
-            Returns "active" if the customer has ordered within the last 120
-            days, "activeag" (for "active aging") if they've ordered before but
-            not within 120 days, "activereg" if they've never ordered. If no
-            customer exists, returns "new".
+          description: Returns "active" if the customer has ordered within the last 120 days, "activeag" (for "active aging") if they've ordered before but not within 120 days, "activereg" if they've never ordered. If no customer exists, returns "new".
           content:
             application/json:
               schema:
@@ -6370,13 +5941,13 @@ components:
   securitySchemes:
     basic:
       type: http
-      description: 'Basic authentication (http://tools.ietf.org/html/rfc2617#section-2)'
+      description: Basic authentication (http://tools.ietf.org/html/rfc2617#section-2)
       scheme: basic
     sessionCookie:
       type: apiKey
       in: header
       name: cookie
-      description: 'Session cookie (http://tools.ietf.org/html/rfc6265)'
+      description: Session cookie (http://tools.ietf.org/html/rfc6265)
   schemas:
     affiliateCode:
       description: an affiliate code and associated marketing slug of a person
@@ -6403,9 +5974,7 @@ components:
           description: name of the person referred
           type: string
         amount-earned:
-          description: >-
-            dollar value for the sum of account credits to the referrer that
-            were caused by this referral
+          description: dollar value for the sum of account credits to the referrer that were caused by this referral
           type: number
           format: float
       required:
@@ -6439,13 +6008,7 @@ components:
         - id
         - path
     bartenderPrintConfiguration:
-      description: >-
-        A BarTender print configuration for BarTender print requests.  These
-        configurations are added to warehouse pieces (which are related to
-        individual stock) in Beehive and are used to route print requests and to
-        tell BarTender which template should be used.  A print request will be
-        created for each print configuration associated with a stock location's
-        warehouse.
+      description: A BarTender print configuration for BarTender print requests. These configurations are added to warehouse pieces (which are related to individual stock) in Beehive and are used to route print requests and to tell BarTender which template should be used. A print request will be created for each print configuration associated with a stock location's warehouse.
       type: object
       properties:
         id:
@@ -6455,9 +6018,7 @@ components:
           description: the BarTender host's code
           type: string
         printer:
-          description: >-
-            The printer ID. The referenced printer must support the `bartender`
-            format and delivery methods.
+          description: The printer ID. The referenced printer must support the `bartender` format and delivery methods.
           type: integer
           format: int64
         template:
@@ -6539,9 +6100,7 @@ components:
           description: The category name.
           type: string
         customer-pricing:
-          description: >-
-            Whether or not reports in this category are customer pricing groups
-            (for use in the pricing module).
+          description: Whether or not reports in this category are customer pricing groups (for use in the pricing module).
           type: boolean
       required:
         - id
@@ -6557,7 +6116,7 @@ components:
         name:
           type: string
         coordinators:
-          description: coordinators for this drop.  The first entry is the primary contact
+          description: coordinators for this drop. The first entry is the primary contact
           type: array
           items:
             description: person ID for this coordinator
@@ -6571,19 +6130,13 @@ components:
           description: whether or not this drop is actively ordering
           type: boolean
         accounts-payable-contact:
-          description: >-
-            name of the drop employee Azure's accounts-payable should contact,
-            if different from the primary contact
+          description: name of the drop employee Azure's accounts-payable should contact, if different from the primary contact
           type: string
         after-hours-phone:
-          description: >-
-            E.123 telephone number Azure should call if we need to contact the
-            drop after business hours
+          description: E.123 telephone number Azure should call if we need to contact the drop after business hours
           type: string
         business-hours:
-          description: >-
-            regular business hours for the drop (e.g. "8:30-6 Mon-Fri, 9-5 Sat,
-            closed Sun")
+          description: regular business hours for the drop (e.g. "8:30-6 Mon-Fri, 9-5 Sat, closed Sun")
           type: string
         business-type:
           description: what type of business do you run?
@@ -6599,15 +6152,10 @@ components:
               - seasonal
               - wholesale-distributor
         buyer:
-          description: >-
-            name of the drop employee who usually places orders for this drop,
-            if different from the primary contact
+          description: name of the drop employee who usually places orders for this drop, if different from the primary contact
           type: string
         pickup-contact:
-          description: >-
-            do customers need to contact you to pick up their orders?  Retail
-            preference.  Only available when how-members-receive is
-            "can-hold-sometimes" or "can-hold"
+          description: do customers need to contact you to pick up their orders?  Retail preference. Only available when how-members-receive is "can-hold-sometimes" or "can-hold"
           type: string
           enum:
             - 'yes'
@@ -6625,19 +6173,13 @@ components:
               - email
               - other
         contact-type-other-notes:
-          description: >-
-            description of the alternative contact method.  Available when
-            contact-type includes "other"
+          description: description of the alternative contact method. Available when contact-type includes "other"
           type: string
         contact-type-phone:
-          description: >-
-            E.123 telephone number customers should call to contact this drop.
-            Available when contact-type includes "phone"
+          description: E.123 telephone number customers should call to contact this drop. Available when contact-type includes "phone"
           type: string
         directions:
-          description: >-
-            driving directions for a truck approaching this drop (e.g. avoiding
-            low bridges, tight turns, etc. on more obvious routes)
+          description: driving directions for a truck approaching this drop (e.g. avoiding low bridges, tight turns, etc. on more obvious routes)
           type: string
         driver-callable-phone:
           description: E.123 telephone number for a driver approaching this drop
@@ -6656,16 +6198,10 @@ components:
             - 'no'
             - limited
         food-stamps-limited-notes:
-          description: >-
-            description of limited food-stamp acceptance.  Business preference.
-            Only available when food-stamps is "limited"
+          description: description of limited food-stamp acceptance. Business preference. Only available when food-stamps is "limited"
           type: string
         hold-time:
-          description: >-
-            how long will you hold a customer's order?  For example, "24 hours",
-            "three days for dry, frozen by arrangement", etc.  Retail
-            preference.  Only available when how-members-receive is
-            "can-hold-sometimes" or "can-hold"
+          description: how long will you hold a customer's order?  For example, "24 hours", "three days for dry, frozen by arrangement", etc. Retail preference. Only available when how-members-receive is "can-hold-sometimes" or "can-hold"
           type: string
         how-members-receive:
           description: how do your members receive their items?  Retail preference
@@ -6675,9 +6211,7 @@ components:
             - can-hold-sometimes
             - can-hold
         invoice-always:
-          description: >-
-            always print paper invoices, regardless of the customer's
-            invoice-delivery preference
+          description: always print paper invoices, regardless of the customer's invoice-delivery preference
           type: boolean
         okay-to-text-phone:
           description: can the driver send text messages to the driver-callable phone?
@@ -6692,9 +6226,7 @@ components:
             - public
             - other-building
         special-orders:
-          description: >-
-            do you take special orders for Azure products from customers?
-            Wholesale preference
+          description: do you take special orders for Azure products from customers? Wholesale preference
           type: boolean
         storage:
           description: storage environments available at this drop
@@ -6704,13 +6236,7 @@ components:
         fees:
           $ref: '#/components/schemas/dropFees'
         order-minimum:
-          description: >-
-            the minimum total order value (in dollars) required to ship a
-            particular trip to this drop.  For example, if the minimum is $400
-            and there are three $100 orders placed for a stop, that stop will be
-            under-minimum, and the orders will not be shipped.  If, on the other
-            hand, there were four $100 orders placed for a stop, that stop would
-            be (just) over-minimum, and the orders would be shipped.
+          description: the minimum total order value (in dollars) required to ship a particular trip to this drop. For example, if the minimum is $400 and there are three $100 orders placed for a stop, that stop will be under-minimum, and the orders will not be shipped. If, on the other hand, there were four $100 orders placed for a stop, that stop would be (just) over-minimum, and the orders would be shipped.
           type: number
           format: float
         members:
@@ -6730,21 +6256,13 @@ components:
               type: string
               format: date
         notes:
-          description: >-
-            free-form Markdown notes for any member-oriented drop information
-            that doesn't fit into an existing field.  This information is public
-            for open and semi-open drops, and visible to all members for closed
-            drops
+          description: free-form Markdown notes for any member-oriented drop information that doesn't fit into an existing field. This information is public for open and semi-open drops, and visible to all members for closed drops
           type: string
         sells-finished-goods-to-azure:
-          description: >-
-            do you also sell your finished good to Azure?  Only available if
-            business-type includes "manufacturing-business"
+          description: do you also sell your finished good to Azure?  Only available if business-type includes "manufacturing-business"
           type: boolean
         uses-azure-to-drop-ship:
-          description: >-
-            Do you drop ship Azure orders (have Azure ship directly to your
-            customers)?  Only available if business-type includes "online-store"
+          description: Do you drop ship Azure orders (have Azure ship directly to your customers)?  Only available if business-type includes "online-store"
           type: boolean
       required:
         - id
@@ -6787,11 +6305,7 @@ components:
         fees:
           $ref: '#/components/schemas/dropFees'
         notes:
-          description: >-
-            free-form Markdown notes for any member-oriented drop information
-            that doesn't fit into an existing field.  This information is public
-            for open and semi-open drops, and visible to all members for closed
-            drops
+          description: free-form Markdown notes for any member-oriented drop information that doesn't fit into an existing field. This information is public for open and semi-open drops, and visible to all members for closed drops
           type: string
       required:
         - name
@@ -6801,13 +6315,13 @@ components:
       type: object
       properties:
         medium:
-          description: 'payment medium (nothing, volunteer time, or a monetary payment)'
+          description: payment medium (nothing, volunteer time, or a monetary payment)
           type: string
           enum:
             - volunteer
             - payment
         condition:
-          description: 'fee trigger (never, only when orders are held, or for every order)'
+          description: fee trigger (never, only when orders are held, or for every order)
           type: string
           enum:
             - held
@@ -6831,11 +6345,7 @@ components:
           type: integer
           format: int64
         active:
-          description: >-
-            whether or not this membership is active.  Pending memberships are
-            active, and the usual flow for semi-open drops is (active true,
-            pending true) -> (active true, pending false) -> (active false,
-            pending false).
+          description: whether or not this membership is active. Pending memberships are active, and the usual flow for semi-open drops is (active true, pending true) -> (active true, pending false) -> (active false, pending false).
           type: boolean
         pending:
           description: whether the membership is pending (true) or accepted (false).
@@ -6845,17 +6355,12 @@ components:
           type: string
           format: date-time
         heavy:
-          description: >-
-            whether the member can get pallets, totes, barrels, and other heavy
-            objects off a truck (defaults to false).
+          description: whether the member can get pallets, totes, barrels, and other heavy objects off a truck (defaults to false).
           type: boolean
         notifications:
           $ref: '#/components/schemas/dropMembershipNotifications'
         gratitude-total:
-          description: >-
-            total "Azure Gratitude" (monetary incentive for hosting a drop)
-            received from being this drop's coordinator. Only set if the
-            "inline" query parameter contains "gratitude-total".
+          description: total "Azure Gratitude" (monetary incentive for hosting a drop) received from being this drop's coordinator. Only set if the "inline" query parameter contains "gratitude-total".
           type: number
           format: float
           minimum: 0
@@ -6894,9 +6399,7 @@ components:
           description: whether the membership is pending (true) or accepted (false).
           type: boolean
         heavy:
-          description: >-
-            whether the member can get pallets, totes, barrels, and other heavy
-            objects off a truck (defaults to false).
+          description: whether the member can get pallets, totes, barrels, and other heavy objects off a truck (defaults to false).
           type: boolean
         notifications:
           $ref: '#/components/schemas/dropMembershipNotifications'
@@ -6916,15 +6419,11 @@ components:
           items:
             $ref: '#/components/schemas/notificationChannel'
     file:
-      description: >-
-        An opaque file.  This is usually used for product and category images,
-        but could also be used for other content.
+      description: An opaque file. This is usually used for product and category images, but could also be used for other content.
       type: object
       properties:
         id:
-          description: >-
-            The identifier for this file.  This is generated by the server, but
-            will be a UUID as defined by RFC 4122.
+          description: The identifier for this file. This is generated by the server, but will be a UUID as defined by RFC 4122.
           type: string
       required:
         - id
@@ -6952,9 +6451,7 @@ components:
           description: whether or not this pickup is actively supplying purchases
           type: boolean
         notes:
-          description: >-
-            free-form Markdown notes for any pickup information that doesn't fit
-            into an existing field
+          description: free-form Markdown notes for any pickup information that doesn't fit into an existing field
           type: string
       required:
         - id
@@ -6983,9 +6480,7 @@ components:
           type: integer
           format: int32
         internal:
-          description: >-
-            Is the route for internal use? This controls whether customers can
-            access the route via the API (they can't if internal is true).
+          description: Is the route for internal use? This controls whether customers can access the route via the API (they can't if internal is true).
           type: boolean
         backhaul-cost-per-pound:
           description: route backhaul cost per pound
@@ -6996,14 +6491,7 @@ components:
           type: number
           format: float
         hub:
-          description: >-
-            A hub route is a delivery route that occurs after we ship
-            an entire route to a distribution hub (such as a big
-            loading dock in Kansas City). The route is unloaded at the
-            hub and reloaded onto another carrier's truck for actual
-            delivery. In terms of Customer Care, It is a one-way route;
-            the truck, trailer, and any shipped goods refused by a
-            customer never return to the warehouse.
+          description: A hub route is a delivery route that occurs after we ship an entire route to a distribution hub (such as a big loading dock in Kansas City). The route is unloaded at the hub and reloaded onto another carrier's truck for actual delivery. In terms of Customer Care, It is a one-way route; the truck, trailer, and any shipped goods refused by a customer never return to the warehouse.
           type: boolean
         driverName:
           description: Truck drivers name
@@ -7038,9 +6526,7 @@ components:
           type: integer
           format: int32
         internal:
-          description: >-
-            Is the route for internal use? This controls whether customers can
-            access the route via the API (they can't if internal is true).
+          description: Is the route for internal use? This controls whether customers can access the route via the API (they can't if internal is true).
           type: boolean
         backhaul-cost-per-pound:
           description: route backhaul cost per pound
@@ -7051,14 +6537,7 @@ components:
           type: number
           format: float
         hub:
-          description: >-
-            A hub route is a delivery route that occurs after we ship
-            an entire route to a distribution hub (such as a big
-            loading dock in Kansas City). The route is unloaded at the
-            hub and reloaded onto another carrier's truck for actual
-            delivery. In terms of Customer Care, It is a one-way route;
-            the truck, trailer, and any shipped goods refused by a
-            customer never return to the warehouse.
+          description: A hub route is a delivery route that occurs after we ship an entire route to a distribution hub (such as a big loading dock in Kansas City). The route is unloaded at the hub and reloaded onto another carrier's truck for actual delivery. In terms of Customer Care, It is a one-way route; the truck, trailer, and any shipped goods refused by a customer never return to the warehouse.
           type: boolean
         driverName:
           description: Truck drivers name
@@ -7090,13 +6569,7 @@ components:
           type: string
           format: date-time
         confirmed:
-          description: >-
-            when the trip was reviewed and orders were either accepted or (for
-            short drops) bumped to the next trip.  This will always be set
-            before the trip is confirmed, and will be unset until then.
-            Customer service and customers who have received a short-drop
-            notification can continue to manipulate placed orders in the window
-            between cutoff and confirmation.
+          description: when the trip was reviewed and orders were either accepted or (for short drops) bumped to the next trip. This will always be set before the trip is confirmed, and will be unset until then. Customer service and customers who have received a short-drop notification can continue to manipulate placed orders in the window between cutoff and confirmation.
           type: string
           format: date-time
         pick-date:
@@ -7104,9 +6577,7 @@ components:
           type: string
           format: date-time
         shipped:
-          description: >-
-            approximately when the truck left the warehouse.  This will always
-            be set after the truck has left, and will be unset until then.
+          description: approximately when the truck left the warehouse. This will always be set after the truck has left, and will be unset until then.
           type: string
           format: date-time
         delivery-start:
@@ -7130,12 +6601,9 @@ components:
           type: string
           format: date-time
         notes:
-          description: >-
-            free-form Markdown notes for additional trip information.  We expect
-            this will mostly be for delay causes (e.g. "High winds in Laramie"
-            or "The truck broke down")
+          description: free-form Markdown notes for additional trip information. We expect this will mostly be for delay causes (e.g. "High winds in Laramie" or "The truck broke down")
           type: string
-        status: 
+        status:
           description: current stage of a trip's lifecycle
           type: string
           enum:
@@ -7202,9 +6670,7 @@ components:
           type: integer
           format: int64
         delivery-offset:
-          description: >-
-            offset from midnight on the morning of the trips's delivery start
-            until the usual delivery time for this drop
+          description: offset from midnight on the morning of the trips's delivery start until the usual delivery time for this drop
           type: string
           format: duration
         drop-shipping-fee:
@@ -7215,11 +6681,7 @@ components:
         - drop
         - delivery-offset
     stop:
-      description: >-
-        a trip stop or waypoint.  Stops are created for all route-stops when a
-        trip is created for that route.  At confirmation time, stops that will
-        not be visited (e.g. because they missed their order-minimum) are
-        deleted
+      description: a trip stop or waypoint. Stops are created for all route-stops when a trip is created for that route. At confirmation time, stops that will not be visited (e.g. because they missed their order-minimum) are deleted
       type: object
       properties:
         id:
@@ -7234,19 +6696,14 @@ components:
           type: integer
           format: int64
         short-drop:
-          description: >-
-            whether short-drop warnings were sent out for this stop.  If they
-            were, customers can manipulate placed orders after cutoff time,
-            although nobody can edit orders after the trip is confirmed.
+          description: whether short-drop warnings were sent out for this stop. If they were, customers can manipulate placed orders after cutoff time, although nobody can edit orders after the trip is confirmed.
           type: boolean
         pickup:
           description: pickup ID for the stop
           type: integer
           format: int64
         timezone:
-          description: >-
-            IANA time zone location (https://www.iana.org/time-zones, e.g.
-            America/Los_Angeles)
+          description: IANA time zone location (https://www.iana.org/time-zones, e.g. America/Los_Angeles)
           type: string
         estimatedDelivery:
           description: editable until verification
@@ -7300,9 +6757,7 @@ components:
         - estimatedDelivery
         - finalizedDelivery
     shippingService:
-      description: >-
-        A parcel-carrier service.  The listing below is ordered by carrier and
-        then by increasing duration.
+      description: A parcel-carrier service. The listing below is ordered by carrier and then by increasing duration.
       type: string
       enum:
         - UPS 2nd Day Air
@@ -7310,21 +6765,14 @@ components:
         - USPS Priority Mail Express
         - USPS Priority Mail
     shippingClimate:
-      description: >-
-        An environment for shipping products.  'all' is a shipping climate for
-        products of all types.  'dry' includes both 'dry' and 'greenhouse'
-        storage environments.  'chilled/frozen' includes both 'chilled' and
-        'frozen' storage environments.
+      description: An environment for shipping products. 'all' is a shipping climate for products of all types. 'dry' includes both 'dry' and 'greenhouse' storage environments. 'chilled/frozen' includes both 'chilled' and 'frozen' storage environments.
       type: string
       enum:
         - all
         - dry
         - chilled/frozen
     storage:
-      description: >-
-        An environment for storing products.  The related to shippingClimate is
-        less detailed, because stock is generally in transit for less time than
-        it is in storage.
+      description: An environment for storing products. The related to shippingClimate is less detailed, because stock is generally in transit for less time than it is in storage.
       type: string
       enum:
         - dry
@@ -7338,16 +6786,16 @@ components:
         code:
           type: string
         gtin13:
-          description: '13-digit Global Trade Item Number (https://schema.org/gtin13).'
+          description: 13-digit Global Trade Item Number (https://schema.org/gtin13).
           type: string
         size:
-          description: 'Size of the product (e.g. 12 oz., or 6x12 oz.).'
+          description: Size of the product (e.g. 12 oz., or 6x12 oz.).
           type: string
         packs:
-          description: 'Package organization (e.g. "4", "4x32.5", or "2x4x32.5")'
+          description: Package organization (e.g. "4", "4x32.5", or "2x4x32.5")
           type: string
         unit:
-          description: 'Unit of measurement ("ounce", "liter", etc.)'
+          description: Unit of measurement ("ounce", "liter", etc.)
           type: string
         weight:
           $ref: '#/components/schemas/weight'
@@ -7358,18 +6806,11 @@ components:
         price:
           $ref: '#/components/schemas/price'
         stock:
-          description: >-
-            Amount of stock available for purchase.  This includes breakdown
-            ancestors.  For example, if we have a single 4 x 6 x 14 oz case in
-            the warehouse, the 4 x 6 x 14 oz packaging will have 1 stock, the 6
-            x 14 oz packagaging will have 4 stock, and the 14 oz packaging will
-            have 24 stock.
+          description: Amount of stock available for purchase. This includes breakdown ancestors. For example, if we have a single 4 x 6 x 14 oz case in the warehouse, the 4 x 6 x 14 oz packaging will have 1 stock, the 6 x 14 oz packagaging will have 4 stock, and the 14 oz packaging will have 24 stock.
           type: integer
           format: int32
         favorite:
-          description: >-
-            If the annotate-person you associated with the request has favorited
-            this packaged product.
+          description: If the annotate-person you associated with the request has favorited this packaged product.
           type: boolean
         favorites:
           description: Number of people who've marked this packaged product as a favorite.
@@ -7387,13 +6828,7 @@ components:
           description: Reason this packaged product is in its current status.
           type: string
         servings-per-container:
-          description: >-
-            Servings per container.  The rest of the nutrition information is in
-            product.nutrition-facts, but the number of servings per container
-            depends on the packaging size.  For composite packaging (e.g. a 12 x
-            6 x 2 oz case), the value applies to the smallest component with a
-            nutrition label (e.g. the 2 oz items, if they're labeled, or the 6 x
-            2 oz boxes, if they're labeled and the 2 oz items are not).
+          description: Servings per container. The rest of the nutrition information is in product.nutrition-facts, but the number of servings per container depends on the packaging size. For composite packaging (e.g. a 12 x 6 x 2 oz case), the value applies to the smallest component with a nutrition label (e.g. the 2 oz items, if they're labeled, or the 6 x 2 oz boxes, if they're labeled and the 2 oz items are not).
           type: string
         product:
           description: The product that this packaging packages.
@@ -7423,9 +6858,7 @@ components:
           description: File ID for the associated image.
           type: string
         order:
-          description: >-
-            Ordering precedence among other entries associated with this
-            packaged product.  Defaults to zero.
+          description: Ordering precedence among other entries associated with this packaged product. Defaults to zero.
           type: integer
           format: int32
       required:
@@ -7476,51 +6909,33 @@ components:
           description: sentence-length product name
           type: string
         seo-name:
-          description: >-
-            An SEO-optimized name.  A lengthened version of the full name that
-            includes additional keywords or rephrasing, suitable for use in a
-            title tag.  When this is unset, the name is a reasonable fallback.
+          description: An SEO-optimized name. A lengthened version of the full name that includes additional keywords or rephrasing, suitable for use in a title tag. When this is unset, the name is a reasonable fallback.
           type: string
         treatAsActive:
-          description: If true, this product will be published to search engines
-            even when it is inactive (out for season, out long term, or
-            discontinued).
+          description: If true, this product will be published to search engines even when it is inactive (out for season, out long term, or discontinued).
           type: boolean
         inactiveDescription:
-          description: >-
-            HTML description applicable only when the product is inactive (out
-            for season, out long term, or discontinued). It should contain
-            specific information pertinent to the inactive status of the product
-            (e.g. details about why it is inactive and what similar products
-            are available instead). It should not duplicate information in
-            short-description or description.
+          description: HTML description applicable only when the product is inactive (out for season, out long term, or discontinued). It should contain specific information pertinent to the inactive status of the product (e.g. details about why it is inactive and what similar products are available instead). It should not duplicate information in short-description or description.
           type: string
         short-description:
-          description: 'paragraph-length, stand-alone, plain-text product description'
+          description: paragraph-length, stand-alone, plain-text product description
           type: string
         description:
-          description: >-
-            long-form, HTML product description.  When short-description is set,
-            this value is for additional information which did not fit into
-            short-description.  Displaying both short-description and
-            description is not redundant.  Displaying only description may be
-            confusing when short-description is available.
+          description: long-form, HTML product description. When short-description is set, this value is for additional information which did not fit into short-description. Displaying both short-description and description is not redundant. Displaying only description may be confusing when short-description is available.
           type: string
         brand:
           description: the brand associated with this product
           type: integer
           format: int64
         directions:
-          description: 'product use directions (e.g., cooking suggestions)'
+          description: product use directions (e.g., cooking suggestions)
           type: string
         favorites:
           description: number of people who've marked this product as a favorite
           type: integer
           format: int32
         ingredients:
-          description: >-
-            ingredients used in this product (e.g., "dried cranberries (organic
-            cranberries, organic cane sugar, organic sunflower oil)")
+          description: ingredients used in this product (e.g., "dried cranberries (organic cranberries, organic cane sugar, organic sunflower oil)")
           type: string
         nutrition-facts:
           $ref: '#/components/schemas/nutritionFacts'
@@ -7535,17 +6950,13 @@ components:
           type: object
           properties:
             by-category:
-              description: >-
-                Suggested substitute product IDs which belong to related
-                categories.
+              description: Suggested substitute product IDs which belong to related categories.
               type: array
               items:
                 type: integer
                 format: int64
             staff-picks:
-              description: >-
-                Suggested substitute product IDs which were chosen by staff
-                members.
+              description: Suggested substitute product IDs which were chosen by staff members.
               type: array
               items:
                 type: integer
@@ -7566,9 +6977,7 @@ components:
       type: object
       properties:
         headers:
-          description: >-
-            nutrition-fact headers (e.g. "Serving Size 1 cake (19g)" or
-            "Calories 60")
+          description: nutrition-fact headers (e.g. "Serving Size 1 cake (19g)" or "Calories 60")
           type: array
           items:
             type: string
@@ -7582,15 +6991,13 @@ components:
       type: object
       properties:
         indent:
-          description: >-
-            if true, this label should be indented (e.g. an indented "Dietary
-            Fiber" entry might follow a non-indented "Total Carbohydrate" entry)
+          description: if true, this label should be indented (e.g. an indented "Dietary Fiber" entry might follow a non-indented "Total Carbohydrate" entry)
           type: boolean
         label:
-          description: 'daily value label (e.g. "Total Carbohydrate 14g", "Calcium")'
+          description: daily value label (e.g. "Total Carbohydrate 14g", "Calcium")
           type: string
         percentage:
-          description: 'daily value percentage (e.g., "10" or "<1")'
+          description: daily value percentage (e.g., "10" or "<1")
           type: string
       required:
         - indent
@@ -7628,7 +7035,7 @@ components:
           description: Whether the `dollars` value is per-pound or per-package.
           type: boolean
         discount:
-          description: 'Text for the discount (e.g. "12%", or "$3.50").'
+          description: Text for the discount (e.g. "12%", or "$3.50").
           type: string
         dollars-per-unit:
           description: The per-unit price.
@@ -7636,20 +7043,12 @@ components:
           format: float
           minimum: 0
         rewards-rate:
-          description: >-
-            Rewards rate (as a percentage) earned for this packaging.  This will
-            only be set for packaging with a fixed rewards rate.  The rewards
-            earned for this product will be the price (after sales) *
-            min(max(`person.rewards-rate`, `product.rewards-rate`),
-            `product.maxRewardsRate`) / 100, rounded to the nearest cent,
-            rounding half to even.
+          description: Rewards rate (as a percentage) earned for this packaging. This will only be set for packaging with a fixed rewards rate. The rewards earned for this product will be the price (after sales) * min(max(`person.rewards-rate`, `product.rewards-rate`), `product.maxRewardsRate`) / 100, rounded to the nearest cent, rounding half to even.
           type: integer
           format: int32
           minimum: 0
         maxRewardsRate:
-          description: >-
-            The maximum rewards rate that could be earned for this product.  A
-            value of 0 means that no rewards will be earned.
+          description: The maximum rewards rate that could be earned for this product. A value of 0 means that no rewards will be earned.
           type: integer
           format: int32
           minimum: 0
@@ -7690,55 +7089,31 @@ components:
           type: integer
           format: int64
         name:
-          description: >-
-            A phrase naming the category.  This should be understandable (but
-            not necessarily unique) without any further context.  It must be
-            unique for categories sharing a given parent.
+          description: A phrase naming the category. This should be understandable (but not necessarily unique) without any further context. It must be unique for categories sharing a given parent.
           type: string
         short-name:
-          description: >-
-            A word or two naming the category.  A shortened version of the full
-            name that drops any words already contained in the category's
-            ancestors' short names.  This will be used in places where the
-            ancestor short names are in close proximity (e.g. URL slugs) to
-            avoid having the same word many times.  When this is unset, the name
-            is a reasonable fallback
+          description: A word or two naming the category. A shortened version of the full name that drops any words already contained in the category's ancestors' short names. This will be used in places where the ancestor short names are in close proximity (e.g. URL slugs) to avoid having the same word many times. When this is unset, the name is a reasonable fallback
           type: string
         seo-name:
-          description: >-
-            An SEO-optimized name for the category.  A lengthened version of the
-            full name that includes additional keywords or rephrasing, suitable
-            for use in a title tag.  When this is unset, the name is a
-            reasonable fallback.
+          description: An SEO-optimized name for the category. A lengthened version of the full name that includes additional keywords or rephrasing, suitable for use in a title tag. When this is unset, the name is a reasonable fallback.
           type: string
         description:
-          description: >-
-            A sentence or two with a stand-alone category description.  When
-            this is unset, the nearest ancestor description is a reasonable
-            fallback.
+          description: A sentence or two with a stand-alone category description. When this is unset, the nearest ancestor description is a reasonable fallback.
           type: string
         image:
-          description: >-
-            A picture of this category.  When set for a fetched category, the
-            value will be a URL.  When set for an uploaded category, file IDs
-            and media URLs can be used interchangeably.
+          description: A picture of this category. When set for a fetched category, the value will be a URL. When set for an uploaded category, file IDs and media URLs can be used interchangeably.
           type: string
         parent:
           description: Category ID for the parent category.
           type: integer
           format: int64
         ancestors:
-          description: >-
-            Ancestor categories.  If set, `ancestors[0]` is the parent category
-            and the final `ancestors` entry is the root category.  Include
-            "ancestors" in the `inline` query parameter if you need this.
+          description: Ancestor categories. If set, `ancestors[0]` is the parent category and the final `ancestors` entry is the root category. Include "ancestors" in the `inline` query parameter if you need this.
           type: array
           items:
             $ref: '#/components/schemas/category'
         depth:
-          description: >-
-            The number of ancestor categories.  Include "depth" in the `inline`
-            query parameter if you need this.
+          description: The number of ancestor categories. Include "depth" in the `inline` query parameter if you need this.
           type: integer
           format: int32
         primary:
@@ -7753,13 +7128,11 @@ components:
             description: A keyword for this category.
             type: string
         featured:
-          description: Ordering precedence for likely customer interest.  Defaults to zero.
+          description: Ordering precedence for likely customer interest. Defaults to zero.
           type: integer
           format: int32
         slug:
-          description: >-
-            A slug generated from the category short-name (or name if short-name
-            is not defined).
+          description: A slug generated from the category short-name (or name if short-name is not defined).
           type: string
       required:
         - id
@@ -7769,38 +7142,19 @@ components:
       type: object
       properties:
         name:
-          description: >-
-            A phrase naming the category.  This should be understandable (but
-            not necessarily unique) without any further context.  It must be
-            unique for categories sharing a given parent.
+          description: A phrase naming the category. This should be understandable (but not necessarily unique) without any further context. It must be unique for categories sharing a given parent.
           type: string
         short-name:
-          description: >-
-            A word or two naming the category.  A shortened version of the full
-            name that drops any words already contained in the category's
-            ancestors' short names.  This will be used in places where the
-            ancestor short names are in close proximity (e.g. URL slugs) to
-            avoid having the same word many times.  When this is unset, the name
-            is a reasonable fallback
+          description: A word or two naming the category. A shortened version of the full name that drops any words already contained in the category's ancestors' short names. This will be used in places where the ancestor short names are in close proximity (e.g. URL slugs) to avoid having the same word many times. When this is unset, the name is a reasonable fallback
           type: string
         seo-name:
-          description: >-
-            An SEO-optimized name for the category.  A lengthened version of the
-            full name that includes additional keywords or rephrasing, suitable
-            for use in a title tag.  When this is unset, the name is a
-            reasonable fallback.
+          description: An SEO-optimized name for the category. A lengthened version of the full name that includes additional keywords or rephrasing, suitable for use in a title tag. When this is unset, the name is a reasonable fallback.
           type: string
         description:
-          description: >-
-            A sentence or two with a stand-alone category description.  When
-            this is unset, the nearest ancestor description is a reasonable
-            fallback.
+          description: A sentence or two with a stand-alone category description. When this is unset, the nearest ancestor description is a reasonable fallback.
           type: string
         image:
-          description: >-
-            A picture of this category.  When set for a fetched category, the
-            value will be a URL.  When set for an uploaded category, file IDs
-            and media URLs can be used interchangeably.
+          description: A picture of this category. When set for a fetched category, the value will be a URL. When set for an uploaded category, file IDs and media URLs can be used interchangeably.
           type: string
         parent:
           description: Category ID for the parent category.
@@ -7818,13 +7172,11 @@ components:
             description: A keyword for this category.
             type: string
         featured:
-          description: Ordering precedence for likely customer interest.  Defaults to zero.
+          description: Ordering precedence for likely customer interest. Defaults to zero.
           type: integer
           format: int32
         slug:
-          description: >-
-            A slug generated from the category short-name (or name if short-name
-            is not defined).
+          description: A slug generated from the category short-name (or name if short-name is not defined).
           type: string
       required:
         - name
@@ -7876,9 +7228,7 @@ components:
           type: integer
           format: int64
         notes:
-          description: >-
-            free-form Markdown notes for any purchase information that doesn't
-            fit into an existing field
+          description: free-form Markdown notes for any purchase information that doesn't fit into an existing field
           type: string
       required:
         - id
@@ -7900,9 +7250,7 @@ components:
           type: object
           properties:
             dropMembershipId:
-              description: >-
-                The membership ID of the customer making the order. Only
-                included if the request includes the inlined "dropMembershipId".
+              description: The membership ID of the customer making the order. Only included if the request includes the inlined "dropMembershipId".
               type: integer
               format: int64
         status:
@@ -7923,15 +7271,11 @@ components:
           type: string
           format: date-time
         target-delivery:
-          description: >-
-            planned delivery time (fixed before the trip starts, and unset for
-            parcel-carrier orders)
+          description: planned delivery time (fixed before the trip starts, and unset for parcel-carrier orders)
           type: string
           format: date-time
         estimated-delivery:
-          description: >-
-            estimated delivery time (updated after the trip starts until the
-            order is delivered, and unset for parcel-carrier orders)
+          description: estimated delivery time (updated after the trip starts until the order is delivered, and unset for parcel-carrier orders)
           type: string
           format: date-time
         delivered:
@@ -7941,16 +7285,7 @@ components:
         checkout-payment:
           $ref: '#/components/schemas/payment'
         rewards-allocation:
-          description: >-
-            Rewards allocated for this order.  For open orders, this value has
-            no side-effects.  For placed orders that are not yet shipped, this
-            value will match the associated pending rewards debit amount.  When
-            the order ships, this value does not change, but the associated
-            rewards debit will have its amount reduced if the allocated rewards
-            exceed the dollar balance.  If, instead of shipping, the placed
-            order returns to open status, the associated pending rewards debit
-            is deleted, releasing those rewards to be allocated towards other
-            orders.
+          description: Rewards allocated for this order. For open orders, this value has no side-effects. For placed orders that are not yet shipped, this value will match the associated pending rewards debit amount. When the order ships, this value does not change, but the associated rewards debit will have its amount reduced if the allocated rewards exceed the dollar balance. If, instead of shipping, the placed order returns to open status, the associated pending rewards debit is deleted, releasing those rewards to be allocated towards other orders.
           type: number
           format: float
         drop:
@@ -7958,9 +7293,7 @@ components:
           type: integer
           format: int64
         trip:
-          description: >-
-            trip delivering the order (automatically populated for
-            parcel-carrier orders)
+          description: trip delivering the order (automatically populated for parcel-carrier orders)
           type: integer
           format: int64
         address:
@@ -7968,9 +7301,7 @@ components:
         parcel-carrier-services:
           $ref: '#/components/schemas/orderParcelCarrierServices'
         perishable-shipping-warning-accepted:
-          description: >-
-            If true, the customer has accepted the warning regarding shipping
-            perishable product.
+          description: If true, the customer has accepted the warning regarding shipping perishable product.
           type: boolean
         cases-shipped:
           description: Total quantity of shipped boxes and bulk stock
@@ -7982,35 +7313,25 @@ components:
           description: Warehouse packing instructions
           type: string
         lastApiUpdate:
-          description: >-
-            a datetime denoting when the order or its order-lines were last
-            updated via the API
+          description: a datetime denoting when the order or its order-lines were last updated via the API
           type: string
         holdShipmentUntilStockAvailable:
-          description: >-
-            If true, the customer has requested to hold shipment of the order
-            until all requested stock is available.
+          description: If true, the customer has requested to hold shipment of the order until all requested stock is available.
           type: boolean
         computed:
           description: Optional computed properties included via the "computed" parameter.
           type: object
           properties:
             totalPriceOrdered:
-              description: >-
-                Dollar value for the sum of all ordered products (does not
-                include potential fees).
+              description: Dollar value for the sum of all ordered products (does not include potential fees).
               type: number
               format: float
             totalPriceShipped:
-              description: >-
-                Dollar value for the sum of all shipped products (does not
-                include potential fees).
+              description: Dollar value for the sum of all shipped products (does not include potential fees).
               type: number
               format: float
             totalFees:
-              description: >-
-                Dollar value for the sum of all order fees (pre or post
-                shipment, dependent on order status).
+              description: Dollar value for the sum of all order fees (pre or post shipment, dependent on order status).
               type: number
               format: float
             cases:
@@ -8021,9 +7342,7 @@ components:
                   type: integer
                   format: int64
                 refrigeratedAndRoomTemp:
-                  description: >-
-                    Count of cases shipped with refrigerated/room-temperature
-                    products.
+                  description: Count of cases shipped with refrigerated/room-temperature products.
                   type: integer
                   format: int64
                 greenhouse:
@@ -8092,9 +7411,7 @@ components:
                   type: number
                   format: float
                 roomTemp:
-                  description: >-
-                    Total weight (in pounds) of room temperature products
-                    ordered.
+                  description: Total weight (in pounds) of room temperature products ordered.
                   type: number
                   format: float
                 greenhouse:
@@ -8117,9 +7434,7 @@ components:
                   type: number
                   format: float
                 roomTemp:
-                  description: >-
-                    Total weight (in pounds) of room temperature products
-                    shipped.
+                  description: Total weight (in pounds) of room temperature products shipped.
                   type: number
                   format: float
                 greenhouse:
@@ -8138,15 +7453,11 @@ components:
                   type: number
                   format: float
                 refrigerated:
-                  description: >-
-                    Total volume (in cubic feet) of refrigerated products
-                    ordered.
+                  description: Total volume (in cubic feet) of refrigerated products ordered.
                   type: number
                   format: float
                 roomTemp:
-                  description: >-
-                    Total volume (in cubic feet) of room temperature products
-                    ordered.
+                  description: Total volume (in cubic feet) of room temperature products ordered.
                   type: number
                   format: float
                 greenhouse:
@@ -8165,15 +7476,11 @@ components:
                   type: number
                   format: float
                 refrigerated:
-                  description: >-
-                    Total volume (in cubic feet) of refrigerated products
-                    shipped.
+                  description: Total volume (in cubic feet) of refrigerated products shipped.
                   type: number
                   format: float
                 roomTemp:
-                  description: >-
-                    Total volume (in cubic feet) of room temperature products
-                    shipped.
+                  description: Total volume (in cubic feet) of room temperature products shipped.
                   type: number
                   format: float
                 greenhouse:
@@ -8211,9 +7518,7 @@ components:
           type: integer
           format: int64
         trip:
-          description: >-
-            trip delivering the order (automatically populated for
-            parcel-carrier orders)
+          description: trip delivering the order (automatically populated for parcel-carrier orders)
           type: integer
           format: int64
         address:
@@ -8221,19 +7526,13 @@ components:
         parcel-carrier-services:
           $ref: '#/components/schemas/orderParcelCarrierServices'
         perishable-shipping-warning-accepted:
-          description: >-
-            If true, the customer has accepted the warning regarding shipping
-            perishable product.
+          description: If true, the customer has accepted the warning regarding shipping perishable product.
           type: boolean
         notes:
-          description: >-
-            Additional information about the order, including special
-            instructions for Azure's pickers
+          description: Additional information about the order, including special instructions for Azure's pickers
           type: string
         holdShipmentUntilStockAvailable:
-          description: >-
-            If true, the customer has requested to hold shipment of the order
-            until all requested stock is available.
+          description: If true, the customer has requested to hold shipment of the order until all requested stock is available.
           type: boolean
       required:
         - customer
@@ -8245,9 +7544,7 @@ components:
         order:
           $ref: '#/components/schemas/order'
         changes:
-          description: >-
-            An array of side-effects.  Will be set if there were side-effects
-            and unset if there were none
+          description: An array of side-effects. Will be set if there were side-effects and unset if there were none
           type: array
           items:
             $ref: '#/components/schemas/orderChange'
@@ -8279,15 +7576,11 @@ components:
           type: integer
           format: int32
         refrigerated:
-          description: >-
-            Quantity of shipped boxes and bulk stock with the refrigerated
-            climate
+          description: Quantity of shipped boxes and bulk stock with the refrigerated climate
           type: integer
           format: int32
         roomTemp:
-          description: >-
-            Quantity of shipped boxes and bulk stock with the room temperature
-            climate
+          description: Quantity of shipped boxes and bulk stock with the room temperature climate
           type: integer
           format: int32
     orderLine:
@@ -8309,11 +7602,7 @@ components:
           type: integer
           format: int64
         name:
-          description: >-
-            most order lines are for packaged products, but Azure sometimes
-            bills for less concrete items like catalog ads.  This field holds a
-            brief description of the line, and should be used for invoices
-            instead of following packaged-product (which may not be set).
+          description: most order lines are for packaged products, but Azure sometimes bills for less concrete items like catalog ads. This field holds a brief description of the line, and should be used for invoices instead of following packaged-product (which may not be set).
           type: string
         quantity-ordered:
           description: number of product instances requested
@@ -8324,39 +7613,26 @@ components:
           type: number
           format: float
         weight:
-          description: >-
-            weight of the shipped products in pounds (estimated until picking
-            time)
+          description: weight of the shipped products in pounds (estimated until picking time)
           type: number
           format: float
         volume:
-          description: >-
-            volume of the shipped products in cubic feet (estimated until
-            picking time)
+          description: volume of the shipped products in cubic feet (estimated until picking time)
           type: number
           format: float
         price:
-          description: >-
-            the total price for this line in dollars (estimated until picking
-            time).  The per-unit price used to calculate this total is currently
-            locked in when you place the order.
+          description: the total price for this line in dollars (estimated until picking time). The per-unit price used to calculate this total is currently locked in when you place the order.
           type: number
           format: float
         rewards:
-          description: >-
-            The total rewards earned by this line (estimated until picking
-            time).  The per-unit rewards used to calculate this total are
-            currently locked in when you place the order.
+          description: The total rewards earned by this line (estimated until picking time). The per-unit rewards used to calculate this total are currently locked in when you place the order.
           type: number
           format: float
         warnings:
           description: An array of warnings about this product.
           type: array
           items:
-            description: >-
-              Warnings about products that a customer can associate with this
-              order, but maybe should not (e.g. that is is likely to expire
-              before reaching the customer)
+            description: Warnings about products that a customer can associate with this order, but maybe should not (e.g. that is is likely to expire before reaching the customer)
             type: string
       required:
         - id
@@ -8377,11 +7653,7 @@ components:
           description: packaged product code that is being ordered
           type: string
         name:
-          description: >-
-            most order lines are for packaged products, but Azure sometimes
-            bills for less concrete items like catalog ads.  This field holds a
-            brief description of the line, and should be used for invoices
-            instead of following packaged-product (which may not be set).
+          description: most order lines are for packaged products, but Azure sometimes bills for less concrete items like catalog ads. This field holds a brief description of the line, and should be used for invoices instead of following packaged-product (which may not be set).
           type: string
         quantity-ordered:
           description: number of product instances requested
@@ -8391,9 +7663,7 @@ components:
         - order
         - quantity-ordered
     orderFee:
-      description: >-
-        An additional charge associated with an order (estimated until picking
-        time).
+      description: An additional charge associated with an order (estimated until picking time).
       type: object
       properties:
         id:
@@ -8427,22 +7697,15 @@ components:
         - shipping
         - small-order
     dropShippingFee:
-      description: >-
-        information for calculating shipping costs for orders delivered to a
-        stop
+      description: information for calculating shipping costs for orders delivered to a stop
       type: object
       properties:
         percent:
-          description: >-
-            the `shipping` order fee is the total order-line price over all
-            lines on the order, multiplied by this percentage, and then rounded
-            to the nearest cent.
+          description: the `shipping` order fee is the total order-line price over all lines on the order, multiplied by this percentage, and then rounded to the nearest cent.
           type: number
           format: float
     orderParcelCarrierEstimate:
-      description: >-
-        A parcel carrier shipping estimate for a given order or portion of
-        order.
+      description: A parcel carrier shipping estimate for a given order or portion of order.
       type: object
       properties:
         cost:
@@ -8457,10 +7720,7 @@ components:
           items:
             $ref: '#/components/schemas/shippingService'
         expires:
-          description: >-
-            The date-time when this estimate expires.  Orders placed for this
-            climate/service after that expiration may have a different fee or
-            delivery estimates.
+          description: The date-time when this estimate expires. Orders placed for this climate/service after that expiration may have a different fee or delivery estimates.
           type: string
           format: date-time
         shipping-date:
@@ -8468,21 +7728,15 @@ components:
           type: string
           format: date
         earliest-delivery:
-          description: >-
-            The estimated earliest delivery date (inclusive) for the covered
-            order-lines.
+          description: The estimated earliest delivery date (inclusive) for the covered order-lines.
           type: string
           format: date
         latest-delivery:
-          description: >-
-            The estimated latest delivery date (inclusive) for the covered
-            order-lines.
+          description: The estimated latest delivery date (inclusive) for the covered order-lines.
           type: string
           format: date
         contact-for-quote:
-          description: >-
-            The customer should contact this person or team for a personalized
-            shipping quote for this service.
+          description: The customer should contact this person or team for a personalized shipping quote for this service.
           type: object
           properties:
             name:
@@ -8547,9 +7801,7 @@ components:
           type: integer
           format: int64
         amount:
-          description: >-
-            dollar value for the entry (positive for credits like customer
-            payments, negative for debits like order charges)
+          description: dollar value for the entry (positive for credits like customer payments, negative for debits like order charges)
           type: number
           format: float
         date:
@@ -8557,9 +7809,7 @@ components:
           type: string
           format: date
         notes:
-          description: >-
-            a line of Markdown identifying the entry (e.g. "charge for order
-            123" or "payed with card ending in 0123").
+          description: a line of Markdown identifying the entry (e.g. "charge for order 123" or "payed with card ending in 0123").
           type: string
         balance:
           description: account balance after this account entry
@@ -8595,17 +7845,13 @@ components:
         address:
           $ref: '#/components/schemas/address'
         issuer:
-          description: >-
-            provider network.  You can determine this from the leading digits of
-            the card number, but we don't store those digits
+          description: provider network. You can determine this from the leading digits of the card number, but we don't store those digits
           type: string
         last-four:
           description: last four digits of the card number for identification
           type: string
         expiration:
-          description: >-
-            expiration date.  We only use the month and year; the day will
-            always be '01'.
+          description: expiration date. We only use the month and year; the day will always be '01'.
           type: string
           format: date
       required:
@@ -8618,10 +7864,7 @@ components:
         - last-four
         - expiration
     newCreditCard:
-      description: >-
-        Azure does not store much credit card information internally (we use an
-        external card processor), but we do need all of the information for the
-        initial upload so we can pass it along to the external processor.
+      description: Azure does not store much credit card information internally (we use an external card processor), but we do need all of the information for the initial upload so we can pass it along to the external processor.
       type: object
       properties:
         type:
@@ -8630,9 +7873,7 @@ components:
           enum:
             - credit-card
         active:
-          description: >-
-            whether or not this payment method is available for further
-            activity.  Defaults to true
+          description: whether or not this payment method is available for further activity. Defaults to true
           type: boolean
         person:
           description: person associated with this payment method
@@ -8652,9 +7893,7 @@ components:
           description: security code (also known as the verification value)
           type: string
         expiration:
-          description: >-
-            expiration date.  We only use the month and year and ignore the day
-            (which you should set to '01').
+          description: expiration date. We only use the month and year and ignore the day (which you should set to '01').
           type: string
           format: date
       required:
@@ -8666,22 +7905,14 @@ components:
         - security-code
         - expiration
     genericPaymentMethod:
-      description: >-
-        one of our supported payment methods that does not have properties
-        beyond the generic payment-method properties
+      description: one of our supported payment methods that does not have properties beyond the generic payment-method properties
       type: object
       properties:
         id:
           type: integer
           format: int64
         type:
-          description: >-
-            string identifying this payment method.  cash-on-delivery means
-            customers must pay for their order in cash to pick up the order.
-            hold-for-payment means customers must pay for the order before Azure
-            will ship it.  net-N means the order must be paid for within N
-            days.  payroll-deduction means the invoiced price will be deducted
-            from the customer's (an Azure employee) next paycheck.
+          description: string identifying this payment method. cash-on-delivery means customers must pay for their order in cash to pick up the order. hold-for-payment means customers must pay for the order before Azure will ship it. net-N means the order must be paid for within N days. payroll-deduction means the invoiced price will be deducted from the customer's (an Azure employee) next paycheck.
           type: string
           enum:
             - cash-on-delivery
@@ -8709,9 +7940,7 @@ components:
       anyOf:
         - $ref: '#/components/schemas/newCreditCard'
     payment:
-      description: >-
-        A payment instance where an amount will be (or has been) charged via a
-        payment-method.
+      description: A payment instance where an amount will be (or has been) charged via a payment-method.
       type: object
       properties:
         payment-method:
@@ -8722,9 +7951,7 @@ components:
           description: The type of payment used
           type: string
         last-four:
-          description: >-
-            The last four digits of the credit card used. Only included if the
-            payment type is Credit Card
+          description: The last four digits of the credit card used. Only included if the payment type is Credit Card
           type: string
         amount:
           description: Amount to charge (or which was charged) in dollars
@@ -8747,15 +7974,11 @@ components:
         address:
           $ref: '#/components/schemas/address'
         email:
-          description: >-
-            The registrant's primary email address.  Will have a preference
-            level of 100.
+          description: The registrant's primary email address. Will have a preference level of 100.
           type: string
           format: email
         telephone:
-          description: >-
-            The registrant's telephone numbers (currently only supports 'voice'
-            and 'text' types)
+          description: The registrant's telephone numbers (currently only supports 'voice' and 'text' types)
           type: array
           items:
             $ref: '#/components/schemas/telephone'
@@ -8766,11 +7989,7 @@ components:
         context:
           $ref: '#/components/schemas/registrationContext'
         authentication-base-url:
-          description: >-
-            Redirect URL for the authentication UI.  The authentication
-            notification points customers at
-            {authentication-base-url}{authentication-token} to authenticate a
-            new session.
+          description: Redirect URL for the authentication UI. The authentication notification points customers at {authentication-base-url}{authentication-token} to authenticate a new session.
           type: string
           format: url
         post-affiliate-pro:
@@ -8780,9 +7999,7 @@ components:
         - email
         - authentication-base-url
     registrationContext:
-      description: >-
-        The context in which the registration request is being made (to select
-        between available notification templates).  Defaults to "registration".
+      description: The context in which the registration request is being made (to select between available notification templates). Defaults to "registration".
       type: string
       enum:
         - registration
@@ -8800,9 +8017,7 @@ components:
           type: integer
           format: int64
         amount:
-          description: >-
-            Reward value for the entry (positive for credits, negative for
-            debits).
+          description: Reward value for the entry (positive for credits, negative for debits).
           type: number
           format: float
         type:
@@ -8814,22 +8029,15 @@ components:
             - expired
             - promotion
         settled:
-          description: >-
-            When the entry was settled.  This will be unset for pending debits,
-            and will be set for all settled debits.
+          description: When the entry was settled. This will be unset for pending debits, and will be set for all settled debits.
           type: string
           format: date-time
         order:
-          description: >-
-            The order which produced (for credits) or consumed (for debits) this
-            entry.
+          description: The order which produced (for credits) or consumed (for debits) this entry.
           type: integer
           format: int64
         account-entry:
-          description: >-
-            The account-entry credit created by this entry.  This will be set
-            for rewards debits where the referenced account-entry credit shows
-            the dollar increase associated with this rewards decrease.
+          description: The account-entry credit created by this entry. This will be set for rewards debits where the referenced account-entry credit shows the dollar increase associated with this rewards decrease.
           type: integer
           format: int64
         total-credit:
@@ -8853,22 +8061,17 @@ components:
         - amount
         - order
     postAffiliatePro:
-      description: >-
-        Business logic around the affiliate program is handled by Beehive.  If
-        Beehive determines the referrer is due credit then this information is
-        passed on to Post Affiliate Pro as a sale.
+      description: Business logic around the affiliate program is handled by Beehive. If Beehive determines the referrer is due credit then this information is passed on to Post Affiliate Pro as a sale.
       type: object
       properties:
         referrer:
           description: Post Affiliate Pro referring affiliate code.
           type: string
         visitor:
-          description: Post Affiliate Pro visitor id.  This information is opaque to Azure.
+          description: Post Affiliate Pro visitor id. This information is opaque to Azure.
           type: string
         banner:
-          description: >-
-            Post Affiliate Pro banner ad id.  This information is opaque to
-            Azure.
+          description: Post Affiliate Pro banner ad id. This information is opaque to Azure.
           type: string
       required:
         - referrer
@@ -8880,12 +8083,10 @@ components:
         session:
           $ref: '#/components/schemas/session'
         auth-token:
-          description: Auth token.  Can be sent to login to authenticate a new session.
+          description: Auth token. Can be sent to login to authenticate a new session.
           type: string
         resend-token:
-          description: >-
-            Resend token.  Can be sent to resendRegistrationNotification to
-            trigger a new registration notification.
+          description: Resend token. Can be sent to resendRegistrationNotification to trigger a new registration notification.
           type: string
       required:
         - session
@@ -8897,11 +8098,7 @@ components:
         context:
           $ref: '#/components/schemas/registrationContext'
         authentication-base-url:
-          description: >-
-            Redirect URL for the authentication UI.  The authentication
-            notification points customers at
-            {authentication-base-url}{authentication-token} to authenticate a
-            new session.
+          description: Redirect URL for the authentication UI. The authentication notification points customers at {authentication-base-url}{authentication-token} to authenticate a new session.
           type: string
           format: url
         token:
@@ -8924,9 +8121,7 @@ components:
       type: object
       properties:
         username:
-          description: >-
-            Username for authentication.  Instead of your username, you could
-            also use your primary email address or your person ID here
+          description: Username for authentication. Instead of your username, you could also use your primary email address or your person ID here
           type: string
         password:
           description: Password for authentication
@@ -8939,17 +8134,11 @@ components:
       type: object
       properties:
         base-url:
-          description: >-
-            Redirect URL for the password reset UI.  The password reset email
-            points customers at {base-url}{confirmation-token} to confirm their
-            password reset.
+          description: Redirect URL for the password reset UI. The password reset email points customers at {base-url}{confirmation-token} to confirm their password reset.
           type: string
           format: url
         email:
-          description: >-
-            The email address for the person whose password will be reset.
-            Instead of the email address, you may also use your username or
-            person ID here
+          description: The email address for the person whose password will be reset. Instead of the email address, you may also use your username or person ID here
           type: string
       required:
         - base-url
@@ -8999,7 +8188,7 @@ components:
         - text
         - voice
     person:
-      description: 'a person (customer, vendor, employee, ...)'
+      description: a person (customer, vendor, employee, ...)
       type: object
       properties:
         id:
@@ -9008,17 +8197,13 @@ components:
         name:
           type: string
         active:
-          description: >-
-            Whether or not this account is active.  Inactive users cannot log
-            in.
+          description: Whether or not this account is active. Inactive users cannot log in.
           type: boolean
         password-usable:
           description: Whether or not this account has a usable password.
           type: boolean
         email:
-          description: >-
-            The person's preferred, error-less email address (set if the
-            "inline" query parameter contains "email").
+          description: The person's preferred, error-less email address (set if the "inline" query parameter contains "email").
           type: string
           format: email
         can-email:
@@ -9036,12 +8221,7 @@ components:
         price-level:
           $ref: '#/components/schemas/priceLevel'
         rewards-rate:
-          description: >-
-            Rewards rate (as a percentage) for this customer.  The rewards
-            earned for a product will be the price (after sales) *
-            min(max(`person.rewards-rate`, `product.rewards-rate`),
-            `product.maxRewardsRate`) / 100, rounded to the nearest cent,
-            rounding half to even.
+          description: Rewards rate (as a percentage) for this customer. The rewards earned for a product will be the price (after sales) * min(max(`person.rewards-rate`, `product.rewards-rate`), `product.maxRewardsRate`) / 100, rounded to the nearest cent, rounding half to even.
           type: integer
           format: int32
           minimum: 0
@@ -9053,22 +8233,14 @@ components:
           items:
             $ref: '#/components/schemas/permission'
         order-place-issue:
-          description: >-
-            If the person should be warned or blocked from placing orders, this
-            property will be set with a slugged reason and recommended action.
-            Only set if the "inline" query parameter contains
-            "order-place-issue".
+          description: If the person should be warned or blocked from placing orders, this property will be set with a slugged reason and recommended action. Only set if the "inline" query parameter contains "order-place-issue".
           type: string
           enum:
             - outstanding-balance-contact
             - outstanding-balance-pay
             - outstanding-balance-warn
         internal-notes:
-          description: >-
-            free-form Markdown notes for any internal information that doesn't
-            fit into an existing field.  Only Azure employees can view or edit
-            this information, although it may be passed into the registerPerson
-            endpoint when registering new people.
+          description: free-form Markdown notes for any internal information that doesn't fit into an existing field. Only Azure employees can view or edit this information, although it may be passed into the registerPerson endpoint when registering new people.
           type: string
         affiliate-code:
           description: Affiliate code to be used with URL shares.
@@ -9087,60 +8259,43 @@ components:
             - lead
             - community
         marketing-slug:
-          description: >-
-            A person's unique, primary marketing slug used, e.g., for the Azure
-            Share program.
+          description: A person's unique, primary marketing slug used, e.g., for the Azure Share program.
           type: string
         recency:
-          description: >-
-            Order recency ranking.  Higher rankings for customers with more
-            recent orders.
+          description: Order recency ranking. Higher rankings for customers with more recent orders.
           type: integer
           format: int32
           minimum: 1
           maximum: 5
         frequency:
-          description: >-
-            Order frequency ranking.  Higher rankings for customers with more
-            frequent orders.
+          description: Order frequency ranking. Higher rankings for customers with more frequent orders.
           type: integer
           format: int32
           minimum: 1
           maximum: 5
         monetary:
-          description: >-
-            Order value ranking.  Higher rankings for customers with larger
-            orders.
+          description: Order value ranking. Higher rankings for customers with larger orders.
           type: integer
           format: int32
           minimum: 1
           maximum: 5
         first-order-placed:
-          description: >-
-            When this customer's first order was placed.  This timestamp does
-            not change once set, even if the initial order is subsequently
-            deleted.
+          description: When this customer's first order was placed. This timestamp does not change once set, even if the initial order is subsequently deleted.
           type: string
           format: date-time
         last-order-placed:
-          description: >-
-            When this customer's most recent order was placed.  This timestamp
-            includes all open-to-placed transitions, regardless of whether the
-            related order is subsequently deleted.
+          description: When this customer's most recent order was placed. This timestamp includes all open-to-placed transitions, regardless of whether the related order is subsequently deleted.
           type: string
           format: date-time
         is-drop-coordinator:
-          description: >-
-            Is a drop coordinator (inclusive of both primary contact and
-            managers). Only set if the "inline" query parameter contains
-            "is-drop-coordinator".
+          description: Is a drop coordinator (inclusive of both primary contact and managers). Only set if the "inline" query parameter contains "is-drop-coordinator".
           type: boolean
       required:
         - id
         - name
         - notifications
     updatePerson:
-      description: 'a person (customer, vendor, employee, ...)'
+      description: a person (customer, vendor, employee, ...)
       type: object
       properties:
         name:
@@ -9149,39 +8304,27 @@ components:
           description: Password for authentication
           type: string
         can-email:
-          description: >-
-            Can Azure contact this person for reasons other than registration?
-            Defaults to true when creating a person
+          description: Can Azure contact this person for reasons other than registration? Defaults to true when creating a person
           type: boolean
         sale-magazine:
-          description: >-
-            Subscribed to receive the sale magazine?  Defaults to false when
-            creating a person
+          description: Subscribed to receive the sale magazine?  Defaults to false when creating a person
           type: boolean
         company:
           description: Employer name
           type: string
         allow-social-media:
-          description: >-
-            Does this person want social media links to display?  Defaults to
-            true when creating a person
+          description: Does this person want social media links to display?  Defaults to true when creating a person
           type: boolean
         notifications:
           $ref: '#/components/schemas/personNotifications'
         affiliate-code:
-          description: >-
-            Affiliate code to be used with URL shares.  Only users with the
-            update-person permission can edit this information.
+          description: Affiliate code to be used with URL shares. Only users with the update-person permission can edit this information.
           type: string
         is-allowed-to-be-affiliate:
-          description: >-
-            Is allowed to be an affiliate.  Only users with the update-person
-            permission can edit this information.
+          description: Is allowed to be an affiliate. Only users with the update-person permission can edit this information.
           type: boolean
     updatePersonUserPassword:
-      description: >-
-        a person (customer, vendor, employee, ...) with the logged in user's
-        password
+      description: a person (customer, vendor, employee, ...) with the logged in user's password
       type: object
       properties:
         name:
@@ -9202,9 +8345,7 @@ components:
           description: Does this person want social media links to display
           type: boolean
         user-password:
-          description: >-
-            The authenticated person's password.  Required when changing
-            password for users with a usable password.
+          description: The authenticated person's password. Required when changing password for users with a usable password.
           type: string
         notifications:
           $ref: '#/components/schemas/personNotifications'
@@ -9223,7 +8364,7 @@ components:
           items:
             $ref: '#/components/schemas/notificationChannel'
         delivery:
-          description: 'sent after order delivery, and after updates to delivery estimates.'
+          description: sent after order delivery, and after updates to delivery estimates.
           format: array
           items:
             $ref: '#/components/schemas/notificationChannel'
@@ -9241,15 +8382,11 @@ components:
               - paper
               - email
     address:
-      description: >-
-        an address following the convention of
-        http://microformats.org/wiki/h-adr and
-        https://tools.ietf.org/html/rfc6350#section-6.3.1, with an additional
-        "name" property
+      description: An address following the convention of http://microformats.org/wiki/h-adr and https://tools.ietf.org/html/rfc6350#section-6.3.1, with an additional `name` property
       type: object
       properties:
         name:
-          description: 'contact name for this address (e.g. "Mr. John Q. Public, Esq.")'
+          description: contact name for this address (e.g. "Mr. John Q. Public, Esq.")
           type: string
         post-office-box:
           type: string
@@ -9260,20 +8397,15 @@ components:
         locality:
           type: string
         region:
-          description: >-
-            required for the United States and Canada, optional for other
-            countries
+          description: required for the United States and Canada, optional for other countries
           type: string
         postal-code:
           type: string
         country:
-          description: >-
-            ISO 3166-1 alpha-3 code for the country.  On push, you can set the
-            alpha-2 code or case-insensitve name instead, or you can use an
-            inline country object.
+          description: ISO 3166-1 alpha-3 code for the country. On push, you can set the alpha-2 code or case-insensitve name instead, or you can use an inline country object.
           type: string
         preference:
-          description: ordering precedence for the findAddresses.  Defaults to zero.
+          description: ordering precedence for the findAddresses. Defaults to zero.
           type: integer
           format: int32
       required:
@@ -9352,9 +8484,7 @@ components:
           type: integer
           format: int64
         error:
-          description: >-
-            Reason for not using this address (e.g. "email bounced on
-            2016-08-15").
+          description: Reason for not using this address (e.g. "email bounced on 2016-08-15").
           type: string
         preference:
           description: Ordering precedence for the findEmails.
@@ -9365,17 +8495,13 @@ components:
         - address
         - person
     updateEmailUserPassword:
-      description: >-
-        A request for adding or updating an email address with the logged in
-        user's password
+      description: A request for adding or updating an email address with the logged in user's password
       type: object
       properties:
         email:
           $ref: '#/components/schemas/email'
         user-password:
-          description: >-
-            The authenticated person's password.  Required for users with a
-            usable password.
+          description: The authenticated person's password. Required for users with a usable password.
           type: string
       required:
         - email
@@ -9468,11 +8594,7 @@ components:
           type: integer
           format: int64
         expires:
-          description: >-
-            current expiration date-time for this session
-            (http://tools.ietf.org/html/rfc6265#section-5.3, covering both
-            Max-Age and Expires representations, unset if the session expires at
-            browser-close)
+          description: current expiration date-time for this session (http://tools.ietf.org/html/rfc6265#section-5.3, covering both Max-Age and Expires representations, unset if the session expires at browser-close)
           type: string
           format: date-time
     notification:
@@ -9488,9 +8610,7 @@ components:
           type: boolean
         dismissed:
           type: boolean
-          description: >-
-            if annotate-person is specified in the request, this field will note
-            if the notification has been dismissed
+          description: if annotate-person is specified in the request, this field will note if the notification has been dismissed
       required:
         - id
         - message
@@ -9519,14 +8639,10 @@ components:
           type: integer
           format: int64
         name:
-          description: >-
-            sentence-length product name.  Copied from `#definitions/product`
-            for easier UI development
+          description: sentence-length product name. Copied from `#definitions/product` for easier UI development
           type: string
         packaging:
-          description: >-
-            all related audited and/or non-audited packaged versions of this
-            product
+          description: all related audited and/or non-audited packaged versions of this product
           type: array
           items:
             $ref: '#/components/schemas/packagedProductAudit'
@@ -9545,22 +8661,13 @@ components:
           description: the old size of the product (e.g. "12 oz." or "6x12 oz.")
           type: string
         packs:
-          description: >-
-            the new dimensions of package sizes (e.g. "4", "4x32.5", or
-            "2x4x32.5")
+          description: the new dimensions of package sizes (e.g. "4", "4x32.5", or "2x4x32.5")
           type: string
         unit:
-          description: >-
-            the new unit of measurement.  You can use any string, but the
-            backend will only be able to make automatic comparisons if you use
-            SI prefixes (e.g. "mm" for millimeters) and stick to the following
-            base units: pound, ounce, gram, gallon, liter, quart, pint, cup,
-            fluid ounce, yard, and count
+          description: 'The new unit of measurement. You can use any string, but the backend will only be able to make automatic comparisons if you use SI prefixes (e.g. "mm" for millimeters) and stick to the following base units: pound, ounce, gram, gallon, liter, quart, pint, cup, fluid ounce, yard, and count'
           type: string
         audited:
-          description: >-
-            a datetime denoting if and when the packaged-product was last
-            audited
+          description: a datetime denoting if and when the packaged-product was last audited
           type: string
       required:
         - id
@@ -9573,26 +8680,16 @@ components:
       type: object
       properties:
         packs:
-          description: >-
-            the new dimensions of package sizes (e.g. "4", "4x32.5", or
-            "2x4x32.5")
+          description: the new dimensions of package sizes (e.g. "4", "4x32.5", or "2x4x32.5")
           type: string
         unit:
-          description: >-
-            the new unit of measurement.  Ideally one of "", or "", but you can
-            use another unit if none of those fit.
+          description: the new unit of measurement. Ideally one of "", or "", but you can use another unit if none of those fit.
           type: string
         size:
-          description: >-
-            override the auto-generated size (based on packs and unit) with a
-            custom name.  This can be useful for adding packaging information
-            (e.g. "32 floz glass" to distinguish glass from plastic vinegar
-            bottles).
+          description: override the auto-generated size (based on packs and unit) with a custom name. This can be useful for adding packaging information (e.g. "32 floz glass" to distinguish glass from plastic vinegar bottles).
           type: string
         clear-audited:
-          description: >-
-            If true, clear the audited date-time for this packaged-product.  If
-            false (the default), set the audited date-time to the current time.
+          description: If true, clear the audited date-time for this packaged-product. If false (the default), set the audited date-time to the current time.
           type: boolean
       required:
         - packs
@@ -9679,7 +8776,7 @@ components:
         - message
       properties:
         code:
-          description: 'HTTP error code (https://tools.ietf.org/html/rfc7231#section-6).'
+          description: HTTP error code (https://tools.ietf.org/html/rfc7231#section-6).
           type: integer
           format: int32
         message:

--- a/public.yaml
+++ b/public.yaml
@@ -574,7 +574,8 @@ paths:
                 $ref: '#/components/schemas/error'
   '/bartender-print-configuration/{id}/actions/test-print':
     post:
-      summary: Create a test BarTender print request using this print configuration. The print request uses hard-coded dummy data if a stock ID is not provided.
+      summary: Create a test BarTender print request
+      description: Create a test BarTender print request using this print configuration. The print request uses hard-coded dummy data if a stock ID is not provided.
       operationId: actionTestBartenderPrintConfiguration
       tags:
         - bartender

--- a/public.yaml
+++ b/public.yaml
@@ -7269,8 +7269,7 @@ components:
         name:
           type: string
         description:
-|-
-            type: string
+          type: string
         cutoff-frequency:
           description: |-
             Number of days between cutoffs.
@@ -7326,8 +7325,7 @@ components:
       type: object
       properties:
         description:
-|-
-            type: string
+          type: string
         cutoff-frequency:
           description: |-
             Number of days between cutoffs.
@@ -7812,14 +7810,12 @@ components:
             HTML description applicable only when the product is inactive (out for season, out long term, or discontinued). It should contain specific information pertinent to the inactive status of the product (e.g. details about why it is inactive and what similar products are available instead). It should not duplicate information in short-description or description.
           type: string
         short-description:
-|-
-            description: |-
-  Paragraph-length, stand-alone, plain-text product description.
+          description: |-
+            Paragraph-length, stand-alone, plain-text product description.
           type: string
         description:
-|-
-            description: |-
-  Long-form, HTML product description. When short-description is set, this value is for additional information which did not fit into short-description. Displaying both short-description and description is not redundant. Displaying only description may be confusing when short-description is available.
+          description: |-
+            Long-form, HTML product description. When short-description is set, this value is for additional information which did not fit into short-description. Displaying both short-description and description is not redundant. Displaying only description may be confusing when short-description is available.
           type: string
         brand:
           description: |-
@@ -8031,9 +8027,8 @@ components:
             An SEO-optimized name for the category. A lengthened version of the full name that includes additional keywords or rephrasing, suitable for use in a title tag. When this is unset, the name is a reasonable fallback.
           type: string
         description:
-|-
-            description: |-
-  A sentence or two with a stand-alone category description. When this is unset, the nearest ancestor description is a reasonable fallback.
+          description: |-
+            A sentence or two with a stand-alone category description. When this is unset, the nearest ancestor description is a reasonable fallback.
           type: string
         image:
           description: |-
@@ -8099,9 +8094,8 @@ components:
             An SEO-optimized name for the category. A lengthened version of the full name that includes additional keywords or rephrasing, suitable for use in a title tag. When this is unset, the name is a reasonable fallback.
           type: string
         description:
-|-
-            description: |-
-  A sentence or two with a stand-alone category description. When this is unset, the nearest ancestor description is a reasonable fallback.
+          description: |-
+            A sentence or two with a stand-alone category description. When this is unset, the nearest ancestor description is a reasonable fallback.
           type: string
         image:
           description: |-


### PR DESCRIPTION
Details: 

- Adds a "Style Guide" section to the readme.
- Makes formatting changes to match those specified in the style guide.
- Removes the block start syntax (`>-`) from `summary` properties (as `summary` should always be a simple string)
- Replaces the block start syntax (`>-`) on the `description` properties with `|-` (see https://yaml-multiline.info/ for differences). This is to support new lines in the description values, which are utilized by documentation tools. Also, when editing in Stoplight.io, this is the block start syntax that gets used, so another motivation for this is to prevent merge conflicts when editing between different tools.