### PR TITLE
Make fixes/improvements to packaged-products endpoints

### DIFF
--- a/spec.json
+++ b/spec.json
@@ -9105,7 +9105,6 @@
               "favorites",
               "next-purchase-arrival",
               "quantity-on-next-purchase",
-              "image",
               "product",
               "vendors"
             ]
@@ -10411,8 +10410,8 @@
             "type": "number",
             "format": "float"
           },
-          "image": {
-            "description": "Image URLs of for this package. This will only be included if the `inline` query parameter includes `image`.",
+          "images": {
+            "description": "Image URLs of for this package.",
             "type": "array",
             "items": {
               "type": "string"

--- a/spec.json
+++ b/spec.json
@@ -3436,11 +3436,10 @@
     },
     "/audit/products": {
       "get": {
-        "summary": "Returns all products and their packaging from the system",
+        "summary": "Returns all products and their packaging from the system (for audit)",
         "operationId": "findProductAudits",
         "tags": [
-          "audit",
-          "product"
+          "audit"
         ],
         "parameters": [
           {
@@ -3530,11 +3529,10 @@
     },
     "/audit/product/{id}": {
       "get": {
-        "summary": "Returns a product based on a single ID",
+        "summary": "Returns a product based on a single ID (for audit)",
         "operationId": "findProductAuditById",
         "tags": [
-          "audit",
-          "product"
+          "audit"
         ],
         "parameters": [
           {
@@ -3585,8 +3583,7 @@
         "summary": "Audit an existing packaged-product",
         "operationId": "updatePackagedProductAudit",
         "tags": [
-          "audit",
-          "product"
+          "audit"
         ],
         "parameters": [
           {
@@ -3903,7 +3900,7 @@
         "summary": "Returns all packaged products from the system that the user has access to",
         "operationId": "findPackagedProduct",
         "tags": [
-          "product"
+          "packaged-product"
         ],
         "parameters": [
           {
@@ -4106,7 +4103,7 @@
         "summary": "Returns a packaged product based on a single ID, if the user has access to the packaged product",
         "operationId": "findPackagedProductById",
         "tags": [
-          "product"
+          "packaged-product"
         ],
         "parameters": [
           {
@@ -4119,17 +4116,7 @@
             }
           },
           {
-            "name": "inline",
-            "in": "query",
-            "description": "For convenience, include a full representation of the inlined property. Currently supports the local \"favorites\", \"next-purchase-arrival\", and \"quantity-on-next-purchase\" as well as \"image\", \"product\", \"vendors\", and descendants.",
-            "required": false,
-            "style": "form",
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
+            "$ref": "#/components/parameters/packagedProductInline"
           }
         ],
         "responses": {
@@ -4161,8 +4148,7 @@
         "summary": "Returns all packaged product images from the system that the user has access to",
         "operationId": "findPackagedProductImages",
         "tags": [
-          "image",
-          "product"
+          "packaged-product-image"
         ],
         "parameters": [
           {
@@ -4239,8 +4225,7 @@
         "summary": "Add a packaged product image",
         "operationId": "addPackagedProductImage",
         "tags": [
-          "image",
-          "product"
+          "packaged-product-image"
         ],
         "responses": {
           "200": {
@@ -4282,8 +4267,7 @@
         "summary": "Returns a packaged product image based on a single ID, if the user has access to that object",
         "operationId": "findPackagedProductImageById",
         "tags": [
-          "image",
-          "product"
+          "packaged-product-image"
         ],
         "parameters": [
           {
@@ -4323,8 +4307,7 @@
         "summary": "Update a packaged product image",
         "operationId": "updatePackagedProductImage",
         "tags": [
-          "image",
-          "product"
+          "packaged-product-image"
         ],
         "parameters": [
           {
@@ -4376,8 +4359,7 @@
         "summary": "Delete a packaged product image",
         "operationId": "deletePackagedProductImage",
         "tags": [
-          "image",
-          "product"
+          "packaged-product-image"
         ],
         "parameters": [
           {
@@ -10432,7 +10414,7 @@
             "type": "boolean"
           },
           "favorites": {
-            "description": "Number of people who've marked this packaged product as a favorite.",
+            "description": "Number of people who've marked this packaged product as a favorite. This will only be included if the `inline` query parameter includes `favorites`.",
             "type": "integer",
             "format": "int32"
           },
@@ -10456,7 +10438,7 @@
             "type": "string"
           },
           "product": {
-            "description": "The product that this packaging packages.",
+            "description": "The product's ID, unless the `inline` query parameter includes `product`, in which case this is a product object (though it doesn't currently return the whole product response).",
             "type": "integer",
             "format": "int64"
           },
@@ -10464,6 +10446,30 @@
             "description": "The id of the primary category for this packaged product.",
             "type": "integer",
             "format": "int64"
+          },
+          "next-purchase-arrival": {
+            "description": "When the next stock of this packaged is expected to arrive at the warehouse. This will only be included if the `inline` query parameter includes `next-purchase-arrival`.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "quantity-on-next-purchase": {
+            "description": "Package quantity arriving on the next-purchase-arrival. This will only be included if the `inline` query parameter includes `quantity-on-next-purchase`.",
+            "type": "number",
+            "format": "float"
+          },
+          "image": {
+            "description": "Image URLs of for this package. This will only be included if the `inline` query parameter includes `image`.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "vendors": {
+            "description": "This will only be included if the `inline` query parameter includes `vendors`.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/vendor"
+            }
           }
         },
         "required": [

--- a/spec.json
+++ b/spec.json
@@ -4041,17 +4041,7 @@
             }
           },
           {
-            "name": "inline",
-            "in": "query",
-            "description": "For convenience, include a full representation of the inlined property. Currently supports the local \"favorites\", \"next-purchase-arrival\", and \"quantity-on-next-purchase\" as well as \"image\", \"product\", \"vendors\", and descendants.",
-            "required": false,
-            "style": "form",
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
+            "$ref": "#/components/parameters/packagedProductInline"
           },
           {
             "name": "limit",
@@ -9144,7 +9134,6 @@
         "name": "inline",
         "in": "query",
         "description": "Optional properties returned if specified in the request.",
-        "required": false,
         "style": "form",
         "schema": {
           "type": "array",
@@ -9217,6 +9206,27 @@
         "in": "query",
         "name": "target",
         "description": "The email addresses to send the *test* message to (for previewing). Including this parameter will prevent the email from being sent to the intended recipients (its intended use is for sending previews)."
+      },
+      "packagedProductInline": {
+        "name": "inline",
+        "in": "query",
+        "description": "For convenience, include a full representation of the inlined property.",
+        "required": false,
+        "style": "form",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "favorites",
+              "next-purchase-arrival",
+              "quantity-on-next-purchase",
+              "image",
+              "product",
+              "vendors"
+            ]
+          }
+        }
       }
     },
     "schemas": {

--- a/spec.json
+++ b/spec.json
@@ -10401,12 +10401,12 @@
             "format": "int64"
           },
           "next-purchase-arrival": {
-            "description": "When the next stock of this packaged is expected to arrive at the warehouse. This will only be included if the `inline` query parameter includes `next-purchase-arrival`.",
+            "description": "When the next stock of this packaged is expected to arrive at the warehouse. This will only be included if the `inline` query parameter includes `next-purchase-arrival` or `quantity-on-next-purchase`.",
             "type": "string",
             "format": "date-time"
           },
           "quantity-on-next-purchase": {
-            "description": "Package quantity arriving on the next-purchase-arrival. This will only be included if the `inline` query parameter includes `quantity-on-next-purchase`.",
+            "description": "Package quantity arriving on the next-purchase-arrival. This will only be included if the `inline` query parameter includes `next-purchase-arrival` or `quantity-on-next-purchase`.",
             "type": "number",
             "format": "float"
           },


### PR DESCRIPTION
Details:

- Adds missing response properties to the `packaged-products` endpoints.
- Adds missing query parameters to the `packaged-products` endpoints (and fixes the descriptions on some existing ones that didn't mention their relation to the `inline` query parameter).
- Adds "audit" to the descriptions of the `audit/product*` endpoints to help differentiate them with the non-audit product endpoints.
- Changes tags on product-related endpoints for improved grouping in the ReDoc docs (so that they are now grouped more logically with their endpoints). Previously these were not organized clearly, with most of the endpoints showing under "product" but others under "image" and "packaged-product-tag". We now have them organized by: 
  - product
  - packaged-product
  - packaged-product-image
  - packaged-product-tag  