### PR TITLE
Add finalized delivery state param to stop

### DIFF
--- a/spec.json
+++ b/spec.json
@@ -10424,6 +10424,20 @@
                 "$ref": "#/components/schemas/truckload"
               }
             ]
+          },
+          "finalizedDeliveryState": {
+            "oneOf": [
+              {
+                "enum": [
+                  "confirmed",
+                  "driverWillCall",
+                  "toBeDetermined",
+                  "unknownDelay"
+                ],
+                "description": "The state of the stop's finalized delivery. This is always returned if a `finalizedDelivery` value is returned."
+              }
+            ],
+            "type": "string"
           }
         },
         "required": [

--- a/spec.json
+++ b/spec.json
@@ -10425,16 +10425,15 @@
               }
             ]
           },
-          "finalizedDeliveryState": {
+          "finalizedDeliveryFlag": {
             "oneOf": [
               {
                 "enum": [
-                  "confirmed",
                   "driverWillCall",
                   "toBeDetermined",
                   "unknownDelay"
                 ],
-                "description": "The state of the stop's finalized delivery. This is always returned if a `finalizedDelivery` value is returned."
+                "description": "This is used to indicate an exception-state for the finalized delivery. This is always returned if the trip's status is not `new`."
               }
             ],
             "type": "string"


### PR DESCRIPTION
For https://github.com/azurestandard/beehive/issues/5444.

In discussion with Tom and Thomas we were thinking to name the property `finalizedState`. While creating this PR, however, it became clear to me that a more descriptive name is `finalizedDeliveryState` (further reasoning: The date-time property is named `finalizedDelivery`, and this property essentially describes the state of that property, so "extending" its name seems to make good sense (i.e. `finalizedDelivery + [state]`)). Of course feel free to share any reasons we may not want to go with `finalizedDeliveryState`. 