### PR TITLE
Dwm/truckload support for orders

### DIFF
--- a/spec.json
+++ b/spec.json
@@ -3184,6 +3184,16 @@
             }
           },
           {
+            "name": "truckloadId",
+            "in": "query",
+            "description": "Truckload (pickset) ID to filter by.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
             "$ref": "#/components/parameters/stopInline"
           }
         ],

--- a/spec.json
+++ b/spec.json
@@ -5317,6 +5317,16 @@
             }
           },
           {
+            "name": "truckloadId",
+            "in": "query",
+            "description": "Truckload (pickset) ID to filter by.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
             "$ref": "#/components/parameters/orderInline"
           }
         ],


### PR DESCRIPTION
This is for the truckloadId filtering for the `GET api/orders` and `GET api/stops` endpoints that we are doing in: https://github.com/azurestandard/beehive/pull/5195