### PR TITLE
Migrate from Netlify to CF Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ OpenAPI 3.0 Specification for Azure Standard's API.
 
 ## Docs site
 
-URL: https://azure-api-docs.netlify.app/
+URL: https://api-spec-2at.pages.dev
 
 Uses [Redoc](https://github.com/Redocly/redoc).
 

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "api-spec",
   "version": "1.0.0",
   "engines": {
-    "node": "14.x.x",
-    "npm": "8.x.x"
+    "node": "18.x.x",
+    "npm": "9.x.x"
   },
   "description": "OpenAPI 3.0 Specification for Azure Standard's API.",
   "scripts": {


### PR DESCRIPTION
Resolves #340

Also updates our "engines" entry in package.json (for accuracy and consistency since CF Pages uses these versions and these are the same versions we use in our other repos).

Notes:

- URL for Pages' project in the CF panel: https://dash.cloudflare.com/6003ffc5444305b2caff9dc3886e6ae8/pages/view/api-spec