### PR TITLE
Add parcelCarrierShipByDate field to the spec for updateOrder endpoint

### DIFF
--- a/spec.json
+++ b/spec.json
@@ -11377,6 +11377,11 @@
           "holdShipmentUntilStockAvailable": {
             "description": "If true, the customer has requested to hold shipment of the order until all requested stock is available.",
             "type": "boolean"
+          },
+          "parcelCarrierShipByDate": {
+            "description": "For parcel carrier orders, this is the date the order needs to ship by.",
+            "type": "string",
+            "format": "date"
           }
         },
         "required": [

--- a/spec.json
+++ b/spec.json
@@ -11096,7 +11096,7 @@
             "type": "boolean"
           },
           "parcelCarrierShipByDate": {
-            "description": "For parcel carrier orders, this is the date the order needs to ship by.",
+            "description": "For parcel carrier orders, this is the date the order needs to ship by. Since we are using ISO format, the string can either be a date or datetime but it will be stored on the backend as a date.",
             "type": "string",
             "format": "date"
           },
@@ -11384,7 +11384,7 @@
             "type": "boolean"
           },
           "parcelCarrierShipByDate": {
-            "description": "For parcel carrier orders, this is the date the order needs to ship by.",
+            "description": "For parcel carrier orders, this is the date the order needs to ship by. Since we are using ISO format, the string can either be a date or datetime but it will be stored on the backend as a date.",
             "type": "string",
             "format": "date"
           }

--- a/spec.json
+++ b/spec.json
@@ -11095,6 +11095,11 @@
             "description": "If true, the customer has requested to hold shipment of the order until all requested stock is available.",
             "type": "boolean"
           },
+          "parcelCarrierShipByDate": {
+            "description": "For parcel carrier orders, this is the date the order needs to ship by.",
+            "type": "string",
+            "format": "date"
+          },
           "computed": {
             "description": "Optional computed properties included via the \"computed\" parameter.",
             "type": "object",


### PR DESCRIPTION
This is for the latest code in PR: https://github.com/azurestandard/beehive/pull/5188 

@igregson I could not remember how to update this spec in the UI of https://azurestandard.stoplight.io/docs/api-spec/public.yaml so I just modified the code manually in the spec.json to add the field that is now getting returned in the `updateOrder` endpoint. 