### PR TITLE
remove 'engine' from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,6 @@
 {
   "name": "api-spec",
   "version": "1.0.0",
-  "engines": {
-    "node": "14.x.x",
-    "npm": "8.x.x"
-  },
   "description": "OpenAPI 3.0 Specification for Azure Standard's API.",
   "scripts": {
     "buildDocs": "redoc-cli bundle spec.json -t index.hbs -o index.html --options.pathInMiddlePanel --options.requiredPropsFirst --options.sortPropsAlphabetically"


### PR DESCRIPTION
'engine' here is counter productive — it's just an api spec!  This makes it harder to depend on and gives spurious errors.

For what it's worth, `api-spec` isn't a great name.  Maybe `@azurestandard/api-spec` a scoped package name and then publish it?