### PR TITLE
Add id to promoCode response object

### DIFF
--- a/spec.json
+++ b/spec.json
@@ -12122,7 +12122,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
+            "type": "integer",
+            "format": "int64",
             "description": "The promo code's ID."
           },
           "code": {

--- a/spec.json
+++ b/spec.json
@@ -12121,6 +12121,10 @@
         "description": "A promo code applied to an order.",
         "type": "object",
         "properties": {
+          "id": {
+            "type": "string",
+            "description": "The promo code's ID."
+          },
           "code": {
             "description": "Code for the promo code.",
             "type": "string"
@@ -12144,6 +12148,7 @@
           }
         },
         "required": [
+          "id",
           "code",
           "description",
           "orderId",


### PR DESCRIPTION
This is needed for the frontend to use some of the promo-code endpoints.

For context, see: 

- https://github.com/azurestandard/beehive/pull/5884#issuecomment-974141741
- https://github.com/azurestandard/beehive/pull/5884#issuecomment-974258070